### PR TITLE
feat(tenancy): Sprint 2 — módulo tenancy + switcher + /admin/companies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,9 @@
         "supabase": "^1.224.2",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/src/app/(dashboard)/admin/companies/[id]/page.tsx
+++ b/src/app/(dashboard)/admin/companies/[id]/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { UpdateCompanyForm } from "@/modules/tenancy";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Página de edição de empresa — /admin/companies/[id]
+ */
+export default async function EditCompanyPage({ params }: Props) {
+  const { id } = await params;
+
+  const supabase = await createClient();
+  const { data: company, error } = await supabase
+    .from("companies")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error || !company) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button asChild variant="ghost" size="sm">
+          <Link href="/admin/companies">← Voltar</Link>
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold">Editar empresa</h1>
+          <p className="font-mono text-sm text-muted-foreground">{company.slug}</p>
+        </div>
+      </div>
+
+      <div className="max-w-2xl">
+        <UpdateCompanyForm company={company} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/companies/new/page.tsx
+++ b/src/app/(dashboard)/admin/companies/new/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { listModules, CreateCompanyForm } from "@/modules/tenancy";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Página de criação de nova empresa — /admin/companies/new
+ */
+export default async function NewCompanyPage() {
+  const modules = await listModules();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button asChild variant="ghost" size="sm">
+          <Link href="/admin/companies">← Voltar</Link>
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold">Nova empresa</h1>
+          <p className="text-sm text-muted-foreground">
+            Preencha os dados para criar uma nova empresa na plataforma
+          </p>
+        </div>
+      </div>
+
+      <div className="max-w-2xl">
+        <CreateCompanyForm modules={modules} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/companies/page.tsx
+++ b/src/app/(dashboard)/admin/companies/page.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { listAllCompanies } from "@/modules/tenancy";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+/**
+ * Página de listagem de empresas — /admin/companies
+ * Acessível apenas para administradores de plataforma (gated pelo AdminLayout).
+ */
+export default async function AdminCompaniesPage() {
+  const companies = await listAllCompanies();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Empresas</h1>
+          <p className="text-sm text-muted-foreground">Gerencie todas as empresas da plataforma</p>
+        </div>
+        <Button asChild>
+          <Link href="/admin/companies/new">Nova empresa</Link>
+        </Button>
+      </div>
+
+      {companies.length === 0 ? (
+        <p className="text-muted-foreground">Nenhuma empresa cadastrada ainda.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nome</TableHead>
+              <TableHead>Slug</TableHead>
+              <TableHead>Plano</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Criada em</TableHead>
+              <TableHead className="text-right">Ações</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {companies.map((company) => (
+              <TableRow key={company.id}>
+                <TableCell className="font-medium">{company.name}</TableCell>
+                <TableCell className="font-mono text-sm text-muted-foreground">
+                  {company.slug}
+                </TableCell>
+                <TableCell className="capitalize">{company.plan}</TableCell>
+                <TableCell>
+                  {company.is_active ? (
+                    <Badge variant="default">Ativa</Badge>
+                  ) : (
+                    <Badge variant="secondary">Inativa</Badge>
+                  )}
+                </TableCell>
+                <TableCell>{new Date(company.created_at).toLocaleDateString("pt-BR")}</TableCell>
+                <TableCell className="text-right">
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/admin/companies/${company.id}`}>Editar</Link>
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/layout.tsx
+++ b/src/app/(dashboard)/admin/layout.tsx
@@ -1,0 +1,21 @@
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * Layout de proteção para rotas /admin/*.
+ * Verifica is_platform_admin() e renderiza 403 inline se não autorizado.
+ */
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  const supabase = await createClient();
+  const { data: isPlatformAdmin } = await supabase.rpc("is_platform_admin");
+
+  if (!isPlatformAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <h1 className="text-2xl font-bold text-destructive">Acesso negado</h1>
+        <p className="mt-2 text-muted-foreground">Você não tem permissão para acessar esta área.</p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/(dashboard)/admin/layout.tsx
+++ b/src/app/(dashboard)/admin/layout.tsx
@@ -6,7 +6,8 @@ import { createClient } from "@/lib/supabase/server";
  */
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient();
-  const { data: isPlatformAdmin } = await supabase.rpc("is_platform_admin");
+  const { data: isPlatformAdmin, error: rpcError } = await supabase.rpc("is_platform_admin");
+  if (rpcError) throw rpcError;
 
   if (!isPlatformAdmin) {
     return (

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/server";
 import { signOutAction } from "@/modules/auth";
 import { Button } from "@/components/ui/button";
 import { MODULES_MENU } from "@/core/navigation/menu";

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -5,10 +5,13 @@ import { signOutAction } from "@/modules/auth";
 import { Button } from "@/components/ui/button";
 import { MODULES_MENU } from "@/core/navigation/menu";
 import { getCurrentUser } from "@/modules/auth";
+import { CompanySwitcher, listMyCompanies, getActiveCompanyId } from "@/modules/tenancy";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const user = await getCurrentUser();
   if (!user) redirect("/login");
+
+  const [companies, activeCompanyId] = await Promise.all([listMyCompanies(), getActiveCompanyId()]);
 
   return (
     <div className="grid min-h-screen grid-cols-[240px_1fr]">
@@ -35,7 +38,8 @@ export default async function DashboardLayout({ children }: { children: React.Re
       {/* Main content */}
       <main className="flex flex-col">
         {/* Topbar */}
-        <header className="flex items-center justify-end border-b px-8 py-3">
+        <header className="flex items-center justify-between border-b px-8 py-3">
+          <CompanySwitcher companies={companies} activeCompanyId={activeCompanyId} />
           <form action={signOutAction}>
             <Button type="submit" variant="ghost" size="sm">
               Sair

--- a/src/core/navigation/menu.ts
+++ b/src/core/navigation/menu.ts
@@ -3,6 +3,8 @@ export type MenuItem = {
   href: string;
   icon?: string;
   roles?: string[];
+  requiresModule?: string;
+  requiresPermission?: string;
 };
 
 /**

--- a/src/modules/auth/services/profile-service.ts
+++ b/src/modules/auth/services/profile-service.ts
@@ -1,4 +1,6 @@
-import type { UserRole } from "@/types/database.types";
+import type { Enums } from "@/types/database.types";
+
+type UserRole = Enums<"user_role">;
 
 /**
  * Verifica se o role do usuário tem permissão de escrita em produtos.

--- a/src/modules/tenancy/actions/create-company.ts
+++ b/src/modules/tenancy/actions/create-company.ts
@@ -54,6 +54,9 @@ export async function createCompanyAction(
 
   const { name, slug, plan, document, modules, ownerEmail } = parsed.data;
 
+  // Nota: estas etapas não são atômicas. Em caso de falha parcial,
+  // a empresa pode existir sem módulos ou roles. Mitigação futura: stored procedure transacional.
+
   // 4. Insere a empresa
   const { data: company, error: companyError } = await supabase
     .from("companies")

--- a/src/modules/tenancy/actions/create-company.ts
+++ b/src/modules/tenancy/actions/create-company.ts
@@ -1,0 +1,162 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { AppError, type ActionResult } from "@/lib/errors";
+import { env } from "@/core/config/env";
+import { createCompanySchema } from "../schemas/create-company";
+
+/**
+ * Server Action para criar uma nova empresa (apenas administradores de plataforma).
+ *
+ * Passos:
+ * 1. Verifica is_platform_admin()
+ * 2. Valida FormData
+ * 3. Insere na tabela companies
+ * 4. Insere módulos em company_modules
+ * 5. Chama bootstrap_company_rbac
+ * 6. Convida owner por e-mail (se fornecido e service role disponível)
+ * 7. Insere audit_log
+ * 8. Revalida cache
+ */
+export async function createCompanyAction(
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  const supabase = await createClient();
+
+  // 1. Verifica permissão de plataforma
+  const { data: isPlatformAdmin, error: rpcError } = await supabase.rpc("is_platform_admin");
+  if (rpcError) return { ok: false, message: rpcError.message };
+  if (!isPlatformAdmin) throw new AppError("Acesso negado", "ACCESS_DENIED");
+
+  // 2. Obtém usuário atual
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
+
+  // 3. Valida FormData (modules vem como múltiplos valores de checkboxes)
+  const rawModules = formData.getAll("modules") as string[];
+  const rawData = {
+    ...Object.fromEntries(formData),
+    modules: rawModules,
+    // Normaliza ownerEmail vazio para undefined
+    ownerEmail: (formData.get("ownerEmail") as string | null) || undefined,
+    document: (formData.get("document") as string | null) || undefined,
+  };
+
+  const parsed = createCompanySchema.safeParse(rawData);
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  const { name, slug, plan, document, modules, ownerEmail } = parsed.data;
+
+  // 4. Insere a empresa
+  const { data: company, error: companyError } = await supabase
+    .from("companies")
+    .insert({
+      name,
+      slug,
+      plan,
+      document: document ?? null,
+      created_by: user.id,
+    })
+    .select("id")
+    .single();
+
+  if (companyError) {
+    if (companyError.message.includes("slug")) {
+      return { ok: false, message: "Já existe uma empresa com este slug" };
+    }
+    return { ok: false, message: companyError.message };
+  }
+
+  const companyId = company.id;
+
+  // 5. Insere módulos habilitados
+  const { error: modulesError } = await supabase.from("company_modules").insert(
+    modules.map((moduleCode) => ({
+      company_id: companyId,
+      module_code: moduleCode,
+      enabled_by: user.id,
+    })),
+  );
+
+  if (modulesError) return { ok: false, message: modulesError.message };
+
+  // 6. Inicializa RBAC da empresa (roles padrão)
+  const { error: rbacError } = await supabase.rpc("bootstrap_company_rbac", {
+    p_company: companyId,
+  });
+  if (rbacError) return { ok: false, message: rbacError.message };
+
+  // 7. Convida owner por e-mail (opcional)
+  if (ownerEmail && env.SUPABASE_SERVICE_ROLE_KEY) {
+    const adminClient = createAdminClient(
+      env.NEXT_PUBLIC_SUPABASE_URL,
+      env.SUPABASE_SERVICE_ROLE_KEY,
+    );
+
+    // Convida o usuário via Supabase Auth Admin
+    const { data: inviteData, error: inviteError } = await adminClient.auth.admin.inviteUserByEmail(
+      ownerEmail,
+      {
+        redirectTo: `${env.NEXT_PUBLIC_APP_URL}/api/auth/callback`,
+      },
+    );
+
+    if (!inviteError && inviteData.user) {
+      const invitedUserId = inviteData.user.id;
+
+      // Cria membership como owner
+      const { data: membership, error: membershipError } = await supabase
+        .from("memberships")
+        .insert({
+          company_id: companyId,
+          user_id: invitedUserId,
+          is_owner: true,
+          status: "invited",
+          invited_by: user.id,
+          invited_at: new Date().toISOString(),
+        })
+        .select("id")
+        .single();
+
+      if (!membershipError && membership) {
+        // Busca role 'owner' da empresa
+        const { data: ownerRole } = await supabase
+          .from("roles")
+          .select("id")
+          .eq("company_id", companyId)
+          .eq("code", "owner")
+          .maybeSingle();
+
+        if (ownerRole) {
+          await supabase.from("membership_roles").insert({
+            membership_id: membership.id,
+            role_id: ownerRole.id,
+            assigned_by: user.id,
+          });
+        }
+      }
+    }
+  }
+
+  // 8. Registra audit log
+  await supabase.from("audit_logs").insert({
+    action: "company.create",
+    actor_user_id: user.id,
+    actor_email: user.email ?? null,
+    company_id: null,
+    resource_type: "company",
+    resource_id: companyId,
+    status: "success",
+    metadata: { name, slug, plan },
+  });
+
+  revalidatePath("/admin/companies");
+  return { ok: true, message: `Empresa "${name}" criada com sucesso` };
+}

--- a/src/modules/tenancy/actions/switch-active-company.ts
+++ b/src/modules/tenancy/actions/switch-active-company.ts
@@ -5,8 +5,7 @@ import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import type { ActionResult } from "@/lib/errors";
 import { switchActiveCompanySchema } from "../schemas";
-
-const ACTIVE_COMPANY_COOKIE = "erp.active_company";
+import { ACTIVE_COMPANY_COOKIE } from "../constants";
 
 /**
  * Server Action para trocar a empresa ativa do usuário.
@@ -54,6 +53,7 @@ export async function switchActiveCompanyAction(
     httpOnly: true,
     sameSite: "lax",
     path: "/",
+    secure: process.env.NODE_ENV === "production",
   });
 
   revalidatePath("/");

--- a/src/modules/tenancy/actions/switch-active-company.ts
+++ b/src/modules/tenancy/actions/switch-active-company.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+import type { ActionResult } from "@/lib/errors";
+import { switchActiveCompanySchema } from "../schemas";
+
+const ACTIVE_COMPANY_COOKIE = "erp.active_company";
+
+/**
+ * Server Action para trocar a empresa ativa do usuário.
+ *
+ * Valida que o usuário possui membership ativo na empresa solicitada
+ * e define o cookie `erp.active_company` com o UUID da empresa.
+ */
+export async function switchActiveCompanyAction(
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  const parsed = switchActiveCompanySchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  const { companyId } = parsed.data;
+
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { ok: false, message: "Não autenticado" };
+
+  // Verifica se o usuário possui membership ativo na empresa solicitada
+  const { data: membership, error } = await supabase
+    .from("memberships")
+    .select("id")
+    .eq("company_id", companyId)
+    .eq("user_id", user.id)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (error) return { ok: false, message: error.message };
+
+  if (!membership) {
+    return { ok: false, message: "Você não possui acesso a esta empresa" };
+  }
+
+  // Define o cookie de empresa ativa
+  const cookieStore = await cookies();
+  cookieStore.set(ACTIVE_COMPANY_COOKIE, companyId, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+  });
+
+  revalidatePath("/");
+  return { ok: true, message: "Empresa ativa atualizada" };
+}

--- a/src/modules/tenancy/actions/update-company.ts
+++ b/src/modules/tenancy/actions/update-company.ts
@@ -18,6 +18,7 @@ export async function updateCompanyAction(
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
 
   // 2. Verifica permissão de plataforma
   const { data: isPlatformAdmin, error: rpcError } = await supabase.rpc("is_platform_admin");

--- a/src/modules/tenancy/actions/update-company.ts
+++ b/src/modules/tenancy/actions/update-company.ts
@@ -14,12 +14,17 @@ export async function updateCompanyAction(
 ): Promise<ActionResult> {
   const supabase = await createClient();
 
-  // 1. Verifica permissão de plataforma
+  // 1. Obtém usuário atual
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // 2. Verifica permissão de plataforma
   const { data: isPlatformAdmin, error: rpcError } = await supabase.rpc("is_platform_admin");
   if (rpcError) return { ok: false, message: rpcError.message };
   if (!isPlatformAdmin) throw new AppError("Acesso negado", "ACCESS_DENIED");
 
-  // 2. Valida FormData
+  // 3. Valida FormData
   const rawData = {
     ...Object.fromEntries(formData),
     document: (formData.get("document") as string | null) || undefined,
@@ -32,7 +37,7 @@ export async function updateCompanyAction(
 
   const { id, name, plan, document, is_active } = parsed.data;
 
-  // 3. Atualiza a empresa
+  // 4. Atualiza a empresa
   const { error } = await supabase
     .from("companies")
     .update({
@@ -45,6 +50,17 @@ export async function updateCompanyAction(
     .eq("id", id);
 
   if (error) return { ok: false, message: error.message };
+
+  // 5. Registra audit log
+  await supabase.from("audit_logs").insert({
+    action: "company.update",
+    actor_user_id: user?.id ?? null,
+    actor_email: user?.email ?? null,
+    resource_type: "company",
+    resource_id: id,
+    status: "success",
+    metadata: { name, plan, is_active },
+  });
 
   revalidatePath("/admin/companies");
   return { ok: true, message: "Empresa atualizada com sucesso" };

--- a/src/modules/tenancy/actions/update-company.ts
+++ b/src/modules/tenancy/actions/update-company.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { AppError, type ActionResult } from "@/lib/errors";
+import { updateCompanySchema } from "../schemas/update-company";
+
+/**
+ * Server Action para atualizar dados de uma empresa (apenas administradores de plataforma).
+ */
+export async function updateCompanyAction(
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  const supabase = await createClient();
+
+  // 1. Verifica permissão de plataforma
+  const { data: isPlatformAdmin, error: rpcError } = await supabase.rpc("is_platform_admin");
+  if (rpcError) return { ok: false, message: rpcError.message };
+  if (!isPlatformAdmin) throw new AppError("Acesso negado", "ACCESS_DENIED");
+
+  // 2. Valida FormData
+  const rawData = {
+    ...Object.fromEntries(formData),
+    document: (formData.get("document") as string | null) || undefined,
+  };
+
+  const parsed = updateCompanySchema.safeParse(rawData);
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  const { id, name, plan, document, is_active } = parsed.data;
+
+  // 3. Atualiza a empresa
+  const { error } = await supabase
+    .from("companies")
+    .update({
+      name,
+      plan,
+      document: document ?? null,
+      is_active,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id);
+
+  if (error) return { ok: false, message: error.message };
+
+  revalidatePath("/admin/companies");
+  return { ok: true, message: "Empresa atualizada com sucesso" };
+}

--- a/src/modules/tenancy/components/company-badge.tsx
+++ b/src/modules/tenancy/components/company-badge.tsx
@@ -1,0 +1,4 @@
+// Stub — será implementado no PR #10
+export function CompanyBadge() {
+  return null;
+}

--- a/src/modules/tenancy/components/company-badge.tsx
+++ b/src/modules/tenancy/components/company-badge.tsx
@@ -1,4 +1,14 @@
-// Stub — será implementado no PR #10
-export function CompanyBadge() {
-  return null;
+import { Badge } from "@/components/ui/badge";
+import type { Company } from "../queries/list-my-companies";
+
+interface CompanyBadgeProps {
+  company: Company;
+}
+
+export function CompanyBadge({ company }: CompanyBadgeProps) {
+  return (
+    <Badge variant="secondary" className="max-w-[200px] truncate">
+      {company.name}
+    </Badge>
+  );
 }

--- a/src/modules/tenancy/components/company-switcher.tsx
+++ b/src/modules/tenancy/components/company-switcher.tsx
@@ -1,0 +1,4 @@
+// Stub — será implementado no PR #10
+export function CompanySwitcher() {
+  return null;
+}

--- a/src/modules/tenancy/components/company-switcher.tsx
+++ b/src/modules/tenancy/components/company-switcher.tsx
@@ -1,4 +1,52 @@
-// Stub — será implementado no PR #10
-export function CompanySwitcher() {
-  return null;
+"use client";
+
+import { useTransition } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { switchActiveCompanyAction } from "../actions/switch-active-company";
+import type { Company } from "../queries/list-my-companies";
+
+interface CompanySwitcherProps {
+  companies: Company[];
+  activeCompanyId: string | null;
+}
+
+export function CompanySwitcher({ companies, activeCompanyId }: CompanySwitcherProps) {
+  const [isPending, startTransition] = useTransition();
+
+  if (companies.length <= 1) {
+    const company = companies[0];
+    if (!company) return null;
+    return <span className="max-w-[200px] truncate text-sm font-medium">{company.name}</span>;
+  }
+
+  const activeCompany = companies.find((c) => c.id === activeCompanyId) ?? companies[0];
+
+  function handleChange(companyId: string) {
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.set("companyId", companyId);
+      await switchActiveCompanyAction({ ok: true }, formData);
+    });
+  }
+
+  return (
+    <Select value={activeCompany?.id ?? ""} onValueChange={handleChange} disabled={isPending}>
+      <SelectTrigger className="h-8 w-[200px]">
+        <SelectValue placeholder="Selecionar empresa" />
+      </SelectTrigger>
+      <SelectContent>
+        {companies.map((company) => (
+          <SelectItem key={company.id} value={company.id}>
+            {company.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
 }

--- a/src/modules/tenancy/components/company-switcher.tsx
+++ b/src/modules/tenancy/components/company-switcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import {
   Select,
   SelectContent,
@@ -18,6 +18,7 @@ interface CompanySwitcherProps {
 
 export function CompanySwitcher({ companies, activeCompanyId }: CompanySwitcherProps) {
   const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
 
   if (companies.length <= 1) {
     const company = companies[0];
@@ -31,22 +32,30 @@ export function CompanySwitcher({ companies, activeCompanyId }: CompanySwitcherP
     startTransition(async () => {
       const formData = new FormData();
       formData.set("companyId", companyId);
-      await switchActiveCompanyAction({ ok: true }, formData);
+      const result = await switchActiveCompanyAction({ ok: true }, formData);
+      if (!result.ok) {
+        setError(result.message ?? "Erro ao trocar empresa");
+      } else {
+        setError(null);
+      }
     });
   }
 
   return (
-    <Select value={activeCompany?.id ?? ""} onValueChange={handleChange} disabled={isPending}>
-      <SelectTrigger className="h-8 w-[200px]">
-        <SelectValue placeholder="Selecionar empresa" />
-      </SelectTrigger>
-      <SelectContent>
-        {companies.map((company) => (
-          <SelectItem key={company.id} value={company.id}>
-            {company.name}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <div>
+      <Select value={activeCompany?.id ?? ""} onValueChange={handleChange} disabled={isPending}>
+        <SelectTrigger aria-label="Empresa ativa" className="h-8 w-[200px]">
+          <SelectValue placeholder="Selecionar empresa" />
+        </SelectTrigger>
+        <SelectContent>
+          {companies.map((company) => (
+            <SelectItem key={company.id} value={company.id}>
+              {company.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
   );
 }

--- a/src/modules/tenancy/components/create-company-form.tsx
+++ b/src/modules/tenancy/components/create-company-form.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useActionState, useEffect } from "react";
+import { useFormStatus } from "react-dom";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { createCompanyAction } from "../actions/create-company";
+import type { Module } from "../queries/list-modules";
+import type { ActionResult } from "@/lib/errors";
+
+const initial: ActionResult = { ok: false };
+
+type Props = {
+  modules: Module[];
+};
+
+export function CreateCompanyForm({ modules }: Props) {
+  const router = useRouter();
+  const [state, formAction] = useActionState(createCompanyAction, initial);
+  const fieldErrors = state.ok ? undefined : state.fieldErrors;
+
+  useEffect(() => {
+    if (state.ok) {
+      router.push("/admin/companies");
+    }
+  }, [state, router]);
+
+  return (
+    <form action={formAction} className="space-y-6">
+      {!state.ok && state.message && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {state.message}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {/* Nome */}
+        <div className="space-y-2">
+          <Label htmlFor="name">
+            Nome <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            id="name"
+            name="name"
+            required
+            placeholder="Acme Ltda"
+            aria-invalid={!!fieldErrors?.name}
+          />
+          {fieldErrors?.name && <p className="text-sm text-red-600">{fieldErrors.name[0]}</p>}
+        </div>
+
+        {/* Slug */}
+        <div className="space-y-2">
+          <Label htmlFor="slug">
+            Slug <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            id="slug"
+            name="slug"
+            required
+            placeholder="acme"
+            pattern="[a-z0-9-]+"
+            title="Apenas letras minúsculas, números e hífens"
+            aria-invalid={!!fieldErrors?.slug}
+          />
+          {fieldErrors?.slug && <p className="text-sm text-red-600">{fieldErrors.slug[0]}</p>}
+        </div>
+
+        {/* Plano */}
+        <div className="space-y-2">
+          <Label htmlFor="plan">
+            Plano <span className="text-red-500">*</span>
+          </Label>
+          <Select name="plan" defaultValue="starter">
+            <SelectTrigger id="plan">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="starter">Starter</SelectItem>
+              <SelectItem value="pro">Pro</SelectItem>
+              <SelectItem value="enterprise">Enterprise</SelectItem>
+            </SelectContent>
+          </Select>
+          {fieldErrors?.plan && <p className="text-sm text-red-600">{fieldErrors.plan[0]}</p>}
+        </div>
+
+        {/* Documento */}
+        <div className="space-y-2">
+          <Label htmlFor="document">CNPJ / CPF</Label>
+          <Input id="document" name="document" placeholder="00.000.000/0001-00" />
+          {fieldErrors?.document && (
+            <p className="text-sm text-red-600">{fieldErrors.document[0]}</p>
+          )}
+        </div>
+
+        {/* E-mail do owner */}
+        <div className="space-y-2 md:col-span-2">
+          <Label htmlFor="ownerEmail">E-mail do responsável (opcional)</Label>
+          <Input
+            id="ownerEmail"
+            name="ownerEmail"
+            type="email"
+            placeholder="responsavel@empresa.com"
+            aria-invalid={!!fieldErrors?.ownerEmail}
+          />
+          {fieldErrors?.ownerEmail && (
+            <p className="text-sm text-red-600">{fieldErrors.ownerEmail[0]}</p>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Um convite será enviado por e-mail se a chave de serviço estiver configurada.
+          </p>
+        </div>
+      </div>
+
+      {/* Módulos */}
+      <div className="space-y-3">
+        <div>
+          <Label>
+            Módulos habilitados <span className="text-red-500">*</span>
+          </Label>
+          {fieldErrors?.modules && (
+            <p className="mt-1 text-sm text-red-600">{fieldErrors.modules[0]}</p>
+          )}
+        </div>
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+          {modules.map((mod) => (
+            <label
+              key={mod.code}
+              className="flex cursor-pointer items-center gap-2 rounded-md border p-3 hover:bg-accent"
+            >
+              <input type="checkbox" name="modules" value={mod.code} className="h-4 w-4" />
+              <span className="text-sm font-medium">{mod.name}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" onClick={() => history.back()}>
+          Cancelar
+        </Button>
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? "Criando..." : "Criar empresa"}
+    </Button>
+  );
+}

--- a/src/modules/tenancy/components/update-company-form.tsx
+++ b/src/modules/tenancy/components/update-company-form.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useActionState, useEffect } from "react";
+import { useFormStatus } from "react-dom";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { updateCompanyAction } from "../actions/update-company";
+import type { ActionResult } from "@/lib/errors";
+import type { Tables } from "@/types/database.types";
+
+type Company = Tables<"companies">;
+
+const initial: ActionResult = { ok: false };
+
+type Props = {
+  company: Company;
+};
+
+export function UpdateCompanyForm({ company }: Props) {
+  const router = useRouter();
+  const [state, formAction] = useActionState(updateCompanyAction, initial);
+  const fieldErrors = state.ok ? undefined : state.fieldErrors;
+
+  useEffect(() => {
+    if (state.ok) {
+      router.push("/admin/companies");
+    }
+  }, [state, router]);
+
+  return (
+    <form action={formAction} className="space-y-6">
+      {/* ID oculto */}
+      <input type="hidden" name="id" value={company.id} />
+
+      {!state.ok && state.message && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {state.message}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {/* Nome */}
+        <div className="space-y-2">
+          <Label htmlFor="name">
+            Nome <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            id="name"
+            name="name"
+            required
+            defaultValue={company.name}
+            aria-invalid={!!fieldErrors?.name}
+          />
+          {fieldErrors?.name && <p className="text-sm text-red-600">{fieldErrors.name[0]}</p>}
+        </div>
+
+        {/* Slug (somente leitura) */}
+        <div className="space-y-2">
+          <Label htmlFor="slug">Slug</Label>
+          <Input id="slug" name="slug_display" value={company.slug} disabled readOnly />
+          <p className="text-xs text-muted-foreground">
+            O slug não pode ser alterado após a criação.
+          </p>
+        </div>
+
+        {/* Plano */}
+        <div className="space-y-2">
+          <Label htmlFor="plan">
+            Plano <span className="text-red-500">*</span>
+          </Label>
+          <Select name="plan" defaultValue={company.plan}>
+            <SelectTrigger id="plan">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="starter">Starter</SelectItem>
+              <SelectItem value="pro">Pro</SelectItem>
+              <SelectItem value="enterprise">Enterprise</SelectItem>
+            </SelectContent>
+          </Select>
+          {fieldErrors?.plan && <p className="text-sm text-red-600">{fieldErrors.plan[0]}</p>}
+        </div>
+
+        {/* Documento */}
+        <div className="space-y-2">
+          <Label htmlFor="document">CNPJ / CPF</Label>
+          <Input
+            id="document"
+            name="document"
+            placeholder="00.000.000/0001-00"
+            defaultValue={company.document ?? ""}
+          />
+          {fieldErrors?.document && (
+            <p className="text-sm text-red-600">{fieldErrors.document[0]}</p>
+          )}
+        </div>
+
+        {/* Status ativo */}
+        <div className="space-y-2 md:col-span-2">
+          <div className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              id="is_active"
+              name="is_active"
+              defaultChecked={company.is_active}
+              className="h-4 w-4"
+            />
+            <Label htmlFor="is_active">Empresa ativa</Label>
+          </div>
+          {fieldErrors?.is_active && (
+            <p className="text-sm text-red-600">{fieldErrors.is_active[0]}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" onClick={() => history.back()}>
+          Cancelar
+        </Button>
+        <SubmitButton />
+      </div>
+    </form>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? "Salvando..." : "Salvar alterações"}
+    </Button>
+  );
+}

--- a/src/modules/tenancy/constants.ts
+++ b/src/modules/tenancy/constants.ts
@@ -1,0 +1,1 @@
+export const ACTIVE_COMPANY_COOKIE = "erp.active_company";

--- a/src/modules/tenancy/index.ts
+++ b/src/modules/tenancy/index.ts
@@ -1,0 +1,19 @@
+// Barrel — única API pública do módulo tenancy
+
+// Actions
+export { switchActiveCompanyAction } from "./actions/switch-active-company";
+
+// Queries
+export { listMyCompanies } from "./queries/list-my-companies";
+export { resolveCompany } from "./queries/resolve-company";
+export { listAllCompanies } from "./queries/list-all-companies";
+
+// Services
+export { getActiveCompanyId } from "./services/active-company";
+
+// Components
+export { CompanySwitcher } from "./components/company-switcher";
+export { CompanyBadge } from "./components/company-badge";
+
+// Types
+export type { Company } from "./queries/list-my-companies";

--- a/src/modules/tenancy/index.ts
+++ b/src/modules/tenancy/index.ts
@@ -2,11 +2,14 @@
 
 // Actions
 export { switchActiveCompanyAction } from "./actions/switch-active-company";
+export { createCompanyAction } from "./actions/create-company";
+export { updateCompanyAction } from "./actions/update-company";
 
 // Queries
 export { listMyCompanies } from "./queries/list-my-companies";
 export { resolveCompany } from "./queries/resolve-company";
 export { listAllCompanies } from "./queries/list-all-companies";
+export { listModules } from "./queries/list-modules";
 
 // Services
 export { getActiveCompanyId } from "./services/active-company";
@@ -14,6 +17,9 @@ export { getActiveCompanyId } from "./services/active-company";
 // Components
 export { CompanySwitcher } from "./components/company-switcher";
 export { CompanyBadge } from "./components/company-badge";
+export { CreateCompanyForm } from "./components/create-company-form";
+export { UpdateCompanyForm } from "./components/update-company-form";
 
 // Types
 export type { Company } from "./queries/list-my-companies";
+export type { Module } from "./queries/list-modules";

--- a/src/modules/tenancy/queries/list-all-companies.ts
+++ b/src/modules/tenancy/queries/list-all-companies.ts
@@ -23,7 +23,11 @@ export async function listAllCompanies(): Promise<Company[]> {
     throw new AppError("Acesso negado", "ACCESS_DENIED");
   }
 
-  const { data, error } = await supabase.from("companies").select("*").order("name");
+  const { data, error } = await supabase
+    .from("companies")
+    .select("*")
+    .eq("is_active", true)
+    .order("name");
 
   if (error) throw error;
 

--- a/src/modules/tenancy/queries/list-all-companies.ts
+++ b/src/modules/tenancy/queries/list-all-companies.ts
@@ -23,11 +23,7 @@ export async function listAllCompanies(): Promise<Company[]> {
     throw new AppError("Acesso negado", "ACCESS_DENIED");
   }
 
-  const { data, error } = await supabase
-    .from("companies")
-    .select("*")
-    .eq("is_active", true)
-    .order("name");
+  const { data, error } = await supabase.from("companies").select("*").order("name");
 
   if (error) throw error;
 

--- a/src/modules/tenancy/queries/list-all-companies.ts
+++ b/src/modules/tenancy/queries/list-all-companies.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+import { AppError } from "@/lib/errors";
+import type { Tables } from "@/types/database.types";
+
+export type Company = Tables<"companies">;
+
+/**
+ * Retorna todas as empresas da plataforma (somente para administradores de plataforma).
+ *
+ * @throws {AppError} Se o usuário não for administrador da plataforma
+ */
+export async function listAllCompanies(): Promise<Company[]> {
+  const supabase = await createClient();
+
+  // Verifica se o usuário é administrador da plataforma
+  const { data: isPlatformAdmin, error: rpcError } = await supabase.rpc("is_platform_admin");
+
+  if (rpcError) throw rpcError;
+
+  if (!isPlatformAdmin) {
+    throw new AppError("Acesso negado", "ACCESS_DENIED");
+  }
+
+  const { data, error } = await supabase.from("companies").select("*").order("name");
+
+  if (error) throw error;
+
+  return data ?? [];
+}

--- a/src/modules/tenancy/queries/list-modules.ts
+++ b/src/modules/tenancy/queries/list-modules.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+import type { Tables } from "@/types/database.types";
+
+export type Module = Tables<"modules">;
+
+/**
+ * Retorna todos os módulos ativos da plataforma, ordenados por sort_order.
+ * Não requer autenticação especial — módulos são legíveis por usuários autenticados.
+ */
+export async function listModules(): Promise<Module[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("modules")
+    .select("*")
+    .eq("is_active", true)
+    .order("sort_order");
+
+  if (error) throw error;
+
+  return data ?? [];
+}

--- a/src/modules/tenancy/queries/list-my-companies.ts
+++ b/src/modules/tenancy/queries/list-my-companies.ts
@@ -29,7 +29,7 @@ export async function listMyCompanies(): Promise<Company[]> {
   const companies: Company[] = [];
   for (const row of data ?? []) {
     if (row.companies) {
-      companies.push(row.companies as Company);
+      companies.push(row.companies);
     }
   }
 

--- a/src/modules/tenancy/queries/list-my-companies.ts
+++ b/src/modules/tenancy/queries/list-my-companies.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+import type { Tables } from "@/types/database.types";
+
+export type Company = Tables<"companies">;
+
+/**
+ * Retorna todas as empresas onde o usuário atual possui membership ativo.
+ */
+export async function listMyCompanies(): Promise<Company[]> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from("memberships")
+    .select("companies(*)")
+    .eq("user_id", user.id)
+    .eq("status", "active");
+
+  if (error) throw error;
+
+  // Extrai as empresas dos relacionamentos
+  const companies: Company[] = [];
+  for (const row of data ?? []) {
+    if (row.companies) {
+      companies.push(row.companies as Company);
+    }
+  }
+
+  return companies;
+}

--- a/src/modules/tenancy/queries/resolve-company.ts
+++ b/src/modules/tenancy/queries/resolve-company.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+import { AppError } from "@/lib/errors";
+import type { Tables } from "@/types/database.types";
+
+export type Company = Tables<"companies">;
+
+/**
+ * Resolve uma empresa pelo slug. Verifica se o usuário atual possui
+ * membership ativo na empresa ou se é um administrador da plataforma.
+ *
+ * @throws {AppError} Se a empresa não for encontrada
+ * @throws {AppError} Se o usuário não tiver membership ativo na empresa
+ */
+export async function resolveCompany(slug: string): Promise<Company> {
+  const supabase = await createClient();
+
+  // Busca a empresa pelo slug
+  const { data: company, error: companyError } = await supabase
+    .from("companies")
+    .select("*")
+    .eq("slug", slug)
+    .single();
+
+  if (companyError || !company) {
+    throw new AppError("Empresa não encontrada", "COMPANY_NOT_FOUND");
+  }
+
+  // Verifica se é platform admin (admins da plataforma podem acessar qualquer empresa)
+  const { data: isPlatformAdmin } = await supabase.rpc("is_platform_admin");
+
+  if (isPlatformAdmin) {
+    return company;
+  }
+
+  // Verifica se o usuário tem membership ativo na empresa
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new AppError("Não autenticado", "UNAUTHENTICATED");
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("memberships")
+    .select("id")
+    .eq("company_id", company.id)
+    .eq("user_id", user.id)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (membershipError) throw membershipError;
+
+  if (!membership) {
+    throw new AppError("Acesso negado a esta empresa", "ACCESS_DENIED");
+  }
+
+  return company;
+}

--- a/src/modules/tenancy/queries/resolve-company.ts
+++ b/src/modules/tenancy/queries/resolve-company.ts
@@ -27,20 +27,21 @@ export async function resolveCompany(slug: string): Promise<Company> {
     throw new AppError("Empresa não encontrada", "COMPANY_NOT_FOUND");
   }
 
-  // Verifica se é platform admin (admins da plataforma podem acessar qualquer empresa)
-  const { data: isPlatformAdmin } = await supabase.rpc("is_platform_admin");
-
-  if (isPlatformAdmin) {
-    return company;
-  }
-
-  // Verifica se o usuário tem membership ativo na empresa
+  // Verifica autenticação antes de qualquer RPC
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   if (!user) {
     throw new AppError("Não autenticado", "UNAUTHENTICATED");
+  }
+
+  // Verifica se é platform admin (admins da plataforma podem acessar qualquer empresa)
+  const { data: isPlatformAdmin, error: rpcError } = await supabase.rpc("is_platform_admin");
+  if (rpcError) throw rpcError;
+
+  if (isPlatformAdmin) {
+    return company;
   }
 
   const { data: membership, error: membershipError } = await supabase

--- a/src/modules/tenancy/schemas/create-company.ts
+++ b/src/modules/tenancy/schemas/create-company.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const createCompanySchema = z.object({
+  name: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
+  slug: z
+    .string()
+    .min(3, "Slug deve ter pelo menos 3 caracteres")
+    .regex(/^[a-z0-9-]+$/, "Slug deve conter apenas letras minúsculas, números e hífens"),
+  plan: z.enum(["starter", "pro", "enterprise"], {
+    errorMap: () => ({ message: "Plano inválido" }),
+  }),
+  document: z.string().optional(),
+  modules: z.array(z.string().min(1)).min(1, "Selecione pelo menos um módulo"),
+  ownerEmail: z.string().email("E-mail inválido").optional().or(z.literal("")),
+});
+
+export type CreateCompanyInput = z.infer<typeof createCompanySchema>;

--- a/src/modules/tenancy/schemas/index.ts
+++ b/src/modules/tenancy/schemas/index.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+// Schema para trocar a empresa ativa
+export const switchActiveCompanySchema = z.object({
+  companyId: z.string().uuid("ID de empresa inválido"),
+});
+
+export type SwitchActiveCompanyInput = z.infer<typeof switchActiveCompanySchema>;

--- a/src/modules/tenancy/schemas/update-company.ts
+++ b/src/modules/tenancy/schemas/update-company.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const updateCompanySchema = z.object({
+  id: z.string().uuid("ID de empresa inválido"),
+  name: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
+  plan: z.enum(["starter", "pro", "enterprise"], {
+    errorMap: () => ({ message: "Plano inválido" }),
+  }),
+  document: z.string().optional(),
+  is_active: z
+    .string()
+    .transform((v) => v === "on" || v === "true")
+    .or(z.boolean()),
+});
+
+export type UpdateCompanyInput = z.infer<typeof updateCompanySchema>;

--- a/src/modules/tenancy/schemas/update-company.ts
+++ b/src/modules/tenancy/schemas/update-company.ts
@@ -9,8 +9,8 @@ export const updateCompanySchema = z.object({
   document: z.string().optional(),
   is_active: z
     .string()
-    .transform((v) => v === "on" || v === "true")
-    .or(z.boolean()),
+    .optional()
+    .transform((v) => v === "on" || v === "true"),
 });
 
 export type UpdateCompanyInput = z.infer<typeof updateCompanySchema>;

--- a/src/modules/tenancy/services/active-company.ts
+++ b/src/modules/tenancy/services/active-company.ts
@@ -2,8 +2,7 @@ import "server-only";
 
 import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
-
-const ACTIVE_COMPANY_COOKIE = "erp.active_company";
+import { ACTIVE_COMPANY_COOKIE } from "../constants";
 
 /**
  * Retorna o ID da empresa ativa para o usuário atual.

--- a/src/modules/tenancy/services/active-company.ts
+++ b/src/modules/tenancy/services/active-company.ts
@@ -1,0 +1,48 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+
+const ACTIVE_COMPANY_COOKIE = "erp.active_company";
+
+/**
+ * Retorna o ID da empresa ativa para o usuário atual.
+ *
+ * Lê o cookie `erp.active_company` e valida que o usuário ainda possui
+ * membership ativo nessa empresa. Caso o cookie seja inválido ou ausente,
+ * faz fallback para a primeira empresa com membership ativo do usuário.
+ *
+ * @returns O ID (UUID) da empresa ativa, ou null se o usuário não estiver
+ *          autenticado ou não possuir nenhum membership ativo.
+ */
+export async function getActiveCompanyId(): Promise<string | null> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  // Busca todos os memberships ativos do usuário
+  const { data: memberships, error } = await supabase
+    .from("memberships")
+    .select("company_id")
+    .eq("user_id", user.id)
+    .eq("status", "active");
+
+  if (error || !memberships || memberships.length === 0) return null;
+
+  const validCompanyIds = new Set(memberships.map((m) => m.company_id));
+
+  // Tenta usar o cookie de empresa ativa
+  const cookieStore = await cookies();
+  const storedCompanyId = cookieStore.get(ACTIVE_COMPANY_COOKIE)?.value;
+
+  if (storedCompanyId && validCompanyIds.has(storedCompanyId)) {
+    return storedCompanyId;
+  }
+
+  // Fallback: retorna a primeira empresa com membership ativo
+  return memberships[0]?.company_id ?? null;
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1,5 +1,3 @@
-// TODO(S1): regenerar após aplicar as migrations do Sprint 1 ao projeto Supabase linked
-// Execute: npm run db:push && npm run db:types
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
@@ -10,6 +8,303 @@ export type Database = {
   };
   public: {
     Tables: {
+      audit_logs: {
+        Row: {
+          action: string;
+          actor_email: string | null;
+          actor_user_id: string | null;
+          company_id: string | null;
+          created_at: string;
+          id: string;
+          ip: unknown;
+          metadata: Json;
+          permission: string | null;
+          resource_id: string | null;
+          resource_type: string | null;
+          status: string;
+          user_agent: string | null;
+        };
+        Insert: {
+          action: string;
+          actor_email?: string | null;
+          actor_user_id?: string | null;
+          company_id?: string | null;
+          created_at?: string;
+          id?: string;
+          ip?: unknown;
+          metadata?: Json;
+          permission?: string | null;
+          resource_id?: string | null;
+          resource_type?: string | null;
+          status?: string;
+          user_agent?: string | null;
+        };
+        Update: {
+          action?: string;
+          actor_email?: string | null;
+          actor_user_id?: string | null;
+          company_id?: string | null;
+          created_at?: string;
+          id?: string;
+          ip?: unknown;
+          metadata?: Json;
+          permission?: string | null;
+          resource_id?: string | null;
+          resource_type?: string | null;
+          status?: string;
+          user_agent?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "audit_logs_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      companies: {
+        Row: {
+          created_at: string;
+          created_by: string | null;
+          document: string | null;
+          id: string;
+          is_active: boolean;
+          name: string;
+          plan: string;
+          slug: string;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          created_by?: string | null;
+          document?: string | null;
+          id?: string;
+          is_active?: boolean;
+          name: string;
+          plan?: string;
+          slug: string;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          created_by?: string | null;
+          document?: string | null;
+          id?: string;
+          is_active?: boolean;
+          name?: string;
+          plan?: string;
+          slug?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+      company_modules: {
+        Row: {
+          company_id: string;
+          enabled_at: string;
+          enabled_by: string | null;
+          module_code: string;
+        };
+        Insert: {
+          company_id: string;
+          enabled_at?: string;
+          enabled_by?: string | null;
+          module_code: string;
+        };
+        Update: {
+          company_id?: string;
+          enabled_at?: string;
+          enabled_by?: string | null;
+          module_code?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "company_modules_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "company_modules_module_code_fkey";
+            columns: ["module_code"];
+            isOneToOne: false;
+            referencedRelation: "modules";
+            referencedColumns: ["code"];
+          },
+        ];
+      };
+      membership_roles: {
+        Row: {
+          assigned_at: string;
+          assigned_by: string | null;
+          membership_id: string;
+          role_id: string;
+        };
+        Insert: {
+          assigned_at?: string;
+          assigned_by?: string | null;
+          membership_id: string;
+          role_id: string;
+        };
+        Update: {
+          assigned_at?: string;
+          assigned_by?: string | null;
+          membership_id?: string;
+          role_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "membership_roles_membership_id_fkey";
+            columns: ["membership_id"];
+            isOneToOne: false;
+            referencedRelation: "memberships";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "membership_roles_role_id_fkey";
+            columns: ["role_id"];
+            isOneToOne: false;
+            referencedRelation: "roles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      memberships: {
+        Row: {
+          company_id: string;
+          created_at: string;
+          id: string;
+          invited_at: string | null;
+          invited_by: string | null;
+          is_owner: boolean;
+          joined_at: string | null;
+          status: Database["public"]["Enums"]["membership_status"];
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          company_id: string;
+          created_at?: string;
+          id?: string;
+          invited_at?: string | null;
+          invited_by?: string | null;
+          is_owner?: boolean;
+          joined_at?: string | null;
+          status?: Database["public"]["Enums"]["membership_status"];
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          company_id?: string;
+          created_at?: string;
+          id?: string;
+          invited_at?: string | null;
+          invited_by?: string | null;
+          is_owner?: boolean;
+          joined_at?: string | null;
+          status?: Database["public"]["Enums"]["membership_status"];
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "memberships_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      modules: {
+        Row: {
+          code: string;
+          created_at: string;
+          description: string | null;
+          icon: string | null;
+          is_active: boolean;
+          is_system: boolean;
+          name: string;
+          sort_order: number;
+        };
+        Insert: {
+          code: string;
+          created_at?: string;
+          description?: string | null;
+          icon?: string | null;
+          is_active?: boolean;
+          is_system?: boolean;
+          name: string;
+          sort_order?: number;
+        };
+        Update: {
+          code?: string;
+          created_at?: string;
+          description?: string | null;
+          icon?: string | null;
+          is_active?: boolean;
+          is_system?: boolean;
+          name?: string;
+          sort_order?: number;
+        };
+        Relationships: [];
+      };
+      permissions: {
+        Row: {
+          action: string;
+          code: string;
+          created_at: string;
+          description: string | null;
+          module_code: string;
+          resource: string;
+        };
+        Insert: {
+          action: string;
+          code: string;
+          created_at?: string;
+          description?: string | null;
+          module_code: string;
+          resource: string;
+        };
+        Update: {
+          action?: string;
+          code?: string;
+          created_at?: string;
+          description?: string | null;
+          module_code?: string;
+          resource?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "permissions_module_code_fkey";
+            columns: ["module_code"];
+            isOneToOne: false;
+            referencedRelation: "modules";
+            referencedColumns: ["code"];
+          },
+        ];
+      };
+      platform_admins: {
+        Row: {
+          granted_at: string;
+          granted_by: string | null;
+          user_id: string;
+        };
+        Insert: {
+          granted_at?: string;
+          granted_by?: string | null;
+          user_id: string;
+        };
+        Update: {
+          granted_at?: string;
+          granted_by?: string | null;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       products: {
         Row: {
           cost_price: number;
@@ -85,6 +380,80 @@ export type Database = {
         };
         Relationships: [];
       };
+      role_permissions: {
+        Row: {
+          granted_at: string;
+          permission_code: string;
+          role_id: string;
+        };
+        Insert: {
+          granted_at?: string;
+          permission_code: string;
+          role_id: string;
+        };
+        Update: {
+          granted_at?: string;
+          permission_code?: string;
+          role_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "role_permissions_permission_code_fkey";
+            columns: ["permission_code"];
+            isOneToOne: false;
+            referencedRelation: "permissions";
+            referencedColumns: ["code"];
+          },
+          {
+            foreignKeyName: "role_permissions_role_id_fkey";
+            columns: ["role_id"];
+            isOneToOne: false;
+            referencedRelation: "roles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      roles: {
+        Row: {
+          code: string;
+          company_id: string;
+          created_at: string;
+          description: string | null;
+          id: string;
+          is_system: boolean;
+          name: string;
+          updated_at: string;
+        };
+        Insert: {
+          code: string;
+          company_id: string;
+          created_at?: string;
+          description?: string | null;
+          id?: string;
+          is_system?: boolean;
+          name: string;
+          updated_at?: string;
+        };
+        Update: {
+          code?: string;
+          company_id?: string;
+          created_at?: string;
+          description?: string | null;
+          id?: string;
+          is_system?: boolean;
+          name?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "roles_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       stock_movements: {
         Row: {
           created_at: string;
@@ -131,12 +500,23 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
+      bootstrap_company_rbac: {
+        Args: { p_company: string };
+        Returns: undefined;
+      };
       current_user_role: {
         Args: never;
         Returns: Database["public"]["Enums"]["user_role"];
       };
+      has_permission: {
+        Args: { p_company: string; p_permission: string };
+        Returns: boolean;
+      };
+      is_platform_admin: { Args: never; Returns: boolean };
+      user_company_ids: { Args: never; Returns: string[] };
     };
     Enums: {
+      membership_status: "invited" | "active" | "suspended";
       movement_type: "in" | "out" | "adjustment";
       user_role: "admin" | "manager" | "operator";
     };
@@ -261,12 +641,10 @@ export type CompositeTypes<
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never;
 
-export type UserRole = Database["public"]["Enums"]["user_role"];
-export type MovementType = Database["public"]["Enums"]["movement_type"];
-
 export const Constants = {
   public: {
     Enums: {
+      membership_status: ["invited", "active", "suspended"],
       movement_type: ["in", "out", "adjustment"],
       user_role: ["admin", "manager", "operator"],
     },

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,5 +1,7 @@
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
+project_id = "jrfyfgpjnswcguvvuxpx"
+
 [api]
 enabled = true
 # Port to use for the API URL.

--- a/supabase/migrations/20260422_09_fix_companies_update_rls.sql
+++ b/supabase/migrations/20260422_09_fix_companies_update_rls.sql
@@ -1,0 +1,27 @@
+-- ============================================================
+-- FIX: Separa a policy de update de companies em duas policies
+-- para impedir que owners alterem is_active e plan.
+-- ============================================================
+
+-- Remove a policy combinada que não restringia colunas para owners
+drop policy if exists "companies_update_platform_or_owner" on public.companies;
+
+-- Apenas platform admin pode criar/atualizar qualquer campo (plano, is_active, etc.)
+create policy "companies_update_platform" on public.companies
+  for update
+  using (public.is_platform_admin())
+  with check (public.is_platform_admin());
+
+-- Owner pode atualizar apenas name, document e updated_at — não is_active nem plan
+create policy "companies_update_owner" on public.companies
+  for update
+  using (
+    exists (
+      select 1 from public.memberships
+      where user_id = auth.uid() and company_id = companies.id and is_owner
+    )
+  )
+  with check (
+    is_active = (select c2.is_active from public.companies c2 where c2.id = companies.id)
+    and plan   = (select c2.plan   from public.companies c2 where c2.id = companies.id)
+  );


### PR DESCRIPTION
## Resumo

- **PR #09** — Módulo `src/modules/tenancy/` completo: cookie `erp.active_company` (httpOnly, secure, SameSite=lax), serviço `getActiveCompanyId()` com fallback para primeira empresa ativa, actions `switchActiveCompanyAction` / `createCompanyAction` / `updateCompanyAction`, queries `listMyCompanies` / `resolveCompany` / `listAllCompanies` / `listModules`
- **PR #10** — `CompanySwitcher` (Shadcn Select, client component) e `CompanyBadge` integrados no header do dashboard; `MenuItem` em `menu.ts` estendido com `requiresModule?` e `requiresPermission?`
- **PR #11** — Rotas `/admin/companies/*` protegidas por `is_platform_admin()`: listagem, criação (com bootstrap RBAC + convite ao owner), edição; layout inline 403 sem redirect
- **Migration** `20260422_09_fix_companies_update_rls.sql` — corrige policy `companies_update` para bloquear owners de alterar `is_active` e `plan` diretamente via RLS

## Plano de testes

- [ ] Typecheck: `npm run typecheck` — zero erros
- [ ] Usuário logado vê `CompanySwitcher` no header com a empresa ativa
- [ ] Trocar de empresa atualiza cookie `erp.active_company` e revalida a página
- [ ] Rota `/admin/companies` retorna 403 inline para usuários não-admin
- [ ] Platform admin consegue criar uma nova empresa (com módulos + bootstrap RBAC)
- [ ] Platform admin consegue editar nome e plano; owner não consegue mudar `is_active` ou `plan` via RLS
- [ ] `getActiveCompanyId()` faz fallback para primeira empresa se cookie inválido

🤖 Generated with [Claude Code](https://claude.com/claude-code)