### PR TITLE
feat(inventory): refactor multi-tenant S5 — RLS + RBAC + testes

### DIFF
--- a/src/app/(dashboard)/[companySlug]/inventory/[id]/delete-product-form.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/[id]/delete-product-form.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useActionState } from "react";
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { useFormStatus } from "react-dom";
+import type { ActionResult } from "@/lib/errors";
+
+const initial: ActionResult = { ok: false };
+
+type Props = {
+  deleteAction: (_prev: ActionResult, formData: FormData) => Promise<ActionResult>;
+  isActive: boolean;
+};
+
+export function DeleteProductForm({ deleteAction, isActive }: Props) {
+  const [state, formAction] = useActionState(deleteAction, initial);
+
+  useEffect(() => {
+    if (!state.ok && state.message) toast.error(state.message);
+  }, [state]);
+
+  if (!isActive) {
+    return <p className="text-sm text-muted-foreground">Este produto já está inativo.</p>;
+  }
+
+  return (
+    <form action={formAction}>
+      <SubmitButton />
+    </form>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" variant="destructive" disabled={pending}>
+      {pending ? "Desativando..." : "Desativar produto"}
+    </Button>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/inventory/[id]/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/[id]/page.tsx
@@ -2,11 +2,18 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { getProduct, updateProductAction, listMovements } from "@/modules/inventory";
+import {
+  getProduct,
+  updateProductAction,
+  deleteProductAction,
+  listMovements,
+} from "@/modules/inventory";
 import { ProductForm } from "@/modules/inventory";
 import { MovementTable } from "@/modules/inventory";
 import { formatCurrency } from "@/lib/utils";
 import { resolveCompany } from "@/modules/tenancy";
+import { Can } from "@/modules/authz";
+import { DeleteProductForm } from "./delete-product-form";
 
 export const metadata = { title: "Produto — ERP" };
 
@@ -23,8 +30,8 @@ export default async function ProductDetailPage({ params }: Props) {
 
   if (!product) notFound();
 
-  // Bind parcial: injeta o ID na action de update
   const updateAction = updateProductAction.bind(null, product.id);
+  const deleteAction = deleteProductAction.bind(null, companySlug, product.id);
   const isLowStock = Number(product.stock) <= Number(product.min_stock);
 
   return (
@@ -59,28 +66,43 @@ export default async function ProductDetailPage({ params }: Props) {
       </div>
 
       {/* Formulário de edição */}
-      <div className="rounded-lg border bg-card p-6">
-        <h2 className="mb-4 text-lg font-semibold">Editar produto</h2>
-        <ProductForm product={product} updateAction={updateAction} />
-      </div>
+      <Can permission="inventory:product:update">
+        <div className="rounded-lg border bg-card p-6">
+          <h2 className="mb-4 text-lg font-semibold">Editar produto</h2>
+          <ProductForm product={product} updateAction={updateAction} />
+        </div>
+      </Can>
+
+      {/* Zona de perigo */}
+      <Can permission="inventory:product:delete">
+        <div className="rounded-lg border border-destructive/30 bg-card p-6">
+          <h2 className="mb-1 text-lg font-semibold text-destructive">Zona de perigo</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Desativa o produto e preserva o histórico de movimentações.
+          </p>
+          <DeleteProductForm deleteAction={deleteAction} isActive={product.is_active} />
+        </div>
+      </Can>
 
       {/* Histórico de movimentações */}
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Histórico de movimentações</h2>
-          <Button asChild variant="outline" size="sm">
-            <Link href={`/${companySlug}/inventory/movements?productId=${product.id}`}>
-              Ver todas
-            </Link>
-          </Button>
+      <Can permission="movements:movement:read">
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">Histórico de movimentações</h2>
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/${companySlug}/inventory/movements?productId=${product.id}`}>
+                Ver todas
+              </Link>
+            </Button>
+          </div>
+          <MovementTable
+            data={movements.data}
+            total={movements.total}
+            page={movements.page}
+            totalPages={movements.totalPages}
+          />
         </div>
-        <MovementTable
-          data={movements.data}
-          total={movements.total}
-          page={movements.page}
-          totalPages={movements.totalPages}
-        />
-      </div>
+      </Can>
     </section>
   );
 }

--- a/src/app/(dashboard)/[companySlug]/inventory/[id]/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/[id]/page.tsx
@@ -6,18 +6,19 @@ import { getProduct, updateProductAction, listMovements } from "@/modules/invent
 import { ProductForm } from "@/modules/inventory";
 import { MovementTable } from "@/modules/inventory";
 import { formatCurrency } from "@/lib/utils";
-import { getActiveCompanyId } from "@/modules/tenancy";
+import { resolveCompany } from "@/modules/tenancy";
 
 export const metadata = { title: "Produto — ERP" };
 
-type Props = { params: Promise<{ id: string }> };
+type Props = { params: Promise<{ companySlug: string; id: string }> };
 
 export default async function ProductDetailPage({ params }: Props) {
-  const { id } = await params;
-  const companyId = (await getActiveCompanyId()) ?? "";
+  const { companySlug, id } = await params;
+  const company = await resolveCompany(companySlug);
+
   const [product, movements] = await Promise.all([
-    getProduct(id, companyId),
-    listMovements(companyId, { productId: id, pageSize: 10 }),
+    getProduct(id, company.id),
+    listMovements(company.id, { productId: id, pageSize: 10 }),
   ]);
 
   if (!product) notFound();
@@ -39,7 +40,7 @@ export default async function ProductDetailPage({ params }: Props) {
           <p className="font-mono text-sm text-muted-foreground">{product.sku}</p>
         </div>
         <Button asChild variant="outline">
-          <Link href="/inventory">← Voltar</Link>
+          <Link href={`/${companySlug}/inventory`}>← Voltar</Link>
         </Button>
       </header>
 
@@ -68,7 +69,9 @@ export default async function ProductDetailPage({ params }: Props) {
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold">Histórico de movimentações</h2>
           <Button asChild variant="outline" size="sm">
-            <Link href={`/inventory/movements?productId=${product.id}`}>Ver todas</Link>
+            <Link href={`/${companySlug}/inventory/movements?productId=${product.id}`}>
+              Ver todas
+            </Link>
           </Button>
         </div>
         <MovementTable

--- a/src/app/(dashboard)/[companySlug]/inventory/movements/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/movements/page.tsx
@@ -2,6 +2,7 @@ import { listMovements, listProducts } from "@/modules/inventory";
 import { MovementForm } from "@/modules/inventory";
 import { MovementTable } from "@/modules/inventory";
 import { resolveCompany } from "@/modules/tenancy";
+import { Can } from "@/modules/authz";
 
 export const metadata = { title: "Movimentações — ERP" };
 
@@ -34,17 +35,19 @@ export default async function MovementsPage({ params, searchParams }: Props) {
         <p className="text-sm text-muted-foreground">Registre entradas, saídas e ajustes</p>
       </header>
 
-      {/* Formulário de registro */}
-      <div className="rounded-lg border bg-card p-6">
-        <h2 className="mb-4 text-lg font-semibold">Nova movimentação</h2>
-        {productOptions.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            Cadastre pelo menos um produto ativo para registrar movimentações.
-          </p>
-        ) : (
-          <MovementForm products={productOptions} />
-        )}
-      </div>
+      {/* Formulário de registro — apenas para quem pode criar movimentações */}
+      <Can permission="movements:movement:create">
+        <div className="rounded-lg border bg-card p-6">
+          <h2 className="mb-4 text-lg font-semibold">Nova movimentação</h2>
+          {productOptions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Cadastre pelo menos um produto ativo para registrar movimentações.
+            </p>
+          ) : (
+            <MovementForm products={productOptions} />
+          )}
+        </div>
+      </Can>
 
       {/* Histórico */}
       <div className="space-y-4">

--- a/src/app/(dashboard)/[companySlug]/inventory/movements/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/movements/page.tsx
@@ -1,18 +1,23 @@
 import { listMovements, listProducts } from "@/modules/inventory";
 import { MovementForm } from "@/modules/inventory";
 import { MovementTable } from "@/modules/inventory";
-import { getActiveCompanyId } from "@/modules/tenancy";
+import { resolveCompany } from "@/modules/tenancy";
 
 export const metadata = { title: "Movimentações — ERP" };
 
-type Props = { searchParams: Promise<Record<string, string>> };
+type Props = {
+  params: Promise<{ companySlug: string }>;
+  searchParams: Promise<Record<string, string>>;
+};
 
-export default async function MovementsPage({ searchParams }: Props) {
-  const params = await searchParams;
-  const companyId = (await getActiveCompanyId()) ?? "";
+export default async function MovementsPage({ params, searchParams }: Props) {
+  const { companySlug } = await params;
+  const company = await resolveCompany(companySlug);
+  const rawParams = await searchParams;
+
   const [movements, products] = await Promise.all([
-    listMovements(companyId, params),
-    listProducts(companyId, { onlyActive: true, pageSize: 100 }),
+    listMovements(company.id, rawParams),
+    listProducts(company.id, { onlyActive: true, pageSize: 100 }),
   ]);
 
   const productOptions = products.data.map((p) => ({
@@ -25,7 +30,7 @@ export default async function MovementsPage({ searchParams }: Props) {
   return (
     <section className="space-y-8">
       <header>
-        <h1 className="text-2xl font-semibold">Movimentações de Estoque</h1>
+        <h1 className="text-2xl font-semibold">Movimentações de Estoque — {company.name}</h1>
         <p className="text-sm text-muted-foreground">Registre entradas, saídas e ajustes</p>
       </header>
 

--- a/src/app/(dashboard)/[companySlug]/inventory/new/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/new/page.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ProductForm } from "@/modules/inventory";
+import { resolveCompany } from "@/modules/tenancy";
+
+export const metadata = { title: "Novo Produto — ERP" };
+
+type Props = {
+  params: Promise<{ companySlug: string }>;
+};
+
+export default async function NewProductPage({ params }: Props) {
+  const { companySlug } = await params;
+  // Resolve empresa apenas para validar acesso; company_id é injetado na action via cookie
+  await resolveCompany(companySlug);
+
+  return (
+    <section className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Novo Produto</h1>
+          <p className="text-sm text-muted-foreground">Preencha os dados do produto</p>
+        </div>
+        <Button asChild variant="outline">
+          <Link href={`/${companySlug}/inventory`}>Cancelar</Link>
+        </Button>
+      </header>
+
+      <div className="rounded-lg border bg-card p-6">
+        <ProductForm />
+      </div>
+    </section>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/inventory/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/page.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input";
 import { listProducts } from "@/modules/inventory";
 import { ProductTable } from "@/modules/inventory";
 import { resolveCompany } from "@/modules/tenancy";
+import { Can } from "@/modules/authz";
 
 export const metadata = { title: "Estoque — ERP" };
 
@@ -26,12 +27,16 @@ export default async function InventoryPage({ params, searchParams }: Props) {
           <p className="text-sm text-muted-foreground">{total} produtos cadastrados</p>
         </div>
         <div className="flex gap-2">
-          <Button asChild variant="outline">
-            <Link href={`/${companySlug}/inventory/movements`}>Movimentações</Link>
-          </Button>
-          <Button asChild>
-            <Link href={`/${companySlug}/inventory/new`}>+ Novo produto</Link>
-          </Button>
+          <Can permission="movements:movement:read">
+            <Button asChild variant="outline">
+              <Link href={`/${companySlug}/inventory/movements`}>Movimentações</Link>
+            </Button>
+          </Can>
+          <Can permission="inventory:product:create">
+            <Button asChild>
+              <Link href={`/${companySlug}/inventory/new`}>+ Novo produto</Link>
+            </Button>
+          </Can>
         </div>
       </header>
 

--- a/src/app/(dashboard)/[companySlug]/inventory/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/page.tsx
@@ -3,39 +3,42 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { listProducts } from "@/modules/inventory";
 import { ProductTable } from "@/modules/inventory";
-import { getActiveCompanyId } from "@/modules/tenancy";
+import { resolveCompany } from "@/modules/tenancy";
 
 export const metadata = { title: "Estoque — ERP" };
 
-type Props = { searchParams: Promise<Record<string, string>> };
+type Props = {
+  params: Promise<{ companySlug: string }>;
+  searchParams: Promise<Record<string, string>>;
+};
 
-export default async function InventoryPage({ searchParams }: Props) {
-  const params = await searchParams;
-  const companyId = (await getActiveCompanyId()) ?? "";
-  const { data, total, page, pageSize, totalPages } = await listProducts(companyId, params);
+export default async function InventoryPage({ params, searchParams }: Props) {
+  const { companySlug } = await params;
+  const company = await resolveCompany(companySlug);
+  const rawParams = await searchParams;
+  const { data, total, page, pageSize, totalPages } = await listProducts(company.id, rawParams);
 
   return (
     <section className="space-y-6">
       <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold">Estoque</h1>
+          <h1 className="text-2xl font-semibold">Estoque — {company.name}</h1>
           <p className="text-sm text-muted-foreground">{total} produtos cadastrados</p>
         </div>
         <div className="flex gap-2">
           <Button asChild variant="outline">
-            <Link href="/inventory/movements">Movimentações</Link>
+            <Link href={`/${companySlug}/inventory/movements`}>Movimentações</Link>
           </Button>
           <Button asChild>
-            <Link href="/inventory/new">+ Novo produto</Link>
+            <Link href={`/${companySlug}/inventory/new`}>+ Novo produto</Link>
           </Button>
         </div>
       </header>
 
-      {/* Busca */}
       <form className="flex gap-2">
         <Input
           name="q"
-          defaultValue={params.q ?? ""}
+          defaultValue={rawParams.q ?? ""}
           placeholder="Buscar por nome ou SKU..."
           className="max-w-sm"
         />

--- a/src/app/(dashboard)/[companySlug]/inventory/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/page.tsx
@@ -53,6 +53,7 @@ export default async function InventoryPage({ params, searchParams }: Props) {
         page={page}
         pageSize={pageSize}
         totalPages={totalPages}
+        basePath={`/${companySlug}/inventory`}
       />
     </section>
   );

--- a/src/app/(dashboard)/inventory/page.tsx
+++ b/src/app/(dashboard)/inventory/page.tsx
@@ -50,6 +50,7 @@ export default async function InventoryPage({ searchParams }: Props) {
         page={page}
         pageSize={pageSize}
         totalPages={totalPages}
+        basePath="/inventory"
       />
     </section>
   );

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -2,15 +2,26 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { signOutAction } from "@/modules/auth";
 import { Button } from "@/components/ui/button";
-import { MODULES_MENU } from "@/core/navigation/menu";
+import { MODULES_MENU, ADMIN_MENU } from "@/core/navigation/menu";
 import { getCurrentUser } from "@/modules/auth";
 import { CompanySwitcher, listMyCompanies, getActiveCompanyId } from "@/modules/tenancy";
+import { createClient } from "@/lib/supabase/server";
+import { getEffectivePermissions } from "@/modules/authz";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const user = await getCurrentUser();
   if (!user) redirect("/login");
 
-  const [companies, activeCompanyId] = await Promise.all([listMyCompanies(), getActiveCompanyId()]);
+  const supabase = await createClient();
+  const [companies, activeCompanyId, { data: isPlatformAdmin }] = await Promise.all([
+    listMyCompanies(),
+    getActiveCompanyId(),
+    supabase.rpc("is_platform_admin"),
+  ]);
+
+  const userPerms = activeCompanyId
+    ? await getEffectivePermissions(activeCompanyId)
+    : new Set<string>();
 
   const activeCompany = companies.find((c) => c.id === activeCompanyId) ?? companies[0];
   const companySlug = activeCompany?.slug ?? "";
@@ -25,7 +36,12 @@ export default async function DashboardLayout({ children }: { children: React.Re
         </div>
 
         <nav className="flex flex-col gap-1">
-          {MODULES_MENU.map((item) => {
+          {MODULES_MENU.filter((item) => {
+            if (!item.requiresPermission) return true;
+            // Platform admin tem acesso irrestrito
+            if (isPlatformAdmin) return true;
+            return userPerms.has(item.requiresPermission) || userPerms.has("*");
+          }).map((item) => {
             const href =
               item.requiresSlug && companySlug ? `/${companySlug}${item.href}` : item.href;
             return (
@@ -38,6 +54,23 @@ export default async function DashboardLayout({ children }: { children: React.Re
               </Link>
             );
           })}
+
+          {isPlatformAdmin && (
+            <div className="mt-6">
+              <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Plataforma
+              </p>
+              {ADMIN_MENU.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          )}
         </nav>
       </aside>
 

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -12,6 +12,9 @@ export default async function DashboardLayout({ children }: { children: React.Re
 
   const [companies, activeCompanyId] = await Promise.all([listMyCompanies(), getActiveCompanyId()]);
 
+  const activeCompany = companies.find((c) => c.id === activeCompanyId) ?? companies[0];
+  const companySlug = activeCompany?.slug ?? "";
+
   return (
     <div className="grid min-h-screen grid-cols-[240px_1fr]">
       {/* Sidebar */}
@@ -22,15 +25,19 @@ export default async function DashboardLayout({ children }: { children: React.Re
         </div>
 
         <nav className="flex flex-col gap-1">
-          {MODULES_MENU.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
-            >
-              {item.label}
-            </Link>
-          ))}
+          {MODULES_MENU.map((item) => {
+            const href =
+              item.requiresSlug && companySlug ? `/${companySlug}${item.href}` : item.href;
+            return (
+              <Link
+                key={item.href}
+                href={href}
+                className="rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+              >
+                {item.label}
+              </Link>
+            );
+          })}
         </nav>
       </aside>
 

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,11 +1,13 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { listProducts } from "@/modules/inventory";
+import { getActiveCompanyId } from "@/modules/tenancy";
 
 export const metadata = { title: "Dashboard — ERP" };
 
 export default async function DashboardPage() {
-  const { data, total } = await listProducts({ onlyActive: true, pageSize: 5 });
+  const companyId = (await getActiveCompanyId()) ?? "";
+  const { data, total } = await listProducts(companyId, { onlyActive: true, pageSize: 5 });
   const lowStockCount = data.filter((p) => Number(p.stock) <= Number(p.min_stock)).length;
 
   return (
@@ -34,19 +36,9 @@ export default async function DashboardPage() {
   );
 }
 
-function MetricCard({
-  label,
-  value,
-  alert,
-}: {
-  label: string;
-  value: number;
-  alert?: boolean;
-}) {
+function MetricCard({ label, value, alert }: { label: string; value: number; alert?: boolean }) {
   return (
-    <div
-      className={`rounded-lg border p-5 ${alert ? "border-red-200 bg-red-50" : "bg-card"}`}
-    >
+    <div className={`rounded-lg border p-5 ${alert ? "border-red-200 bg-red-50" : "bg-card"}`}>
       <p className="text-sm text-muted-foreground">{label}</p>
       <p className={`mt-1 text-3xl font-bold ${alert ? "text-red-600" : ""}`}>{value}</p>
     </div>

--- a/src/core/navigation/menu.ts
+++ b/src/core/navigation/menu.ts
@@ -5,6 +5,8 @@ export type MenuItem = {
   roles?: string[];
   requiresModule?: string;
   requiresPermission?: string;
+  /** Se true, o layout prefixará o href com `/<companySlug>` */
+  requiresSlug?: boolean;
 };
 
 /**
@@ -13,7 +15,7 @@ export type MenuItem = {
  */
 export const MODULES_MENU: MenuItem[] = [
   { label: "Início", href: "/" },
-  { label: "Estoque", href: "/inventory" },
-  { label: "Movimentações", href: "/inventory/movements" },
+  { label: "Estoque", href: "/inventory", requiresSlug: true },
+  { label: "Movimentações", href: "/inventory/movements", requiresSlug: true },
   // Novos módulos: Orçamentos, Clientes, Financeiro, etc.
 ];

--- a/src/core/navigation/menu.ts
+++ b/src/core/navigation/menu.ts
@@ -9,13 +9,21 @@ export type MenuItem = {
   requiresSlug?: boolean;
 };
 
-/**
- * Registro central do menu de navegação.
- * Novos módulos se registram aqui sem alterar o layout.
- */
 export const MODULES_MENU: MenuItem[] = [
   { label: "Início", href: "/" },
-  { label: "Estoque", href: "/inventory", requiresSlug: true },
-  { label: "Movimentações", href: "/inventory/movements", requiresSlug: true },
-  // Novos módulos: Orçamentos, Clientes, Financeiro, etc.
+  {
+    label: "Estoque",
+    href: "/inventory",
+    requiresSlug: true,
+    requiresPermission: "inventory:product:read",
+  },
+  {
+    label: "Movimentações",
+    href: "/inventory/movements",
+    requiresSlug: true,
+    requiresPermission: "movements:movement:read",
+  },
+  { label: "Auditoria", href: "/audit", requiresSlug: true, requiresPermission: "core:audit:read" },
 ];
+
+export const ADMIN_MENU: MenuItem[] = [{ label: "Empresas", href: "/admin/companies" }];

--- a/src/modules/authz/services/with-permission.ts
+++ b/src/modules/authz/services/with-permission.ts
@@ -27,6 +27,16 @@ export function withPermission<T>(
       }
       return result;
     } catch (e) {
+      // Re-throw Next.js internal errors (redirect, notFound) sem auditar como erro
+      if (
+        e instanceof Error &&
+        "digest" in e &&
+        typeof (e as { digest: unknown }).digest === "string" &&
+        ((e as { digest: string }).digest.startsWith("NEXT_REDIRECT") ||
+          (e as { digest: string }).digest.startsWith("NEXT_NOT_FOUND"))
+      ) {
+        throw e;
+      }
       const status = e instanceof ForbiddenError ? "denied" : "error";
       try {
         await audit({

--- a/src/modules/inventory/actions/__tests__/inventory-actions.test.ts
+++ b/src/modules/inventory/actions/__tests__/inventory-actions.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/modules/tenancy", () => ({ getActiveCompanyId: vi.fn() }));
+vi.mock("@/modules/authz", () => {
+  class ForbiddenError extends Error {
+    permission: string;
+    constructor(p: string) {
+      super(`forbidden:${p}`);
+      this.permission = p;
+    }
+  }
+  return { requirePermission: vi.fn(), ForbiddenError };
+});
+
+import { createClient } from "@/lib/supabase/server";
+import { getActiveCompanyId } from "@/modules/tenancy";
+import { requirePermission, ForbiddenError } from "@/modules/authz";
+import { createProductAction } from "../create-product";
+import { updateProductAction } from "../update-product";
+import { deleteProductAction } from "../delete-product";
+import { registerMovementAction } from "../register-movement";
+
+const COMPANY_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const COMPANY_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const PRODUCT_UUID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+function makeFormData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v);
+  return fd;
+}
+
+// Retorna um mock de SupabaseClient que suporta .from().insert(), .from().update().eq().eq(),
+// e .from().select().eq().single() com respostas configuráveis.
+function makeSupabaseMock({
+  userId = "user-xyz",
+  insertError = null as unknown,
+  updateRows = 1,
+  stockValue = 100,
+} = {}) {
+  const insertChain = { insert: vi.fn().mockResolvedValue({ error: insertError }) };
+  const selectChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: { stock: stockValue }, error: null }),
+  };
+  const updateChain = {
+    update: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null, count: updateRows }),
+      }),
+    }),
+  };
+
+  return {
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: userId } } }) },
+    from: vi.fn((table: string) => {
+      if (table === "stock_movements") return insertChain;
+      // products: suporta insert E update E select dependendo do método chamado
+      return {
+        insert: vi.fn().mockResolvedValue({ error: insertError }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        }),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: { stock: stockValue }, error: null }),
+      };
+    }),
+  };
+}
+
+const validProductData = {
+  sku: "PROD-001",
+  name: "Produto Teste",
+  unit: "UN",
+  costPrice: "10",
+  salePrice: "20",
+  minStock: "0",
+};
+
+const validMovementData = {
+  productId: PRODUCT_UUID,
+  type: "in",
+  quantity: "5",
+};
+
+// ─── createProductAction ──────────────────────────────────────────────────────
+
+describe("createProductAction — isolamento por empresa", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("bloqueia quando nenhuma empresa ativa está definida", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(null);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+
+    const result = await createProductAction({ ok: false }, makeFormData(validProductData));
+
+    expect(result.ok).toBe(false);
+    expect((result as { message: string }).message).toMatch(/empresa ativa/i);
+  });
+
+  it("retorna acesso negado quando requirePermission lança ForbiddenError", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(COMPANY_A);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+    vi.mocked(requirePermission).mockRejectedValue(new ForbiddenError("inventory:product:create"));
+
+    const result = await createProductAction({ ok: false }, makeFormData(validProductData));
+
+    expect(result.ok).toBe(false);
+    expect((result as { message: string }).message).toMatch(/acesso negado/i);
+  });
+
+  it("passa o companyId correto para requirePermission", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(COMPANY_A);
+    vi.mocked(requirePermission).mockResolvedValue(undefined);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+
+    await createProductAction({ ok: false }, makeFormData(validProductData));
+
+    expect(requirePermission).toHaveBeenCalledWith(COMPANY_A, "inventory:product:create");
+  });
+
+  it("empresa B não afeta verificação da empresa A (isolamento de contexto)", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(COMPANY_B);
+    vi.mocked(requirePermission).mockResolvedValue(undefined);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+
+    await createProductAction({ ok: false }, makeFormData(validProductData));
+
+    expect(requirePermission).toHaveBeenCalledWith(COMPANY_B, "inventory:product:create");
+    expect(requirePermission).not.toHaveBeenCalledWith(COMPANY_A, expect.anything());
+  });
+
+  it("retorna fieldErrors quando input é inválido (antes de checar permissão)", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(COMPANY_A);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+
+    const result = await createProductAction({ ok: false }, makeFormData({ sku: "", name: "x" }));
+
+    expect(result.ok).toBe(false);
+    // Zod falhou → requirePermission não deve ser chamado
+    expect(requirePermission).not.toHaveBeenCalled();
+  });
+});
+
+// ─── updateProductAction ──────────────────────────────────────────────────────
+
+describe("updateProductAction — controle de permissão", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("bloqueia operador sem permissão de update", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(COMPANY_A);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+    vi.mocked(requirePermission).mockRejectedValue(new ForbiddenError("inventory:product:update"));
+
+    const result = await updateProductAction(
+      "prod-id-1",
+      { ok: false },
+      makeFormData(validProductData),
+    );
+
+    expect(result.ok).toBe(false);
+    expect((result as { message: string }).message).toMatch(/acesso negado/i);
+  });
+
+  it("chama requirePermission com a permissão correta de update", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(COMPANY_A);
+    vi.mocked(requirePermission).mockResolvedValue(undefined);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+
+    await updateProductAction("prod-id-1", { ok: false }, makeFormData(validProductData));
+
+    expect(requirePermission).toHaveBeenCalledWith(COMPANY_A, "inventory:product:update");
+  });
+});
+
+// ─── deleteProductAction ──────────────────────────────────────────────────────
+
+describe("deleteProductAction — controle de permissão", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("bloqueia operador sem permissão de delete", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(COMPANY_A);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+    vi.mocked(requirePermission).mockRejectedValue(new ForbiddenError("inventory:product:delete"));
+
+    const result = await deleteProductAction(
+      "default-company",
+      "prod-id-1",
+      { ok: false },
+      new FormData(),
+    );
+
+    expect(result.ok).toBe(false);
+    expect((result as { message: string }).message).toMatch(/acesso negado/i);
+  });
+
+  it("chama requirePermission com a permissão correta de delete", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(COMPANY_A);
+    vi.mocked(requirePermission).mockResolvedValue(undefined);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+
+    // redirect() do Next.js é mockado — não lança de verdade no teste
+    await deleteProductAction("default-company", "prod-id-1", { ok: false }, new FormData());
+
+    expect(requirePermission).toHaveBeenCalledWith(COMPANY_A, "inventory:product:delete");
+  });
+});
+
+// ─── registerMovementAction ───────────────────────────────────────────────────
+
+describe("registerMovementAction — controle de permissão", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("bloqueia quando requirePermission nega movements:movement:create", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(COMPANY_A);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+    vi.mocked(requirePermission).mockRejectedValue(new ForbiddenError("movements:movement:create"));
+
+    const result = await registerMovementAction({ ok: false }, makeFormData(validMovementData));
+
+    expect(result.ok).toBe(false);
+    expect((result as { message: string }).message).toMatch(/acesso negado/i);
+  });
+
+  it("chama requirePermission com a permissão correta de movimento", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(COMPANY_A);
+    vi.mocked(requirePermission).mockResolvedValue(undefined);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock({ stockValue: 100 }) as never);
+
+    await registerMovementAction({ ok: false }, makeFormData(validMovementData));
+
+    expect(requirePermission).toHaveBeenCalledWith(COMPANY_A, "movements:movement:create");
+  });
+
+  it("bloqueia quando nenhuma empresa ativa está definida", async () => {
+    vi.mocked(getActiveCompanyId).mockResolvedValue(null);
+    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+
+    const result = await registerMovementAction({ ok: false }, makeFormData(validMovementData));
+
+    expect(result.ok).toBe(false);
+    expect((result as { message: string }).message).toMatch(/empresa ativa/i);
+  });
+});

--- a/src/modules/inventory/actions/create-product.ts
+++ b/src/modules/inventory/actions/create-product.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
+import { getActiveCompanyId } from "@/modules/tenancy";
 import { productSchema } from "../schemas";
 import type { ActionResult } from "@/lib/errors";
 
@@ -20,6 +21,9 @@ export async function createProductAction(
   } = await supabase.auth.getUser();
   if (!user) return { ok: false, message: "Não autenticado" };
 
+  const companyId = await getActiveCompanyId();
+  if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
+
   const { error } = await supabase.from("products").insert({
     sku: parsed.data.sku.toUpperCase(),
     name: parsed.data.name,
@@ -29,6 +33,7 @@ export async function createProductAction(
     sale_price: parsed.data.salePrice,
     min_stock: parsed.data.minStock,
     is_active: parsed.data.isActive,
+    company_id: companyId,
     created_by: user.id,
   });
 

--- a/src/modules/inventory/actions/create-product.ts
+++ b/src/modules/inventory/actions/create-product.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveCompanyId } from "@/modules/tenancy";
+import { requirePermission, ForbiddenError } from "@/modules/authz";
 import { productSchema } from "../schemas";
 import type { ActionResult } from "@/lib/errors";
 
@@ -24,6 +25,14 @@ export async function createProductAction(
   const companyId = await getActiveCompanyId();
   if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
 
+  try {
+    await requirePermission(companyId, "inventory:product:create");
+  } catch (e) {
+    if (e instanceof ForbiddenError)
+      return { ok: false, message: "Acesso negado: permissão insuficiente" };
+    throw e;
+  }
+
   const { error } = await supabase.from("products").insert({
     sku: parsed.data.sku.toUpperCase(),
     name: parsed.data.name,
@@ -44,6 +53,6 @@ export async function createProductAction(
     return { ok: false, message: error.message };
   }
 
-  revalidatePath("/inventory");
+  revalidatePath("/", "layout");
   return { ok: true, message: "Produto cadastrado com sucesso" };
 }

--- a/src/modules/inventory/actions/delete-product.ts
+++ b/src/modules/inventory/actions/delete-product.ts
@@ -3,6 +3,8 @@
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
+import { getActiveCompanyId } from "@/modules/tenancy";
+import { requirePermission, ForbiddenError } from "@/modules/authz";
 import type { ActionResult } from "@/lib/errors";
 
 export async function deleteProductAction(
@@ -17,11 +19,23 @@ export async function deleteProductAction(
   } = await supabase.auth.getUser();
   if (!user) return { ok: false, message: "Não autenticado" };
 
+  const companyId = await getActiveCompanyId();
+  if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
+
+  try {
+    await requirePermission(companyId, "inventory:product:delete");
+  } catch (e) {
+    if (e instanceof ForbiddenError)
+      return { ok: false, message: "Acesso negado: permissão insuficiente" };
+    throw e;
+  }
+
   // Soft delete: apenas inativa o produto (preserva histórico de movimentações)
   const { error } = await supabase
     .from("products")
     .update({ is_active: false, updated_at: new Date().toISOString() })
-    .eq("id", id);
+    .eq("id", id)
+    .eq("company_id", companyId);
 
   if (error) {
     return { ok: false, message: error.message };

--- a/src/modules/inventory/actions/delete-product.ts
+++ b/src/modules/inventory/actions/delete-product.ts
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { ActionResult } from "@/lib/errors";
 
 export async function deleteProductAction(
+  companySlug: string,
   id: string,
   _prev: ActionResult,
   _formData: FormData,
@@ -26,6 +27,6 @@ export async function deleteProductAction(
     return { ok: false, message: error.message };
   }
 
-  revalidatePath("/inventory");
-  redirect("/inventory");
+  revalidatePath("/", "layout");
+  redirect(`/${companySlug}/inventory`);
 }

--- a/src/modules/inventory/actions/register-movement.ts
+++ b/src/modules/inventory/actions/register-movement.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
+import { getActiveCompanyId } from "@/modules/tenancy";
 import { movementSchema } from "../schemas";
 import { validateMovement } from "../services/stock-service";
 import type { ActionResult } from "@/lib/errors";
@@ -20,6 +21,9 @@ export async function registerMovementAction(
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return { ok: false, message: "Não autenticado" };
+
+  const companyId = await getActiveCompanyId();
+  if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
 
   // Pré-validação de saldo (melhora UX — banco valida novamente via trigger)
   const { data: product, error: pErr } = await supabase
@@ -44,6 +48,7 @@ export async function registerMovementAction(
     quantity: parsed.data.quantity,
     unit_cost: parsed.data.unitCost ?? null,
     reason: parsed.data.reason ?? null,
+    company_id: companyId,
     performed_by: user.id,
   });
 

--- a/src/modules/inventory/actions/register-movement.ts
+++ b/src/modules/inventory/actions/register-movement.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveCompanyId } from "@/modules/tenancy";
+import { requirePermission, ForbiddenError } from "@/modules/authz";
 import { movementSchema } from "../schemas";
 import { validateMovement } from "../services/stock-service";
 import type { ActionResult } from "@/lib/errors";
@@ -24,6 +25,14 @@ export async function registerMovementAction(
 
   const companyId = await getActiveCompanyId();
   if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
+
+  try {
+    await requirePermission(companyId, "movements:movement:create");
+  } catch (e) {
+    if (e instanceof ForbiddenError)
+      return { ok: false, message: "Acesso negado: permissão insuficiente" };
+    throw e;
+  }
 
   // Pré-validação de saldo (melhora UX — banco valida novamente via trigger)
   const { data: product, error: pErr } = await supabase
@@ -60,7 +69,6 @@ export async function registerMovementAction(
     return { ok: false, message: error.message };
   }
 
-  revalidatePath("/inventory");
-  revalidatePath("/inventory/movements");
+  revalidatePath("/", "layout");
   return { ok: true, message: "Movimentação registrada com sucesso" };
 }

--- a/src/modules/inventory/actions/update-product.ts
+++ b/src/modules/inventory/actions/update-product.ts
@@ -2,6 +2,8 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
+import { getActiveCompanyId } from "@/modules/tenancy";
+import { requirePermission, ForbiddenError } from "@/modules/authz";
 import { productSchema } from "../schemas";
 import type { ActionResult } from "@/lib/errors";
 
@@ -21,6 +23,17 @@ export async function updateProductAction(
   } = await supabase.auth.getUser();
   if (!user) return { ok: false, message: "Não autenticado" };
 
+  const companyId = await getActiveCompanyId();
+  if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
+
+  try {
+    await requirePermission(companyId, "inventory:product:update");
+  } catch (e) {
+    if (e instanceof ForbiddenError)
+      return { ok: false, message: "Acesso negado: permissão insuficiente" };
+    throw e;
+  }
+
   const { error } = await supabase
     .from("products")
     .update({
@@ -34,7 +47,8 @@ export async function updateProductAction(
       is_active: parsed.data.isActive,
       updated_at: new Date().toISOString(),
     })
-    .eq("id", id);
+    .eq("id", id)
+    .eq("company_id", companyId);
 
   if (error) {
     if (error.code === "23505") {
@@ -43,7 +57,6 @@ export async function updateProductAction(
     return { ok: false, message: error.message };
   }
 
-  revalidatePath("/inventory");
-  revalidatePath(`/inventory/${id}`);
+  revalidatePath("/", "layout");
   return { ok: true, message: "Produto atualizado com sucesso" };
 }

--- a/src/modules/inventory/components/product-table.tsx
+++ b/src/modules/inventory/components/product-table.tsx
@@ -11,9 +11,14 @@ import {
 import { formatCurrency } from "@/lib/utils";
 import type { PaginatedResult, Product } from "../types";
 
-type Props = Pick<PaginatedResult<Product>, "data" | "page" | "pageSize" | "total" | "totalPages">;
+type Props = Pick<
+  PaginatedResult<Product>,
+  "data" | "page" | "pageSize" | "total" | "totalPages"
+> & {
+  basePath: string;
+};
 
-export function ProductTable({ data, page, totalPages, total }: Props) {
+export function ProductTable({ data, page, totalPages, total, basePath }: Props) {
   if (data.length === 0) {
     return (
       <div className="rounded-lg border border-dashed py-12 text-center text-sm text-muted-foreground">
@@ -39,7 +44,7 @@ export function ProductTable({ data, page, totalPages, total }: Props) {
           </TableHeader>
           <TableBody>
             {data.map((product) => (
-              <ProductRow key={product.id} product={product} />
+              <ProductRow key={product.id} product={product} basePath={basePath} />
             ))}
           </TableBody>
         </Table>
@@ -59,14 +64,14 @@ export function ProductTable({ data, page, totalPages, total }: Props) {
   );
 }
 
-function ProductRow({ product }: { product: Product }) {
+function ProductRow({ product, basePath }: { product: Product; basePath: string }) {
   const isLowStock = Number(product.stock) <= Number(product.min_stock);
 
   return (
     <TableRow>
       <TableCell className="font-mono text-xs">{product.sku}</TableCell>
       <TableCell>
-        <Link href={`/inventory/${product.id}`} className="font-medium hover:underline">
+        <Link href={`${basePath}/${product.id}`} className="font-medium hover:underline">
           {product.name}
         </Link>
         {product.description && (

--- a/src/modules/inventory/queries/get-product.ts
+++ b/src/modules/inventory/queries/get-product.ts
@@ -2,9 +2,14 @@ import "server-only";
 import { createClient } from "@/lib/supabase/server";
 import type { Product } from "../types";
 
-export async function getProduct(id: string): Promise<Product | null> {
+export async function getProduct(id: string, companyId: string): Promise<Product | null> {
   const supabase = await createClient();
-  const { data, error } = await supabase.from("products").select("*").eq("id", id).single();
+  const { data, error } = await supabase
+    .from("products")
+    .select("*")
+    .eq("id", id)
+    .eq("company_id", companyId)
+    .single();
 
   if (error) return null;
   return data;

--- a/src/modules/inventory/queries/list-movements.ts
+++ b/src/modules/inventory/queries/list-movements.ts
@@ -4,6 +4,7 @@ import { listMovementsSchema } from "../schemas";
 import type { PaginatedResult, StockMovement } from "../types";
 
 export async function listMovements(
+  companyId: string,
   raw: Record<string, unknown>,
 ): Promise<PaginatedResult<StockMovement>> {
   const { productId, page, pageSize } = listMovementsSchema.parse(raw);
@@ -14,6 +15,7 @@ export async function listMovements(
   let query = supabase
     .from("stock_movements")
     .select("*", { count: "exact" })
+    .eq("company_id", companyId)
     .order("created_at", { ascending: false })
     .range(from, to);
 

--- a/src/modules/inventory/queries/list-products.ts
+++ b/src/modules/inventory/queries/list-products.ts
@@ -4,6 +4,7 @@ import { listProductsSchema } from "../schemas";
 import type { PaginatedResult, Product } from "../types";
 
 export async function listProducts(
+  companyId: string,
   raw: Record<string, unknown>,
 ): Promise<PaginatedResult<Product>> {
   const { q, page, pageSize, onlyActive } = listProductsSchema.parse(raw);
@@ -14,6 +15,7 @@ export async function listProducts(
   let query = supabase
     .from("products")
     .select("*", { count: "exact" })
+    .eq("company_id", companyId)
     .order("name")
     .range(from, to);
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -307,7 +307,7 @@ export type Database = {
       };
       products: {
         Row: {
-          company_id: string | null;
+          company_id: string;
           cost_price: number;
           created_at: string;
           created_by: string | null;
@@ -323,7 +323,7 @@ export type Database = {
           updated_at: string;
         };
         Insert: {
-          company_id?: string | null;
+          company_id: string;
           cost_price?: number;
           created_at?: string;
           created_by?: string | null;
@@ -339,7 +339,7 @@ export type Database = {
           updated_at?: string;
         };
         Update: {
-          company_id?: string | null;
+          company_id?: string;
           cost_price?: number;
           created_at?: string;
           created_by?: string | null;
@@ -467,7 +467,7 @@ export type Database = {
       };
       stock_movements: {
         Row: {
-          company_id: string | null;
+          company_id: string;
           created_at: string;
           id: string;
           movement_type: Database["public"]["Enums"]["movement_type"];
@@ -478,7 +478,7 @@ export type Database = {
           unit_cost: number | null;
         };
         Insert: {
-          company_id?: string | null;
+          company_id: string;
           created_at?: string;
           id?: string;
           movement_type: Database["public"]["Enums"]["movement_type"];
@@ -489,7 +489,7 @@ export type Database = {
           unit_cost?: number | null;
         };
         Update: {
-          company_id?: string | null;
+          company_id?: string;
           created_at?: string;
           id?: string;
           movement_type?: Database["public"]["Enums"]["movement_type"];

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -307,6 +307,7 @@ export type Database = {
       };
       products: {
         Row: {
+          company_id: string | null;
           cost_price: number;
           created_at: string;
           created_by: string | null;
@@ -322,6 +323,7 @@ export type Database = {
           updated_at: string;
         };
         Insert: {
+          company_id?: string | null;
           cost_price?: number;
           created_at?: string;
           created_by?: string | null;
@@ -337,6 +339,7 @@ export type Database = {
           updated_at?: string;
         };
         Update: {
+          company_id?: string | null;
           cost_price?: number;
           created_at?: string;
           created_by?: string | null;
@@ -351,7 +354,15 @@ export type Database = {
           unit?: string;
           updated_at?: string;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: "products_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+        ];
       };
       profiles: {
         Row: {
@@ -456,6 +467,7 @@ export type Database = {
       };
       stock_movements: {
         Row: {
+          company_id: string | null;
           created_at: string;
           id: string;
           movement_type: Database["public"]["Enums"]["movement_type"];
@@ -466,6 +478,7 @@ export type Database = {
           unit_cost: number | null;
         };
         Insert: {
+          company_id?: string | null;
           created_at?: string;
           id?: string;
           movement_type: Database["public"]["Enums"]["movement_type"];
@@ -476,6 +489,7 @@ export type Database = {
           unit_cost?: number | null;
         };
         Update: {
+          company_id?: string | null;
           created_at?: string;
           id?: string;
           movement_type?: Database["public"]["Enums"]["movement_type"];
@@ -486,6 +500,13 @@ export type Database = {
           unit_cost?: number | null;
         };
         Relationships: [
+          {
+            foreignKeyName: "stock_movements_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "stock_movements_product_id_fkey";
             columns: ["product_id"];

--- a/supabase/migrations/20260423_11_products_company_nullable.sql
+++ b/supabase/migrations/20260423_11_products_company_nullable.sql
@@ -1,0 +1,9 @@
+-- Subfase A: adiciona company_id NULLABLE (zero-downtime — código antigo continua funcionando)
+alter table public.products
+  add column if not exists company_id uuid references public.companies(id) on delete cascade;
+
+alter table public.stock_movements
+  add column if not exists company_id uuid references public.companies(id) on delete cascade;
+
+create index if not exists idx_products_company     on public.products(company_id);
+create index if not exists idx_movements_company    on public.stock_movements(company_id);

--- a/supabase/migrations/20260423_12_backfill_default_company.sql
+++ b/supabase/migrations/20260423_12_backfill_default_company.sql
@@ -1,0 +1,9 @@
+-- Backfill: atribui default-company a todos os registros existentes sem company_id
+-- Seguro re-executar (WHERE company_id IS NULL)
+update public.products
+   set company_id = (select id from public.companies where slug = 'default-company' limit 1)
+ where company_id is null;
+
+update public.stock_movements
+   set company_id = (select id from public.companies where slug = 'default-company' limit 1)
+ where company_id is null;

--- a/supabase/migrations/20260423_13_sku_unique_per_company.sql
+++ b/supabase/migrations/20260423_13_sku_unique_per_company.sql
@@ -1,0 +1,4 @@
+-- PR #23: SKU único por empresa (não globalmente)
+-- Remove a constraint global e adiciona constraint composta (company_id, sku)
+alter table public.products drop constraint if exists products_sku_key;
+alter table public.products add constraint products_sku_per_company unique (company_id, sku);

--- a/supabase/migrations/20260423_14_products_company_not_null.sql
+++ b/supabase/migrations/20260423_14_products_company_not_null.sql
@@ -1,0 +1,3 @@
+-- PR #24: Torna company_id obrigatório após backfill completo
+alter table public.products alter column company_id set not null;
+alter table public.stock_movements alter column company_id set not null;

--- a/supabase/migrations/20260423_15_products_rls.sql
+++ b/supabase/migrations/20260423_15_products_rls.sql
@@ -1,0 +1,27 @@
+-- PR #25: Ativa RLS em products com policies baseadas em permissão RBAC
+-- Remove policy permissiva do single-tenant (criada na migration 04) se existir
+drop policy if exists "Authenticated users can manage products" on public.products;
+drop policy if exists "products_select" on public.products;
+drop policy if exists "products_insert" on public.products;
+drop policy if exists "products_update" on public.products;
+drop policy if exists "products_delete" on public.products;
+
+alter table public.products enable row level security;
+
+-- Leitura: qualquer membro ativo da empresa
+create policy "products_select" on public.products
+  for select using (company_id in (select public.user_company_ids()));
+
+-- Criação: requer permissão explícita
+create policy "products_insert" on public.products
+  for insert with check (public.has_permission(company_id, 'inventory:product:create'));
+
+-- Atualização: requer permissão explícita (USING + WITH CHECK para evitar escalação)
+create policy "products_update" on public.products
+  for update
+  using (public.has_permission(company_id, 'inventory:product:update'))
+  with check (public.has_permission(company_id, 'inventory:product:update'));
+
+-- Exclusão (soft delete via is_active = false): requer permissão explícita
+create policy "products_delete" on public.products
+  for delete using (public.has_permission(company_id, 'inventory:product:delete'));

--- a/supabase/migrations/20260423_16_movements_rls.sql
+++ b/supabase/migrations/20260423_16_movements_rls.sql
@@ -1,0 +1,14 @@
+-- PR #26: Ativa RLS em stock_movements com policies baseadas em permissão RBAC
+drop policy if exists "Authenticated users can manage stock_movements" on public.stock_movements;
+drop policy if exists "movements_select" on public.stock_movements;
+drop policy if exists "movements_insert" on public.stock_movements;
+
+alter table public.stock_movements enable row level security;
+
+-- Leitura: qualquer membro ativo da empresa
+create policy "movements_select" on public.stock_movements
+  for select using (company_id in (select public.user_company_ids()));
+
+-- Criação: requer permissão explícita
+create policy "movements_insert" on public.stock_movements
+  for insert with check (public.has_permission(company_id, 'movements:movement:create'));


### PR DESCRIPTION
## Summary

- **3 fixes** do review anterior: `revalidatePath("/","layout")` em todos os actions, `deleteProductAction` redireciona para `/${companySlug}/inventory`, `ProductTable` aceita prop `basePath`
- **PRs #23-24 (DB):** SKU único por empresa (`unique(company_id, sku)`), `company_id NOT NULL` em `products` e `stock_movements`
- **PRs #25-26 (RLS):** Políticas baseadas em `has_permission()` em ambas as tabelas — leitura para qualquer membro, escrita exige permissão RBAC explícita
- **PR #27 (Actions):** `requirePermission` inline em todos os 4 actions; `update` e `delete` filtram por `company_id` no WHERE
- **PR #28 (UI):** `<Can>` nos botões de "+ Novo produto", "Movimentações", editar, excluir e formulário de movimentação; `DeleteProductForm` client component com soft-delete
- **PR #29 (Testes):** 12 testes Vitest cobrindo isolamento de empresa e controle de permissão por action (total: 24 testes verdes)

## Test plan

- [x] `npm run typecheck` sem erros
- [x] `npm run test` — 24 testes passando (12 authz + 12 inventory)
- [x] Migrations aplicadas remotamente via MCP
- [x] `database.types.ts` regenerado (`company_id: string`, não mais `string | null`)
- [x] Smoke test manual: criar produto como owner, tentar atualizar como operator (deve recusar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)