### PR TITLE
feat(settings): S7 — gestão de membros e roles por empresa

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "claudeCode.useTerminal": true
+}

--- a/docs/ARCHITECTURE-MULTITENANT.md
+++ b/docs/ARCHITECTURE-MULTITENANT.md
@@ -1,0 +1,1880 @@
+# Arquitetura Multi-Tenant + RBAC Granular
+
+> **Stack:** Next.js (App Router · Server Actions · TypeScript `strict`) · Supabase (Postgres + Auth + RLS) · Zod
+> **Estratégia Multi-tenant:** _Shared Database · Shared Schema · Row-Level Security por `company_id`_
+> **Modelo RBAC:** Permissões como linhas (`permissions`) → ligadas a Roles (`role_permissions`) → atribuídas ao usuário **por empresa** (`memberships`).
+> **Autor:** Yuri · **Criado em:** 2026-04-20
+
+---
+
+## Sumário
+
+1. [Visão Geral Arquitetural](#1-visão-geral-arquitetural)
+2. [Modelo de Dados](#2-modelo-de-dados)
+3. [Estratégia Multi-tenant e Isolamento via RLS](#3-estratégia-multi-tenant-e-isolamento-via-rls)
+4. [Hierarquia de Permissões (RBAC)](#4-hierarquia-de-permissões-rbac)
+5. [Fluxos de Provisionamento](#5-fluxos-de-provisionamento)
+6. [Validação de Permissões no Backend](#6-validação-de-permissões-no-backend)
+7. [Auditoria de Acessos](#7-auditoria-de-acessos)
+8. [Exemplo Prático: Estoque e Movimentações](#8-exemplo-prático-estoque-e-movimentações)
+9. [Adicionando um Novo Módulo (Financeiro)](#9-adicionando-um-novo-módulo-financeiro)
+10. [Convenções, Padrões de Mercado e Checklist](#10-convenções-padrões-de-mercado-e-checklist)
+
+---
+
+## 1. Visão Geral Arquitetural
+
+### 1.1 Conceitos centrais
+
+| Conceito             | Definição                                                                                                    |
+| :------------------- | :----------------------------------------------------------------------------------------------------------- |
+| **Global Admin**     | Usuário do time interno (operador do SaaS) com `is_platform_admin = true`. Cria empresas e habilita módulos. |
+| **Company (Tenant)** | Organização cliente. Unidade de isolamento de dados.                                                         |
+| **User**             | Identidade única (auth.users do Supabase). Pode pertencer a várias empresas.                                 |
+| **Module**           | Funcionalidade plugável do ERP (ex: `inventory`, `movements`, `finance`). Registro declarativo.              |
+| **Permission**       | Ação atômica de um módulo (ex: `inventory:product:create`).                                                  |
+| **Role**             | Agrupamento de permissões **escopo da empresa** (ex: "Gerente de Estoque").                                  |
+| **Membership**       | Vínculo `User × Company` com uma ou mais `Roles`. É a tabela-chave do RBAC.                                  |
+| **Company Module**   | Empresa X tem o módulo Y habilitado (provisionamento).                                                       |
+
+### 1.2 Diagrama (alto nível)
+
+```
+           ┌────────────────┐
+           │ Global Admin   │
+           └────────┬───────┘
+                    │ cria
+                    ▼
+┌─────────────────────────────────────────┐
+│              Company (Tenant)           │
+│  id · name · slug · is_active · plan    │
+└──┬──────────────────────────────┬───────┘
+   │ habilita                     │ possui
+   ▼                              ▼
+┌─────────────────┐         ┌───────────────────┐
+│ company_modules │         │ roles (por cia)   │──┐
+│ company_id +    │         │ id · name ·       │  │ possui
+│ module_code     │         │ company_id        │  │
+└────────┬────────┘         └─────────┬─────────┘  │
+         │ referencia                 │ tem        ▼
+         ▼                            ▼     ┌──────────────────┐
+┌─────────────────┐              ┌───────────────────────┐  permissions
+│ modules (cat.)  │              │ role_permissions      │  id·code·module
+│ code · name ·   │              │ role_id·permission_id │
+│ is_system       │              └───────────────────────┘
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ permissions     │
+│ code(PK) module │
+└─────────────────┘
+
+┌─────────────────┐      ┌──────────────────────────────┐
+│ auth.users      │◄─────│ memberships                  │──► roles
+│ (Supabase Auth) │      │ user_id · company_id · role_ │
+└─────────────────┘      │  id · status · is_owner      │
+                         └──────────────────────────────┘
+```
+
+### 1.3 Princípios
+
+- **Tenant-first:** toda linha de dado de cliente carrega `company_id NOT NULL`.
+- **RLS é a lei:** isolamento entre tenants é responsabilidade do Postgres, nunca do código TS.
+- **RBAC declarativo:** módulos e permissões são **seed** (dados), não código hardcoded.
+- **Extensibilidade > performance inicial:** prefira normalização; indexe depois.
+- **UUID v4** em todas as PKs (`gen_random_uuid()`) — evita colisão entre tenants e facilita import/export.
+- **Auditoria imutável:** tabela `audit_logs` append-only.
+
+---
+
+## 2. Modelo de Dados
+
+### 2.1 DDL completo
+
+```sql
+-- ============================================================
+-- EXTENSÕES
+-- ============================================================
+create extension if not exists "pgcrypto";
+create extension if not exists "uuid-ossp";
+
+-- ============================================================
+-- 1. COMPANIES (Tenants)
+-- ============================================================
+create table public.companies (
+  id           uuid primary key default gen_random_uuid(),
+  name         text not null,
+  slug         text not null unique,
+  document     text,                               -- CNPJ
+  plan         text not null default 'starter',    -- starter|pro|enterprise
+  is_active    boolean not null default true,
+  created_by   uuid references auth.users(id),
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+create index idx_companies_slug on public.companies(slug);
+
+-- ============================================================
+-- 2. PLATFORM ADMINS (flag global — time interno do SaaS)
+-- ============================================================
+create table public.platform_admins (
+  user_id    uuid primary key references auth.users(id) on delete cascade,
+  granted_by uuid references auth.users(id),
+  granted_at timestamptz not null default now()
+);
+
+-- ============================================================
+-- 3. MODULES (catálogo declarativo)
+-- ============================================================
+create table public.modules (
+  code         text primary key,        -- 'inventory', 'movements', 'finance'
+  name         text not null,           -- 'Estoque'
+  description  text,
+  icon         text,                    -- lucide icon name
+  is_system    boolean not null default false,   -- módulos obrigatórios
+  is_active    boolean not null default true,
+  sort_order   int not null default 100,
+  created_at   timestamptz not null default now()
+);
+
+-- ============================================================
+-- 4. PERMISSIONS (catálogo global de permissões atômicas)
+-- ============================================================
+create table public.permissions (
+  code         text primary key,        -- 'inventory:product:create'
+  module_code  text not null references public.modules(code) on delete cascade,
+  resource     text not null,           -- 'product', 'movement'
+  action       text not null,           -- 'create', 'read', 'update', 'delete'
+  description  text,
+  created_at   timestamptz not null default now()
+);
+create index idx_permissions_module on public.permissions(module_code);
+
+-- ============================================================
+-- 5. COMPANY_MODULES (provisionamento)
+-- ============================================================
+create table public.company_modules (
+  company_id   uuid not null references public.companies(id) on delete cascade,
+  module_code  text not null references public.modules(code) on delete restrict,
+  enabled_at   timestamptz not null default now(),
+  enabled_by   uuid references auth.users(id),
+  primary key (company_id, module_code)
+);
+
+-- ============================================================
+-- 6. ROLES (por empresa)
+-- ============================================================
+create table public.roles (
+  id           uuid primary key default gen_random_uuid(),
+  company_id   uuid not null references public.companies(id) on delete cascade,
+  code         text not null,                          -- 'manager', 'operator'
+  name         text not null,                          -- 'Gerente de Estoque'
+  description  text,
+  is_system    boolean not null default false,         -- role semente não editável
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now(),
+  unique (company_id, code)
+);
+create index idx_roles_company on public.roles(company_id);
+
+-- ============================================================
+-- 7. ROLE_PERMISSIONS
+-- ============================================================
+create table public.role_permissions (
+  role_id          uuid not null references public.roles(id) on delete cascade,
+  permission_code  text not null references public.permissions(code) on delete cascade,
+  granted_at       timestamptz not null default now(),
+  primary key (role_id, permission_code)
+);
+
+-- ============================================================
+-- 8. MEMBERSHIPS (User × Company × Roles)
+-- ============================================================
+create type public.membership_status as enum ('invited', 'active', 'suspended');
+
+create table public.memberships (
+  id            uuid primary key default gen_random_uuid(),
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  company_id    uuid not null references public.companies(id) on delete cascade,
+  is_owner      boolean not null default false,
+  status        public.membership_status not null default 'active',
+  invited_by    uuid references auth.users(id),
+  invited_at    timestamptz,
+  joined_at     timestamptz default now(),
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  unique (user_id, company_id)
+);
+create index idx_memberships_user    on public.memberships(user_id);
+create index idx_memberships_company on public.memberships(company_id);
+
+-- ============================================================
+-- 9. MEMBERSHIP_ROLES (N↔M: um membro pode ter várias roles na mesma cia)
+-- ============================================================
+create table public.membership_roles (
+  membership_id  uuid not null references public.memberships(id) on delete cascade,
+  role_id        uuid not null references public.roles(id) on delete cascade,
+  assigned_by    uuid references auth.users(id),
+  assigned_at    timestamptz not null default now(),
+  primary key (membership_id, role_id)
+);
+
+-- ============================================================
+-- 10. AUDIT_LOGS (append-only)
+-- ============================================================
+create table public.audit_logs (
+  id             uuid primary key default gen_random_uuid(),
+  company_id     uuid references public.companies(id) on delete set null,
+  actor_user_id  uuid references auth.users(id),
+  actor_email    text,
+  action         text not null,                 -- 'product.create', 'membership.grant'
+  resource_type  text,
+  resource_id    text,
+  permission     text,                          -- 'inventory:product:create'
+  status         text not null default 'success', -- success|denied|error
+  ip             inet,
+  user_agent     text,
+  metadata       jsonb not null default '{}'::jsonb,
+  created_at     timestamptz not null default now()
+);
+create index idx_audit_logs_company on public.audit_logs(company_id, created_at desc);
+create index idx_audit_logs_actor   on public.audit_logs(actor_user_id, created_at desc);
+
+-- audit_logs: ninguém pode UPDATE/DELETE
+revoke update, delete on public.audit_logs from public, authenticated;
+```
+
+### 2.2 Resumo das tabelas
+
+| Tabela             | PK                 | Papel                     | Escopo |
+| :----------------- | :----------------- | :------------------------ | :----- |
+| `companies`        | uuid               | Tenant raiz               | global |
+| `platform_admins`  | user_id            | Flag de admin do SaaS     | global |
+| `modules`          | code (text)        | Catálogo de módulos       | global |
+| `permissions`      | code (text)        | Catálogo de permissões    | global |
+| `company_modules`  | (company, module)  | Provisionamento           | tenant |
+| `roles`            | uuid               | Função escopada à empresa | tenant |
+| `role_permissions` | (role, perm)       | O que a role pode fazer   | tenant |
+| `memberships`      | uuid               | Vínculo User↔Company      | tenant |
+| `membership_roles` | (membership, role) | Roles do membro na cia    | tenant |
+| `audit_logs`       | uuid               | Trilha imutável           | tenant |
+
+> **Por que `permissions.code` é text e não uuid?** O código é o identificador semântico usado no backend (`hasPermission('inventory:product:create')`). Um UUID adicionaria indireção sem ganho. Em contrapartida, `roles` e `memberships` usam UUID porque são registros editáveis com ciclo de vida.
+
+---
+
+## 3. Estratégia Multi-tenant e Isolamento via RLS
+
+### 3.1 Helpers de contexto
+
+```sql
+-- Retorna todas as empresas em que o usuário logado tem membership ativo
+create or replace function public.user_company_ids()
+returns setof uuid
+language sql stable security definer set search_path = public as $$
+  select company_id from public.memberships
+  where user_id = auth.uid() and status = 'active'
+$$;
+
+-- Confirma se o usuário é admin global
+create or replace function public.is_platform_admin()
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists(select 1 from public.platform_admins where user_id = auth.uid())
+$$;
+
+-- Confirma se o usuário tem uma permissão específica numa empresa
+create or replace function public.has_permission(p_company uuid, p_permission text)
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1
+    from public.memberships m
+    join public.membership_roles mr on mr.membership_id = m.id
+    join public.role_permissions rp on rp.role_id = mr.role_id
+    where m.user_id = auth.uid()
+      and m.company_id = p_company
+      and m.status = 'active'
+      and rp.permission_code = p_permission
+  )
+$$;
+```
+
+### 3.2 Policies RLS (padrão a replicar em toda tabela de tenant)
+
+```sql
+alter table public.companies        enable row level security;
+alter table public.memberships      enable row level security;
+alter table public.roles            enable row level security;
+alter table public.role_permissions enable row level security;
+alter table public.company_modules  enable row level security;
+alter table public.audit_logs       enable row level security;
+
+-- COMPANIES: membro lê sua empresa; platform admin lê todas
+create policy "companies_select" on public.companies
+  for select using (
+    public.is_platform_admin()
+    or id in (select public.user_company_ids())
+  );
+
+create policy "companies_insert_platform" on public.companies
+  for insert with check (public.is_platform_admin());
+
+create policy "companies_update_platform_or_owner" on public.companies
+  for update using (
+    public.is_platform_admin()
+    or exists (
+      select 1 from public.memberships
+      where user_id = auth.uid() and company_id = companies.id and is_owner
+    )
+  );
+
+-- MEMBERSHIPS: usuário vê suas memberships e as da mesma empresa
+create policy "memberships_select" on public.memberships
+  for select using (
+    public.is_platform_admin()
+    or user_id = auth.uid()
+    or company_id in (select public.user_company_ids())
+  );
+
+create policy "memberships_insert" on public.memberships
+  for insert with check (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'core:member:invite')
+  );
+
+create policy "memberships_update" on public.memberships
+  for update using (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'core:member:manage')
+  );
+
+-- ROLES e ROLE_PERMISSIONS: leitura para membros da cia; escrita exige permissão
+create policy "roles_select" on public.roles
+  for select using (company_id in (select public.user_company_ids()));
+
+create policy "roles_write" on public.roles
+  for all using (public.has_permission(company_id, 'core:role:manage'))
+  with check (public.has_permission(company_id, 'core:role:manage'));
+
+create policy "role_permissions_select" on public.role_permissions
+  for select using (
+    role_id in (select id from public.roles where company_id in (select public.user_company_ids()))
+  );
+
+create policy "role_permissions_write" on public.role_permissions
+  for all using (
+    exists (
+      select 1 from public.roles r
+      where r.id = role_permissions.role_id
+        and public.has_permission(r.company_id, 'core:role:manage')
+    )
+  );
+
+-- COMPANY_MODULES: leitura para membros; provisionamento só platform admin
+create policy "company_modules_select" on public.company_modules
+  for select using (company_id in (select public.user_company_ids()));
+
+create policy "company_modules_write_platform" on public.company_modules
+  for all using (public.is_platform_admin())
+  with check (public.is_platform_admin());
+
+-- AUDIT_LOGS: leitura pelo admin global ou por quem tem permissão na cia; INSERT livre (pelo código)
+create policy "audit_logs_select" on public.audit_logs
+  for select using (
+    public.is_platform_admin()
+    or (company_id is not null and public.has_permission(company_id, 'core:audit:read'))
+  );
+create policy "audit_logs_insert" on public.audit_logs
+  for insert with check (true);   -- inserção controlada pelo server (service role)
+```
+
+### 3.3 Padrão para tabelas de domínio (ex.: `products`)
+
+```sql
+alter table public.products enable row level security;
+
+create policy "products_select" on public.products
+  for select using (company_id in (select public.user_company_ids()));
+
+create policy "products_insert" on public.products
+  for insert with check (public.has_permission(company_id, 'inventory:product:create'));
+
+create policy "products_update" on public.products
+  for update using (public.has_permission(company_id, 'inventory:product:update'));
+
+create policy "products_delete" on public.products
+  for delete using (public.has_permission(company_id, 'inventory:product:delete'));
+```
+
+> Repita o mesmo _template_ para qualquer tabela nova. **Toda tabela de tenant precisa de `company_id NOT NULL` + RLS** — vire lei do projeto e valide no CI com um script `check-rls.sql`.
+
+---
+
+## 4. Hierarquia de Permissões (RBAC)
+
+### 4.1 Nomenclatura canônica
+
+```
+<module>:<resource>:<action>
+```
+
+- `module`: código em `modules` (ex: `inventory`, `finance`, `core`)
+- `resource`: objeto manipulado (ex: `product`, `movement`, `invoice`)
+- `action`: verbo — `read`, `create`, `update`, `delete`, `approve`, `export`
+
+**Regra:** toda permissão é _deny-by-default_. O usuário só pode o que está explicitamente em `role_permissions`.
+
+### 4.2 Seed de permissões centrais (`core`) e de `inventory` / `movements`
+
+```sql
+insert into public.modules (code, name, is_system, sort_order) values
+  ('core',       'Núcleo',        true,  0),
+  ('inventory',  'Estoque',       false, 10),
+  ('movements',  'Movimentações', false, 20);
+
+insert into public.permissions (code, module_code, resource, action, description) values
+  -- core (gestão da empresa)
+  ('core:member:invite',     'core', 'member', 'invite',  'Convidar membro'),
+  ('core:member:manage',     'core', 'member', 'manage',  'Gerenciar membros'),
+  ('core:role:manage',       'core', 'role',   'manage',  'Gerenciar roles e permissões'),
+  ('core:audit:read',        'core', 'audit',  'read',    'Ler logs de auditoria'),
+  ('core:company:update',    'core', 'company','update',  'Atualizar dados da empresa'),
+
+  -- inventory
+  ('inventory:product:read',   'inventory', 'product', 'read',   'Listar produtos'),
+  ('inventory:product:create', 'inventory', 'product', 'create', 'Criar produto'),
+  ('inventory:product:update', 'inventory', 'product', 'update', 'Editar produto'),
+  ('inventory:product:delete', 'inventory', 'product', 'delete', 'Excluir produto'),
+  ('inventory:product:export', 'inventory', 'product', 'export', 'Exportar catálogo'),
+
+  -- movements
+  ('movements:movement:read',   'movements', 'movement', 'read',   'Listar movimentações'),
+  ('movements:movement:create', 'movements', 'movement', 'create', 'Registrar movimentação'),
+  ('movements:movement:cancel', 'movements', 'movement', 'cancel', 'Cancelar movimentação');
+```
+
+### 4.3 Roles-padrão criadas no provisionamento
+
+Quando uma empresa é criada, o sistema cria automaticamente três roles (com `is_system = true`, não editáveis):
+
+| Role     | Código     | Descrição                                                 |
+| :------- | :--------- | :-------------------------------------------------------- |
+| Owner    | `owner`    | Todas as permissões dos módulos habilitados + `core:*`.   |
+| Manager  | `manager`  | CRUD em recursos do módulo habilitado, sem `role:manage`. |
+| Operator | `operator` | `read` + `create` nos recursos; sem `update`/`delete`.    |
+
+Veja a função `public.bootstrap_company_rbac()` em [§5.2](#52-função-de-bootstrap).
+
+### 4.4 Relação `membership × roles`
+
+Um membro pode acumular várias roles. A permissão efetiva é a **união**:
+
+```sql
+select distinct rp.permission_code
+from public.memberships m
+join public.membership_roles mr on mr.membership_id = m.id
+join public.role_permissions rp on rp.role_id       = mr.role_id
+where m.user_id = :user_id and m.company_id = :company_id and m.status = 'active';
+```
+
+---
+
+## 5. Fluxos de Provisionamento
+
+### 5.1 Criar uma empresa (Global Admin)
+
+1. Admin acessa painel `/admin/companies/new` (rota gated por `is_platform_admin()`).
+2. Preenche `name`, `slug`, `plan`, marca módulos a provisionar e informa email do **Owner inicial**.
+3. Server Action `createCompanyAction` executa em transação:
+   - insere em `companies`
+   - insere em `company_modules` (um registro por módulo marcado)
+   - chama `bootstrap_company_rbac(company_id)` — cria roles-padrão + seed de `role_permissions`
+   - cria/convida o usuário owner (`auth.admin.inviteUserByEmail`) e grava `memberships` + `membership_roles`
+   - grava em `audit_logs`: `company.create`
+
+### 5.2 Função de bootstrap
+
+```sql
+create or replace function public.bootstrap_company_rbac(p_company uuid)
+returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  v_owner_role uuid;
+  v_manager_role uuid;
+  v_operator_role uuid;
+  v_module text;
+begin
+  insert into public.roles (company_id, code, name, is_system)
+    values (p_company, 'owner',    'Owner',    true) returning id into v_owner_role;
+  insert into public.roles (company_id, code, name, is_system)
+    values (p_company, 'manager',  'Gerente',  true) returning id into v_manager_role;
+  insert into public.roles (company_id, code, name, is_system)
+    values (p_company, 'operator', 'Operador', true) returning id into v_operator_role;
+
+  -- Owner: TUDO dos módulos habilitados + core
+  insert into public.role_permissions (role_id, permission_code)
+  select v_owner_role, p.code
+  from public.permissions p
+  where p.module_code = 'core'
+     or p.module_code in (select module_code from public.company_modules where company_id = p_company);
+
+  -- Manager: CRUD dos módulos habilitados (sem core:role:manage)
+  insert into public.role_permissions (role_id, permission_code)
+  select v_manager_role, p.code
+  from public.permissions p
+  where p.module_code in (select module_code from public.company_modules where company_id = p_company)
+     or p.code in ('core:audit:read', 'core:member:invite');
+
+  -- Operator: somente read + create
+  insert into public.role_permissions (role_id, permission_code)
+  select v_operator_role, p.code
+  from public.permissions p
+  where p.action in ('read', 'create')
+    and p.module_code in (select module_code from public.company_modules where company_id = p_company);
+end $$;
+```
+
+### 5.3 Convidar membro para uma empresa
+
+Requer `core:member:invite` na empresa alvo.
+
+```ts
+// src/modules/tenancy/actions/invite-member.ts
+"use server";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { requirePermission } from "@/modules/authz";
+import { audit } from "@/modules/audit";
+
+const schema = z.object({
+  companyId: z.string().uuid(),
+  email: z.string().email(),
+  roleIds: z.array(z.string().uuid()).min(1),
+});
+
+export async function inviteMemberAction(raw: FormData) {
+  const input = schema.parse(Object.fromEntries(raw));
+  await requirePermission(input.companyId, "core:member:invite");
+
+  const supabase = createClient();
+  // 1. Cria/convida o usuário (service role é necessário para convite administrativo)
+  const { data: invite, error: invErr } = await supabase.auth.admin.inviteUserByEmail(input.email, {
+    redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/accept-invite?c=${input.companyId}`,
+  });
+  if (invErr) throw invErr;
+  const userId = invite.user.id;
+
+  // 2. Cria membership + atribui roles em transação
+  const { data: mem, error: memErr } = await supabase
+    .from("memberships")
+    .insert({ user_id: userId, company_id: input.companyId, status: "invited" })
+    .select("id")
+    .single();
+  if (memErr) throw memErr;
+
+  const rows = input.roleIds.map((role_id) => ({ membership_id: mem.id, role_id }));
+  const { error: mrErr } = await supabase.from("membership_roles").insert(rows);
+  if (mrErr) throw mrErr;
+
+  await audit({
+    companyId: input.companyId,
+    action: "member.invite",
+    resourceType: "user",
+    resourceId: userId,
+    metadata: { email: input.email, roleIds: input.roleIds },
+  });
+}
+```
+
+---
+
+## 6. Validação de Permissões no Backend
+
+### 6.1 Camadas de defesa (defense in depth)
+
+1. **Next.js middleware** (`src/middleware.ts`): valida sessão e redireciona anônimos.
+2. **Layout server component** (`app/(dashboard)/[companySlug]/layout.tsx`): resolve `companyId` do slug e checa que o usuário é membro.
+3. **Guard de módulo**: cada rota `/[companySlug]/inventory/*` valida `company_modules` + permissão de leitura mínima.
+4. **Server Action guard**: `requirePermission(companyId, code)` antes de qualquer mutação.
+5. **RLS no Postgres**: última linha de defesa — se o código TS falhar, o banco não executa.
+
+### 6.2 Sessão de tenant ativo
+
+Armazene o `companyId` ativo em cookie _httpOnly_ (chave: `erp.active_company`). A troca ocorre via Server Action `switchCompanyAction`. Nunca confie no cookie para autorização — apenas para UX; a autorização se baseia em `memberships`.
+
+### 6.3 Serviço `authz`
+
+```ts
+// src/modules/authz/services/authz-service.ts
+import "server-only";
+import { createClient } from "@/lib/supabase/server";
+
+export class ForbiddenError extends Error {
+  constructor(public permission: string) {
+    super(`forbidden:${permission}`);
+  }
+}
+
+/** Retorna o Set de permissões efetivas do usuário logado numa empresa. */
+export async function getEffectivePermissions(companyId: string): Promise<Set<string>> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("memberships")
+    .select(
+      `
+      id,
+      membership_roles (
+        role:roles (
+          role_permissions ( permission_code )
+        )
+      )
+    `,
+    )
+    .eq("company_id", companyId)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return new Set();
+
+  const perms = new Set<string>();
+  for (const mr of data.membership_roles ?? []) {
+    for (const rp of mr.role?.role_permissions ?? []) {
+      perms.add(rp.permission_code);
+    }
+  }
+  return perms;
+}
+
+export async function hasPermission(companyId: string, code: string): Promise<boolean> {
+  const perms = await getEffectivePermissions(companyId);
+  return perms.has(code);
+}
+
+export async function requirePermission(companyId: string, code: string): Promise<void> {
+  if (!(await hasPermission(companyId, code))) throw new ForbiddenError(code);
+}
+```
+
+### 6.4 Higher-order guard para Server Actions
+
+```ts
+// src/modules/authz/services/with-permission.ts
+import "server-only";
+import { requirePermission } from "./authz-service";
+import { audit } from "@/modules/audit";
+
+type ActionCtx = { companyId: string; userId: string };
+
+export function withPermission<T>(
+  permission: string,
+  action: string,
+  handler: (ctx: ActionCtx, formData: FormData) => Promise<T>,
+) {
+  return async function guarded(ctx: ActionCtx, formData: FormData) {
+    try {
+      await requirePermission(ctx.companyId, permission);
+      const result = await handler(ctx, formData);
+      await audit({ companyId: ctx.companyId, action, permission, status: "success" });
+      return result;
+    } catch (e) {
+      await audit({
+        companyId: ctx.companyId,
+        action,
+        permission,
+        status: e instanceof Error && e.message.startsWith("forbidden:") ? "denied" : "error",
+        metadata: { error: (e as Error).message },
+      });
+      throw e;
+    }
+  };
+}
+```
+
+Uso:
+
+```ts
+export const createProductAction = withPermission(
+  "inventory:product:create",
+  "product.create",
+  async (ctx, formData) => {
+    /* ... */
+  },
+);
+```
+
+### 6.5 Helpers de UI
+
+```tsx
+// src/modules/authz/components/can.tsx  (client)
+"use client";
+import type { ReactNode } from "react";
+import { usePermissions } from "../hooks/use-permissions";
+
+export function Can({
+  permission,
+  children,
+  fallback = null,
+}: {
+  permission: string;
+  children: ReactNode;
+  fallback?: ReactNode;
+}) {
+  const { has } = usePermissions();
+  return has(permission) ? <>{children}</> : <>{fallback}</>;
+}
+```
+
+```tsx
+<Can permission="inventory:product:create">
+  <Button>+ Novo produto</Button>
+</Can>
+```
+
+> A UI esconde o botão; o **backend é quem realmente nega**. Nunca confie só no front.
+
+---
+
+## 7. Auditoria de Acessos
+
+### 7.1 O que registrar
+
+| Evento                                          | Nível       |
+| :---------------------------------------------- | :---------- |
+| Autenticação (login, logout, reset)             | obrigatório |
+| CRUD em recursos sensíveis                      | obrigatório |
+| Acesso negado (permission denied)               | obrigatório |
+| Provisionamento (company.create, module.enable) | obrigatório |
+| Exportação/download em massa                    | recomendado |
+| Read de relatórios financeiros                  | recomendado |
+
+### 7.2 Serviço `audit`
+
+```ts
+// src/modules/audit/services/audit-service.ts
+import "server-only";
+import { headers } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+
+type AuditEntry = {
+  companyId?: string | null;
+  action: string;
+  resourceType?: string;
+  resourceId?: string;
+  permission?: string;
+  status?: "success" | "denied" | "error";
+  metadata?: Record<string, unknown>;
+};
+
+export async function audit(e: AuditEntry): Promise<void> {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const h = headers();
+
+  await supabase.from("audit_logs").insert({
+    company_id: e.companyId ?? null,
+    actor_user_id: user?.id ?? null,
+    actor_email: user?.email ?? null,
+    action: e.action,
+    resource_type: e.resourceType ?? null,
+    resource_id: e.resourceId ?? null,
+    permission: e.permission ?? null,
+    status: e.status ?? "success",
+    ip: (h.get("x-forwarded-for")?.split(",")[0] ?? "").trim() || null,
+    user_agent: h.get("user-agent"),
+    metadata: e.metadata ?? {},
+  });
+}
+```
+
+### 7.3 Garantias de integridade
+
+- Remova `UPDATE` e `DELETE` da tabela para todos os roles (já feito no DDL).
+- Exportação periódica para storage WORM (S3 Object Lock, GCS Bucket Lock) — fora do escopo do MVP, mas planeje.
+- Particionamento por mês quando `count > 10M` (`pg_partman`).
+
+---
+
+## 8. Exemplo Prático: Estoque e Movimentações
+
+### 8.1 Migrations dos domínios (com `company_id`)
+
+```sql
+-- PRODUCTS (já existentes + tenant_id)
+alter table public.products add column company_id uuid not null references public.companies(id);
+create index idx_products_company on public.products(company_id);
+
+-- Unicidade do SKU por empresa (não globalmente)
+drop index if exists products_sku_key;
+alter table public.products drop constraint if exists products_sku_key;
+alter table public.products add constraint products_sku_per_company unique (company_id, sku);
+
+-- STOCK_MOVEMENTS
+alter table public.stock_movements add column company_id uuid not null references public.companies(id);
+create index idx_movements_company on public.stock_movements(company_id);
+```
+
+### 8.2 Policies RLS dos domínios
+
+```sql
+-- products
+alter table public.products enable row level security;
+
+create policy "products_select" on public.products
+  for select using (company_id in (select public.user_company_ids()));
+
+create policy "products_insert" on public.products
+  for insert with check (public.has_permission(company_id, 'inventory:product:create'));
+
+create policy "products_update" on public.products
+  for update using (public.has_permission(company_id, 'inventory:product:update'))
+  with check (public.has_permission(company_id, 'inventory:product:update'));
+
+create policy "products_delete" on public.products
+  for delete using (public.has_permission(company_id, 'inventory:product:delete'));
+
+-- stock_movements
+alter table public.stock_movements enable row level security;
+
+create policy "movements_select" on public.stock_movements
+  for select using (company_id in (select public.user_company_ids()));
+
+create policy "movements_insert" on public.stock_movements
+  for insert with check (public.has_permission(company_id, 'movements:movement:create'));
+```
+
+### 8.3 Server Action com todas as camadas
+
+```ts
+// src/modules/inventory/actions/create-product.ts
+"use server";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+import { withPermission } from "@/modules/authz";
+import type { ActionResult } from "@/lib/errors";
+
+const schema = z.object({
+  sku: z.string().min(1),
+  name: z.string().min(2),
+  unit: z.enum(["UN", "KG", "L", "CX", "M"]),
+  costPrice: z.coerce.number().nonnegative(),
+  salePrice: z.coerce.number().nonnegative(),
+  minStock: z.coerce.number().nonnegative().default(0),
+});
+
+export const createProductAction = withPermission(
+  "inventory:product:create",
+  "product.create",
+  async ({ companyId, userId }, formData): Promise<ActionResult> => {
+    const parsed = schema.safeParse(Object.fromEntries(formData));
+    if (!parsed.success) {
+      return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
+    }
+    const supabase = createClient();
+    const { error } = await supabase.from("products").insert({
+      company_id: companyId, // 👈 tenant-scoped
+      sku: parsed.data.sku.toUpperCase(),
+      name: parsed.data.name,
+      unit: parsed.data.unit,
+      cost_price: parsed.data.costPrice,
+      sale_price: parsed.data.salePrice,
+      min_stock: parsed.data.minStock,
+      created_by: userId,
+    });
+    if (error) return { ok: false, message: error.message };
+
+    revalidatePath(`/${companyId}/inventory`);
+    return { ok: true, message: "Produto cadastrado" };
+  },
+);
+```
+
+### 8.4 Componente com UI condicional
+
+```tsx
+// src/app/(dashboard)/[companySlug]/inventory/page.tsx
+import { resolveCompany } from "@/modules/tenancy";
+import { listProducts } from "@/modules/inventory";
+import { Can } from "@/modules/authz";
+import { ProductTable } from "@/modules/inventory/components/product-table";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default async function InventoryPage({
+  params,
+  searchParams,
+}: {
+  params: { companySlug: string };
+  searchParams: Record<string, string>;
+}) {
+  const company = await resolveCompany(params.companySlug);
+  const products = await listProducts(company.id, searchParams);
+
+  return (
+    <section className="space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Estoque — {company.name}</h1>
+        <Can permission="inventory:product:create">
+          <Button asChild>
+            <Link href={`/${company.slug}/inventory/new`}>+ Novo produto</Link>
+          </Button>
+        </Can>
+      </header>
+      <ProductTable items={products.data} />
+    </section>
+  );
+}
+```
+
+### 8.5 Matriz de permissões (exemplo)
+
+| Permissão                   | Owner | Manager | Operator |
+| :-------------------------- | :---: | :-----: | :------: |
+| `inventory:product:read`    |  ✅   |   ✅    |    ✅    |
+| `inventory:product:create`  |  ✅   |   ✅    |    ✅    |
+| `inventory:product:update`  |  ✅   |   ✅    |    ❌    |
+| `inventory:product:delete`  |  ✅   |   ✅    |    ❌    |
+| `inventory:product:export`  |  ✅   |   ✅    |    ❌    |
+| `movements:movement:read`   |  ✅   |   ✅    |    ✅    |
+| `movements:movement:create` |  ✅   |   ✅    |    ✅    |
+| `movements:movement:cancel` |  ✅   |   ✅    |    ❌    |
+| `core:member:invite`        |  ✅   |   ✅    |    ❌    |
+| `core:role:manage`          |  ✅   |   ❌    |    ❌    |
+| `core:audit:read`           |  ✅   |   ✅    |    ❌    |
+
+---
+
+## 9. Adicionando um Novo Módulo (Financeiro)
+
+Cenário: meses após o MVP, queremos habilitar o módulo `finance` sem refatorar o core.
+
+### 9.1 Passo a passo
+
+**1. Migration do módulo + seed de permissões** (`supabase/migrations/xxxx_finance.sql`):
+
+```sql
+insert into public.modules (code, name, sort_order) values ('finance', 'Financeiro', 30);
+
+insert into public.permissions (code, module_code, resource, action, description) values
+  ('finance:invoice:read',    'finance', 'invoice', 'read',    'Ler faturas'),
+  ('finance:invoice:create',  'finance', 'invoice', 'create',  'Criar fatura'),
+  ('finance:invoice:approve', 'finance', 'invoice', 'approve', 'Aprovar fatura'),
+  ('finance:payable:read',    'finance', 'payable', 'read',    'Ler contas a pagar'),
+  ('finance:payable:create',  'finance', 'payable', 'create',  'Criar conta a pagar');
+
+create table public.invoices (
+  id          uuid primary key default gen_random_uuid(),
+  company_id  uuid not null references public.companies(id),
+  number      text not null,
+  amount      numeric(14,2) not null,
+  status      text not null default 'draft',
+  due_date    date,
+  created_by  uuid references auth.users(id),
+  created_at  timestamptz not null default now(),
+  unique (company_id, number)
+);
+create index idx_invoices_company on public.invoices(company_id);
+
+alter table public.invoices enable row level security;
+create policy "invoices_select" on public.invoices
+  for select using (company_id in (select public.user_company_ids()));
+create policy "invoices_insert" on public.invoices
+  for insert with check (public.has_permission(company_id, 'finance:invoice:create'));
+create policy "invoices_update" on public.invoices
+  for update using (public.has_permission(company_id, 'finance:invoice:create'));
+```
+
+**2. Código:** criar `src/modules/finance/{actions,queries,components,schemas,services,index.ts}` seguindo o mesmo _blueprint_.
+
+**3. Registro no menu:** adicionar item em `MODULES_MENU` com guard:
+
+```ts
+{ label: "Financeiro", href: "/finance", requiresModule: "finance", requiresPermission: "finance:invoice:read" }
+```
+
+**4. Ativar na empresa-piloto:** Global Admin marca `finance` em `company_modules`, e roda (uma vez) um SQL para distribuir as permissões nas roles-sistema já existentes:
+
+```sql
+-- Owner existente ganha todas; Manager ganha CRUD; Operator ganha read
+insert into public.role_permissions (role_id, permission_code)
+select r.id, p.code from public.roles r cross join public.permissions p
+where r.company_id = :company_id and r.code = 'owner' and p.module_code = 'finance'
+on conflict do nothing;
+-- ... análogo para manager / operator
+```
+
+> **Zero alteração no core.** Nenhum `switch/case` por módulo em lugar nenhum do código. A UI descobre módulos via query em `company_modules × modules`. Permissões são apenas dados.
+
+---
+
+## 10. Convenções, Padrões de Mercado e Checklist
+
+### 10.1 Padrões de mercado adotados
+
+- **UUID v4** em todas as PKs editáveis; identifiers semânticos (`text`) apenas em catálogos declarativos (`modules.code`, `permissions.code`).
+- **Naming snake_case** nas tabelas/colunas e **camelCase** nos DTOs TS.
+- **Soft delete** via `deleted_at timestamptz` em recursos sensíveis (opt-in por tabela); para catálogos (`modules`, `permissions`) usamos `is_active`.
+- **Timestamps** `created_at` / `updated_at` obrigatórios; trigger `set_updated_at` global.
+- **Idempotência** de mutações críticas via `Idempotency-Key` (cabeçalho em rotas de API públicas).
+- **Rate-limit** por empresa nas APIs públicas (middleware Vercel Edge + Upstash).
+- **Convenções de permissão**: sempre `modulo:recurso:acao` em minúsculas.
+- **RLS é regra**: nenhuma tabela de tenant sem `company_id` + policies.
+- **Auditoria imutável**: `audit_logs` append-only com revoke de UPDATE/DELETE.
+- **OAuth/SSO** (pós-MVP): SAML/OIDC por empresa via Supabase Auth ou WorkOS.
+- **Backups**: PITR do Supabase + export diário em bucket separado.
+
+### 10.2 Índices recomendados
+
+```sql
+-- Leituras frequentes por tenant
+create index if not exists idx_products_company_active on public.products(company_id) where is_active;
+create index if not exists idx_movements_company_date  on public.stock_movements(company_id, created_at desc);
+
+-- Joins de autorização
+create index if not exists idx_memberships_user_company_status
+  on public.memberships(user_id, company_id, status);
+```
+
+### 10.3 Testes obrigatórios
+
+- **Isolation:** usuário da empresa A **não** consegue `SELECT`/`INSERT` em dados da empresa B (testar direto via supabase-js).
+- **Permission deny:** operator **não** consegue `DELETE` produto (espera erro RLS + `ForbiddenError` na action).
+- **Cascade:** deletar `companies` remove `memberships`, `roles`, `role_permissions`, `company_modules`.
+- **Bootstrap:** criar empresa com módulos `inventory` + `movements` gera três roles com permissões corretas.
+- **Audit:** toda ação executada aparece em `audit_logs` com `status` correto.
+
+### 10.4 Checklist de implementação
+
+**Fundação**
+
+- [ ] Migrations 1–10 aplicadas
+- [ ] Helpers `user_company_ids`, `is_platform_admin`, `has_permission`
+- [ ] Seed de `modules` + `permissions` (core, inventory, movements)
+- [ ] Função `bootstrap_company_rbac` testada
+
+**Módulos (`src/modules`)**
+
+- [ ] `tenancy/`: CRUD de `companies`, switcher de empresa ativa, `resolveCompany(slug)`
+- [ ] `authz/`: `getEffectivePermissions`, `hasPermission`, `requirePermission`, `withPermission`, componente `<Can>`, hook `usePermissions`
+- [ ] `audit/`: serviço `audit()`, queries de listagem para admin
+
+**UI / Roteamento**
+
+- [ ] Rotas `/admin/companies/*` (restritas a platform admin)
+- [ ] Rotas `/[companySlug]/...` com layout resolvendo tenant ativo
+- [ ] Página de configurações da empresa com aba "Roles & Permissões" (drag & drop)
+
+**Domínios**
+
+- [ ] `products` e `stock_movements` com `company_id + NOT NULL` e RLS por permissão
+- [ ] Actions `createProduct` / `registerMovement` usando `withPermission`
+- [ ] `<Can>` em todos os botões de ação
+
+**Qualidade**
+
+- [ ] Teste de isolamento entre tenants (automatizado no CI)
+- [ ] Script `check-rls.sql` falha o CI se alguma tabela de domínio não tiver RLS habilitado
+- [ ] Logs de auditoria ativados em 100% das mutações
+- [ ] Documentação por módulo no `index.ts` (JSDoc com permissões necessárias)
+
+---
+
+## 11. Roadmap de Integração com os Módulos Atuais (Auth + Inventory)
+
+> **Premissa:** o MVP descrito em [`PLAN.md`](./PLAN.md) já foi implementado em produção **single-tenant**. O objetivo desta seção é evoluir o sistema para multi-tenant + RBAC sem downtime e sem perder dados, organizando o trabalho em sprints de 1–2 semanas com PRs pequenos e revisáveis.
+
+### 11.1 Estratégia de migração
+
+- **Expand → Migrate → Contract:** adiciona estrutura nova ao lado da antiga, migra dados, só depois remove o legado.
+- **Feature flag `MULTITENANCY_ENABLED`** (env var) controla quando o `companyId` passa a ser obrigatório no código.
+- **Default Company:** todo dado existente é migrado para uma empresa única `default-company`, preservando o histórico.
+- **Nenhum `DROP` antes do sprint de _contract_**. Sempre `ALTER ... NULL → NOT NULL` depois do backfill.
+- **Cada sprint fecha com:** `db:push` + `db:types` + testes verdes + deploy preview na Vercel.
+
+### 11.2 Visão geral dos sprints
+
+| Sprint | Foco                                                              |  Duração  | Dependências |
+| :----: | :---------------------------------------------------------------- | :-------: | :----------- |
+| **S0** | Preparação e guard-rails                                          |  2 dias   | —            |
+| **S1** | Fundação multi-tenant (DB + helpers)                              | 1 semana  | S0           |
+| **S2** | Módulo `tenancy` + switcher de empresa                            | 1 semana  | S1           |
+| **S3** | Módulo `authz` + `audit`                                          | 1 semana  | S2           |
+| **S4** | Refactor do módulo `auth` (profiles → memberships)                | 1 semana  | S3           |
+| **S5** | Refactor do módulo `inventory` (company_id + RLS por permissão)   | 2 semanas | S3           |
+| **S6** | Painel `/admin` do Platform Admin                                 | 1 semana  | S2           |
+| **S7** | UI de gestão de membros & roles por empresa                       | 1 semana  | S5           |
+| **S8** | Sprint de _contract_ (remoção do legado)                          |  3 dias   | S4, S5       |
+| **S9** | Hardening: testes de isolamento, RLS guard no CI, observabilidade | 1 semana  | S8           |
+
+---
+
+### 11.3 Sprint 0 — Preparação
+
+**Objetivo:** criar guard-rails antes de mexer em qualquer esquema.
+
+**PRs**
+
+- **PR #01** — `chore(ci): baseline de rollback`
+  - Dump do schema atual em `supabase/snapshots/pre-multitenant.sql`.
+  - Tag git `pre-multitenant` para rollback rápido.
+- **PR #02** — `feat(config): flag MULTITENANCY_ENABLED`
+  - Adicionar a variável em `src/core/config/env.ts` (Zod, default `false`).
+  - Criar helper `src/core/config/flags.ts` → `isMultitenancyEnabled()`.
+- **PR #03** — `test(infra): script check-rls.sql no CI`
+  - Script SQL que lista tabelas do schema `public` sem `rowsecurity = true` ou sem policies. Falha CI se houver.
+
+**Critérios de aceite**
+
+- `npm run test:rls` passa localmente e no CI.
+- Flag disponível em todos os ambientes com valor explícito.
+
+---
+
+### 11.4 Sprint 1 — Fundação Multi-Tenant
+
+**Objetivo:** aplicar o modelo de dados de §2 sem tocar nas tabelas de domínio ainda.
+
+**PRs**
+
+- **PR #04** — `db: migration 01_tenancy_core.sql`
+  - Cria `companies`, `platform_admins`, `modules`, `permissions`, `company_modules`, `roles`, `role_permissions`, `memberships`, `membership_roles`, `audit_logs`.
+  - Todas com RLS **habilitado** mas sem policies ainda (lock by default).
+- **PR #05** — `db: migration 02_helpers_and_policies.sql`
+  - Funções `user_company_ids()`, `is_platform_admin()`, `has_permission(company, perm)`, `bootstrap_company_rbac(company)`.
+  - Policies RLS das tabelas da fundação (conforme §3.2).
+- **PR #06** — `db: seed 03_seed_core_permissions.sql`
+  - Seeds de `modules` (`core`, `inventory`, `movements`) e `permissions` (ver §4.2).
+- **PR #07** — `db: migration 04_default_company.sql`
+  - Cria empresa semente `default-company` (slug fixo) com todos os módulos habilitados.
+  - Chama `bootstrap_company_rbac()` para gerar roles `owner/manager/operator`.
+- **PR #08** — `chore(types): regen database.types.ts`
+  - `npm run db:types` e commit. Nenhum código TS consome ainda.
+
+**Critérios de aceite**
+
+- `npm run db:push` aplica limpo em ambiente vazio.
+- Admin interno consegue logar no Supabase Studio e ver as tabelas novas.
+- Tabelas da fundação têm RLS ativo (script `check-rls.sql` passa).
+
+---
+
+### 11.5 Sprint 2 — Módulo `tenancy` + switcher
+
+**Objetivo:** criar o módulo `src/modules/tenancy` e o conceito de **empresa ativa**, sem ainda exigir `companyId` nas actions existentes.
+
+**Arquivos criados**
+
+```
+src/modules/tenancy/
+├── actions/
+│   ├── create-company.ts          # platform admin
+│   ├── update-company.ts
+│   └── switch-active-company.ts   # seta cookie httpOnly
+├── queries/
+│   ├── list-my-companies.ts
+│   ├── resolve-company.ts         # por slug → Company
+│   └── list-all-companies.ts      # platform admin only
+├── schemas/index.ts
+├── services/
+│   ├── active-company.ts          # getActiveCompanyId() via cookie + fallback
+│   └── company-service.ts
+├── components/
+│   ├── company-switcher.tsx       # dropdown no header
+│   └── company-badge.tsx
+└── index.ts
+```
+
+**PRs**
+
+- **PR #09** — `feat(tenancy): módulo tenancy + cookie de empresa ativa`
+  - Cookie `erp.active_company` httpOnly, SameSite=Lax.
+  - `getActiveCompanyId()` lê cookie, valida membership, faz fallback para a primeira empresa ativa do usuário.
+- **PR #10** — `feat(tenancy): CompanySwitcher no header`
+  - Componente Shadcn `<DropdownMenu>` listando `list-my-companies`.
+  - Mostra badge da empresa ativa ao lado do nome do usuário.
+- **PR #11** — `feat(tenancy): rota /admin/companies/*` (gated por `is_platform_admin`)
+  - Listagem, criação e edição de empresas.
+  - Criação dispara `bootstrap_company_rbac` + envia convite ao Owner.
+
+**Critérios de aceite**
+
+- Usuário com 2+ memberships consegue alternar entre empresas e ver o cookie mudando.
+- Platform admin cria uma nova empresa e recebe a confirmação no audit log.
+
+---
+
+### 11.6 Sprint 3 — Módulos `authz` + `audit`
+
+**Objetivo:** construir os serviços horizontais que os domínios consumirão a partir do Sprint 4.
+
+**Arquivos criados**
+
+```
+src/modules/authz/
+├── services/
+│   ├── authz-service.ts     # getEffectivePermissions, hasPermission, requirePermission
+│   └── with-permission.ts   # HOC para Server Actions (§6.4)
+├── hooks/
+│   └── use-permissions.ts   # client — lê do RSC via context provider
+├── components/
+│   ├── can.tsx              # <Can permission="...">
+│   └── permissions-provider.tsx
+└── index.ts
+
+src/modules/audit/
+├── actions/
+│   └── (vazio por enquanto — consumidores chamam via service)
+├── queries/
+│   └── list-audit-logs.ts
+├── services/
+│   └── audit-service.ts     # audit({...})
+├── components/
+│   └── audit-log-table.tsx
+└── index.ts
+```
+
+**PRs**
+
+- **PR #12** — `feat(authz): authz-service + withPermission + Can`
+  - `requirePermission(companyId, code)` lança `ForbiddenError`.
+  - `<Can permission="inventory:product:create">` via `PermissionsProvider` injetado no layout do tenant.
+- **PR #13** — `feat(audit): audit-service + tabela + página /audit`
+  - `audit({...})` insere em `audit_logs`.
+  - Página `/[companySlug]/audit` lista logs (gated por `core:audit:read`).
+- **PR #14** — `test(authz): testes unitários do authz-service`
+  - Mocks do Supabase client; verifica união de permissões de múltiplas roles.
+
+**Critérios de aceite**
+
+- Owner vê todos os botões; Operator **não** vê botões de delete (via `<Can>`).
+- `requirePermission` bloqueia com `ForbiddenError` em tentativas diretas.
+- Audit log registra uma entrada `product.create` após criar um produto pelo MVP atual.
+
+---
+
+### 11.7 Sprint 4 — Refactor do módulo `auth`
+
+**Objetivo:** evoluir o `auth` atual para trabalhar com `memberships`, sem quebrar login existente.
+
+**Mudanças**
+
+- `profiles.role` (enum antigo) **deprecated** — continua lá mas não é mais lida. Nova verdade vem de `memberships + membership_roles`.
+- `getCurrentUser()` passa a retornar `{ user, memberships: CompanyMembership[] }`.
+- Login não muda; após autenticar, redireciona para `/[companySlug]` da empresa ativa.
+- Fluxo de cadastro novo → cria usuário → adiciona `membership` na `default-company` como `operator` (comportamento configurável via flag).
+
+**PRs**
+
+- **PR #15** — `refactor(auth): getCurrentUser retorna memberships`
+  - Atualiza consumidores (dashboard layout, middleware, menu).
+  - Mantém `profiles.role` intocado para rollback.
+- **PR #16** — `feat(auth): accept-invite flow`
+  - Rota `/accept-invite?c=<companyId>&token=...`.
+  - Troca `membership.status` de `invited` → `active`.
+  - Redireciona para `/[companySlug]`.
+- **PR #17** — `refactor(auth): onboarding cria membership default`
+  - Trigger `on_auth_user_created` passa a criar também membership em `default-company` enquanto flag `MULTITENANCY_ENABLED = false`.
+  - Quando flag ligar, comportamento muda para exigir convite.
+- **PR #18** — `chore(auth): mover logic de roles para authz`
+  - Remove `canWriteProducts`, `isAdmin` (legados) e substitui por `hasPermission`.
+
+**Critérios de aceite**
+
+- Login de usuários antigos continua funcionando e os carrega na `default-company`.
+- Novo fluxo de convite cria membership em estado `invited` que vira `active` no aceite.
+
+---
+
+### 11.8 Sprint 5 — Refactor do módulo `inventory`
+
+**Objetivo:** aplicar `company_id` + RLS por permissão em `products` e `stock_movements` **com backfill de dados** e **zero-downtime**.
+
+> Esse é o sprint mais crítico. Cada subfase é um PR separado.
+
+**Subfase A — Adicionar `company_id` NULLABLE + backfill**
+
+- **PR #19** — `db: migration 05_products_company_nullable.sql`
+  ```sql
+  alter table public.products add column company_id uuid references public.companies(id);
+  alter table public.stock_movements add column company_id uuid references public.companies(id);
+  create index on public.products(company_id);
+  create index on public.stock_movements(company_id);
+  ```
+- **PR #20** — `db: migration 06_backfill_default_company.sql`
+
+  ```sql
+  update public.products
+     set company_id = (select id from public.companies where slug = 'default-company')
+   where company_id is null;
+
+  update public.stock_movements
+     set company_id = (select id from public.companies where slug = 'default-company')
+   where company_id is null;
+  ```
+
+- **PR #21** — `chore(types): regen types` (após backfill).
+
+**Subfase B — Código passa a gravar `company_id`**
+
+- **PR #22** — `refactor(inventory): actions preenchem company_id`
+  - `createProduct`, `registerMovement` leem `getActiveCompanyId()` e inserem.
+  - `listProducts(companyId, ...)` passa a receber `companyId` explicitamente.
+  - Pages `/inventory/*` migradas para `/[companySlug]/inventory/*`.
+- **PR #23** — `refactor(inventory): SKU único por empresa`
+  ```sql
+  alter table public.products drop constraint products_sku_key;
+  alter table public.products add constraint products_sku_per_company unique (company_id, sku);
+  ```
+
+**Subfase C — Tornar `company_id` obrigatório**
+
+- **PR #24** — `db: migration 07_products_company_not_null.sql`
+  ```sql
+  alter table public.products alter column company_id set not null;
+  alter table public.stock_movements alter column company_id set not null;
+  ```
+
+**Subfase D — Ativar RLS por permissão**
+
+- **PR #25** — `db: migration 08_products_rls.sql` (policies de §8.2).
+- **PR #26** — `db: migration 09_movements_rls.sql`.
+- **PR #27** — `refactor(inventory): actions envolvidas em withPermission`
+  - `createProduct` → `withPermission("inventory:product:create", "product.create", ...)`.
+  - `updateProduct` → `inventory:product:update`.
+  - `deleteProduct` → `inventory:product:delete`.
+  - `registerMovement` → `movements:movement:create`.
+  - `cancelMovement` → `movements:movement:cancel`.
+- **PR #28** — `feat(inventory): UI usa <Can>`
+  - Esconde botões "+ Novo produto", "Editar", "Excluir", "Registrar movimento" quando usuário não tem permissão.
+  - Badge de "Apenas leitura" quando é Operator sem `create`.
+
+**Subfase E — Testes de isolamento**
+
+- **PR #29** — `test(inventory): isolation suite`
+  - Cria 2 empresas + 2 usuários (um em cada).
+  - Garante que `user_a` **não** vê produtos de `company_b`.
+  - Garante que `operator` **não** consegue `DELETE`.
+
+**Critérios de aceite**
+
+- `company_id` NOT NULL em ambas as tabelas.
+- RLS ativo, policies por permissão.
+- Operador **não** consegue excluir produto nem pela UI nem por chamada direta.
+- Testes de isolamento no CI.
+
+---
+
+### 11.9 Sprint 6 — Painel do Platform Admin
+
+**Objetivo:** UI para o time interno do SaaS gerenciar as empresas.
+
+**Rotas**
+
+```
+/admin
+├── /companies                 # lista todas (gated is_platform_admin)
+├── /companies/new             # wizard: dados → módulos → owner inicial
+├── /companies/[id]            # overview + métricas
+├── /companies/[id]/modules    # habilitar/desabilitar módulos
+├── /companies/[id]/members    # visão consolidada
+└── /audit                     # logs globais de plataforma
+```
+
+**PRs**
+
+- **PR #30** — `feat(admin): lista e criação de empresas` (wizard 3 passos).
+- **PR #31** — `feat(admin): toggle de módulos por empresa` (checkbox grid).
+- **PR #32** — `feat(admin): audit global + filtros por empresa/ação/ator`.
+
+**Critérios de aceite**
+
+- Admin cria empresa, marca módulos, recebe link de convite do Owner.
+- Toggle de módulo atualiza `company_modules` e redistribui permissões novas nas roles-sistema.
+
+---
+
+### 11.10 Sprint 7 — Gestão de membros e roles (por empresa)
+
+**Objetivo:** permitir que Owner/Manager de uma empresa gerenciem sua equipe.
+
+**Rotas**
+
+```
+/[companySlug]/settings/
+├── general                  # core:company:update
+├── members                  # core:member:manage
+│   ├── invite               # dialog
+│   └── [memberId]           # editar roles
+└── roles                    # core:role:manage
+    ├── new
+    └── [roleId]             # matriz de permissões (checkboxes por módulo)
+```
+
+**PRs**
+
+- **PR #33** — `feat(settings): listagem/convite/remoção de membros`.
+- **PR #34** — `feat(settings): CRUD de roles customizadas` (não editáveis: `owner`, `manager`, `operator` — `is_system=true`).
+- **PR #35** — `feat(settings): matriz de permissões` (agrupada por módulo habilitado, usa `company_modules`).
+
+**Critérios de aceite**
+
+- Manager convida um Operator por email; Operator aceita e acessa somente recursos permitidos.
+- Editar uma role reflete imediatamente nas permissões efetivas (usa `revalidatePath`).
+
+---
+
+### 11.11 Sprint 8 — Sprint de _Contract_ (remover legado)
+
+**Objetivo:** remover os restos do modelo single-tenant.
+
+**PRs**
+
+- **PR #36** — `refactor(auth): remover profiles.role e helpers legados`
+  - `ALTER TABLE profiles DROP COLUMN role;`
+  - Deletar `canWriteProducts`, `isAdmin` que ainda existirem.
+- **PR #37** — `chore(flags): remover MULTITENANCY_ENABLED`
+  - Código assume multi-tenant universalmente.
+  - Middleware passa a exigir `companySlug` na URL em todas as rotas de `(dashboard)`.
+- **PR #38** — `chore(routes): remover rotas legadas /inventory/*` (sem slug).
+  - Middleware redireciona para `/[defaultSlug]/inventory/*` por 30 dias, depois 410.
+
+**Critérios de aceite**
+
+- Sem referência a `profiles.role` no código ou SQL.
+- Flag removida do `env.ts`.
+- Cobertura de testes ≥ 80% nos módulos `tenancy`, `authz`, `inventory`.
+
+---
+
+### 11.12 Sprint 9 — Hardening
+
+**Objetivo:** deixar o sistema pronto para onboarding real de clientes.
+
+**PRs**
+
+- **PR #39** — `test(rls): suite de isolamento cross-tenant`
+  - Para cada tabela de domínio: cria 2 cias, insere em cada, tenta `SELECT` como user da outra — deve retornar 0 linhas.
+- **PR #40** — `chore(ci): check-rls.sql obrigatório no pipeline`
+  - Falha o CI se alguma tabela nova em `public` não tiver RLS.
+- **PR #41** — `feat(observability): headers `x-request-id` + correlação com audit_logs`
+  - Middleware injeta UUID por request e grava em `audit_logs.metadata.request_id`.
+- **PR #42** — `docs: playbook de onboarding de cliente`
+  - Passo-a-passo que o time usa para provisionar uma empresa nova.
+
+**Critérios de aceite**
+
+- Teste de isolamento roda em < 30s no CI.
+- Qualquer PR que adicione tabela sem RLS é **bloqueado**.
+- Time consegue provisionar uma empresa nova em < 5 min seguindo o playbook.
+
+---
+
+### 11.13 Mapa de impacto nos arquivos atuais
+
+| Arquivo atual                                        | Mudança                                                     |   Sprint    |
+| :--------------------------------------------------- | :---------------------------------------------------------- | :---------: |
+| `src/modules/auth/queries/get-current-user.ts`       | Retornar também `memberships`                               |     S4      |
+| `src/modules/auth/services/profile-service.ts`       | Remover `canWriteProducts`/`isAdmin`                        |    S4→S8    |
+| `src/modules/auth/actions/sign-up.ts`                | Criar `membership` na `default-company`                     |     S4      |
+| `src/middleware.ts`                                  | Parse do `companySlug` da URL                               |     S2      |
+| `src/app/(dashboard)/layout.tsx`                     | Mover para `/[companySlug]/` + `PermissionsProvider`        |     S3      |
+| `src/app/(dashboard)/inventory/**`                   | Mover para `src/app/(dashboard)/[companySlug]/inventory/**` |     S5      |
+| `src/modules/inventory/actions/create-product.ts`    | Wrapper `withPermission` + `company_id`                     |     S5      |
+| `src/modules/inventory/actions/register-movement.ts` | Wrapper `withPermission` + `company_id`                     |     S5      |
+| `src/modules/inventory/queries/list-products.ts`     | Receber `companyId` explicitamente                          |     S5      |
+| `src/modules/inventory/components/product-table.tsx` | `<Can>` nos botões                                          |     S5      |
+| `src/core/navigation/menu.ts`                        | Itens com `requiresModule` e `requiresPermission`           |     S2      |
+| `supabase/migrations/`                               | +10 migrations novas (numeradas a partir da atual)          |   S1, S5    |
+| `src/types/database.types.ts`                        | Regen após cada sprint de migration                         | S1/S4/S5/S8 |
+
+### 11.14 Ordem de execução compacta (checklist mestre)
+
+- [x] S0 · #01–#03 · guard-rails + flag — **mergeado (PR #1)**
+- [x] S1 · #04–#08 · fundação DB + seeds + default-company — **mergeado (PR #1)**
+- [x] S2 · #09–#11 · módulo `tenancy` + switcher + `/admin/companies` — **mergeado (PR #2)**
+- [x] S3 · #12–#14 · `authz` + `audit` + `<Can>` — **mergeado (PR #3)**
+- [x] S4 · #15–#18 · refactor `auth` (memberships) — **mergeado (PR #4)**
+- [x] S5 · #19–#29 · refactor `inventory` (company_id → RLS → withPermission → tests) — **PR #5 aberto, validado manualmente** · branch `feat/multitenant-s5`
+- [ ] S6 · #30–#32 · painel platform admin
+- [ ] S7 · #33–#35 · gestão de membros/roles por empresa
+- [ ] S8 · #36–#38 · _contract_ — remover legado
+- [ ] S9 · #39–#42 · hardening — RLS check, isolation tests, observabilidade
+
+> **Próximo:** S6 — painel platform admin (`/admin/companies` wizard + toggle módulos + audit global)
+
+### 11.15 Riscos e mitigações
+
+| Risco                                                                         | Mitigação                                                                                                                       |
+| :---------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| Backfill da `default-company` erra 1 produto → linha "órfã"                   | `company_id NOT NULL` só vem no PR #24; até lá, job de verificação `SELECT count(*) WHERE company_id IS NULL` bloqueia o merge. |
+| Policy RLS muito restritiva quebra telas antigas                              | Feature flag `MULTITENANCY_ENABLED` mantém policy permissiva para `default-company` até S8.                                     |
+| Usuário antigo sem `membership` após deploy do S4                             | Migration `04_default_company.sql` também faz `INSERT` de `memberships` para todo `auth.users` existente.                       |
+| Permissões das roles-sistema dessincronizadas quando novo módulo é habilitado | Trigger `on_company_modules_insert` chama rotina que re-seed das permissões nas roles `is_system=true`.                         |
+| Regressão na UI (botões sumindo indevidamente)                                | Teste e2e (Playwright) com 3 personas (Owner/Manager/Operator) fixas por ambiente.                                              |
+
+---
+
+## 12. Estratégia de Testes (obrigatória em toda feature)
+
+> **Política do projeto:** toda feature entra em produção com testes automatizados. Nenhum PR passa sem: (a) testes novos cobrindo o comportamento adicionado; (b) todos os testes da suíte verdes no CI; (c) gates de cobertura mínimos atingidos. Features sem testes são **bloqueadas no review**.
+
+### 12.1 Pirâmide de testes
+
+```
+                 ╱──────────────╲
+                ╱   E2E (lento)  ╲          5–10 cenários críticos (Playwright)
+               ╱──────────────────╲         login, convite, CRUD com permissão, isolamento
+              ╱                    ╲
+             ╱  Integration (médio) ╲       Server Actions + RLS contra Supabase local
+            ╱────────────────────────╲      ~40% dos testes; usa @supabase local
+           ╱                          ╲
+          ╱     Unit (rápido)          ╲    services/, schemas/, helpers/
+         ╱──────────────────────────────╲   ~50% dos testes; mocks leves (Vitest)
+```
+
+### 12.2 Ferramentas
+
+| Camada                     | Ferramenta                                                       | Quando usar                                                                 |
+| :------------------------- | :--------------------------------------------------------------- | :-------------------------------------------------------------------------- |
+| Unit                       | **Vitest**                                                       | Funções puras em `services/`, parsing de Zod, formatters, regras de RBAC.   |
+| Component                  | **@testing-library/react** + Vitest                              | Componentes `<Can>`, formulários, tabelas (render + interação).             |
+| Integration (SQL)          | **pgTAP** ou SQL assertions em `supabase/tests/`                 | Triggers (`apply_stock_movement`), helpers (`has_permission`), cascades.    |
+| Integration (Action + RLS) | Vitest + **@supabase/supabase-js** contra `supabase start` local | Server Actions de ponta a ponta, com usuários reais e RLS ativo.            |
+| E2E                        | **Playwright**                                                   | Fluxos completos no navegador: login → criar produto → registrar movimento. |
+| Contrato Zod               | **zod-to-jsonschema** + snapshot                                 | Garante que alterações em schemas sejam intencionais.                       |
+
+### 12.3 Convenções
+
+- Nomear arquivos: `*.test.ts` (unit/integration) e `*.e2e.ts` (Playwright).
+- Um arquivo de teste **por arquivo produzido** quando fizer sentido (ex: `stock-service.ts` → `stock-service.test.ts`).
+- **AAA pattern** (Arrange · Act · Assert) em todos os cases.
+- **Sem mocks globais** — preferir injeção de dependência e _fakes_ tipados.
+- Teste é documentação: nomes descritivos em português (`deve recusar saída quando estoque é insuficiente`).
+- `beforeEach` reseta o DB local via `supabase db reset --no-seed` + factory de seed controlado.
+- **Flakiness zero:** teste `flaky` = teste quebrado. Sem retries automáticos em CI.
+
+### 12.4 Scripts e estrutura
+
+**`package.json`**
+
+```json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:unit": "vitest run --project unit",
+    "test:int": "vitest run --project integration",
+    "test:e2e": "playwright test",
+    "test:rls": "supabase test db",
+    "test:coverage": "vitest run --coverage",
+    "test:ci": "npm run test:unit && npm run test:int && npm run test:rls && npm run test:e2e"
+  }
+}
+```
+
+**Layout dos testes**
+
+```
+src/modules/<dominio>/
+├── services/
+│   ├── stock-service.ts
+│   └── stock-service.test.ts            # unit
+├── actions/
+│   ├── create-product.ts
+│   └── create-product.test.ts           # integration (supabase local)
+└── components/
+    ├── product-form.tsx
+    └── product-form.test.tsx            # component
+
+supabase/tests/
+├── 01_helpers.test.sql                  # pgTAP: has_permission, user_company_ids
+├── 02_triggers.test.sql                 # pgTAP: apply_stock_movement, handle_new_user
+└── 03_rls_isolation.test.sql            # pgTAP: cross-tenant deny
+
+tests/e2e/
+├── fixtures/
+│   ├── personas.ts                      # owner, manager, operator
+│   └── seed.ts
+├── auth.e2e.ts
+├── inventory.e2e.ts
+└── multitenant-isolation.e2e.ts
+```
+
+### 12.5 Padrões por tipo de teste
+
+**Unit (Vitest) — `services/stock-service.test.ts`**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { validateMovement, InsufficientStockError } from "./stock-service";
+
+describe("validateMovement", () => {
+  it("aceita entrada com qualquer quantidade positiva", () => {
+    expect(() => validateMovement({ productId: "x", type: "in", quantity: 10 }, 0)).not.toThrow();
+  });
+
+  it("recusa saída maior que o estoque atual", () => {
+    expect(() => validateMovement({ productId: "x", type: "out", quantity: 5 }, 3)).toThrow(
+      InsufficientStockError,
+    );
+  });
+});
+```
+
+**Integration (Server Action + RLS real) — `actions/create-product.test.ts`**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestUser, createTestCompany, signInAs, resetDb } from "@/tests/helpers";
+import { createProductAction } from "./create-product";
+
+describe("createProductAction", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("Manager cria produto com sucesso", async () => {
+    const { company } = await createTestCompany({ slug: "acme" });
+    const manager = await createTestUser({ role: "manager", company });
+    const client = await signInAs(manager);
+
+    const fd = new FormData();
+    fd.set("sku", "SKU-001");
+    fd.set("name", "Caneta");
+    fd.set("unit", "UN");
+    fd.set("costPrice", "1");
+    fd.set("salePrice", "2");
+
+    const result = await createProductAction({ companyId: company.id, userId: manager.id }, fd);
+
+    expect(result.ok).toBe(true);
+    const { data } = await client.from("products").select("*").eq("sku", "SKU-001").single();
+    expect(data?.company_id).toBe(company.id);
+  });
+
+  it("Operator é bloqueado pela RLS ao tentar criar", async () => {
+    const { company } = await createTestCompany();
+    const operator = await createTestUser({ role: "operator", company });
+    const fd = new FormData();
+    fd.set("sku", "SKU-002");
+    fd.set("name", "Lápis");
+    fd.set("unit", "UN");
+    fd.set("costPrice", "1");
+    fd.set("salePrice", "2");
+
+    const result = await createProductAction({ companyId: company.id, userId: operator.id }, fd);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/forbidden|permission/i);
+  });
+});
+```
+
+**RLS isolation (pgTAP) — `supabase/tests/03_rls_isolation.test.sql`**
+
+```sql
+begin;
+select plan(3);
+
+-- Fixtures: duas empresas, um usuário em cada
+select tests.create_company('acme');
+select tests.create_company('globex');
+select tests.create_user_in('u_acme@test', 'acme', 'operator');
+select tests.create_user_in('u_globex@test', 'globex', 'operator');
+
+-- Produto em cada empresa
+set local role service_role;
+insert into products (id, company_id, sku, name, unit, cost_price, sale_price)
+values (gen_random_uuid(), tests.company_id('acme'),   'A-1', 'A', 'UN', 1, 2),
+       (gen_random_uuid(), tests.company_id('globex'), 'G-1', 'G', 'UN', 1, 2);
+
+-- Usuário de ACME NÃO deve ver nada de Globex
+select tests.authenticate_as('u_acme@test');
+select is(
+  (select count(*)::int from products where sku = 'G-1'),
+  0,
+  'operador ACME não vê produtos de Globex'
+);
+
+-- Operator NÃO pode deletar
+select throws_like(
+  $$ delete from products where sku = 'A-1' $$,
+  '%new row violates row-level security%',
+  'operator não consegue delete'
+);
+
+-- Manager pode deletar
+select tests.authenticate_as_role('u_acme@test', 'manager');
+select lives_ok(
+  $$ delete from products where sku = 'A-1' $$,
+  'manager consegue delete'
+);
+
+select * from finish();
+rollback;
+```
+
+**Component (Testing Library) — `product-form.test.tsx`**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ProductForm } from "./product-form";
+
+vi.mock("../actions/create-product", () => ({
+  createProductAction: vi.fn().mockResolvedValue({ ok: true, message: "Produto cadastrado" }),
+}));
+
+describe("<ProductForm>", () => {
+  it("exibe erros de validação quando SKU está vazio", async () => {
+    render(<ProductForm />);
+    await userEvent.click(screen.getByRole("button", { name: /salvar/i }));
+    expect(await screen.findByText(/obrigatório|required/i)).toBeInTheDocument();
+  });
+});
+```
+
+**E2E (Playwright) — `tests/e2e/inventory.e2e.ts`**
+
+```ts
+import { test, expect } from "@playwright/test";
+import { loginAs, seedCompany } from "./fixtures";
+
+test.describe("Inventory — Manager", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedCompany("acme");
+    await loginAs(page, "manager@acme.test");
+  });
+
+  test("cria produto e registra entrada de estoque", async ({ page }) => {
+    await page.goto("/acme/inventory/new");
+    await page.fill('[name="sku"]', "E2E-001");
+    await page.fill('[name="name"]', "Produto E2E");
+    await page.selectOption('[name="unit"]', "UN");
+    await page.fill('[name="costPrice"]', "10");
+    await page.fill('[name="salePrice"]', "20");
+    await page.click('button[type="submit"]');
+
+    await expect(page).toHaveURL(/\/acme\/inventory$/);
+    await expect(page.getByText("E2E-001")).toBeVisible();
+  });
+});
+
+test.describe("Inventory — Operator (acesso negado)", () => {
+  test("não vê botão '+ Novo produto'", async ({ page }) => {
+    await loginAs(page, "operator@acme.test");
+    await page.goto("/acme/inventory");
+    await expect(page.getByRole("link", { name: /novo produto/i })).toHaveCount(0);
+  });
+});
+```
+
+### 12.6 Matriz mínima de testes por feature
+
+Para cada Server Action/recurso novo, é **obrigatório** cobrir:
+
+| Cenário                                                           | Tipo                 | Severidade     |
+| :---------------------------------------------------------------- | :------------------- | :------------- |
+| Input válido → sucesso                                            | integration          | 🔴 obrigatório |
+| Input inválido → `fieldErrors` do Zod                             | unit ou integration  | 🔴 obrigatório |
+| Usuário sem permissão → negado (`ForbiddenError`)                 | integration          | 🔴 obrigatório |
+| Usuário de outra empresa não consegue ler/escrever → RLS bloqueia | integration ou pgTAP | 🔴 obrigatório |
+| Regra de negócio específica (ex: estoque negativo)                | unit no service      | 🔴 obrigatório |
+| Audit log criado com `status` correto                             | integration          | 🟡 recomendado |
+| Revalidação de cache aciona                                       | integration          | 🟢 opcional    |
+
+### 12.7 Gates de cobertura no CI
+
+| Métrica                               |          Mínimo          | Falha o build? |
+| :------------------------------------ | :----------------------: | :------------: |
+| Cobertura total (`vitest --coverage`) |      **80%** linhas      |       ✅       |
+| Cobertura em `modules/**/services/**` |         **95%**          |       ✅       |
+| Cobertura em `modules/**/actions/**`  |         **85%**          |       ✅       |
+| `supabase test db` (pgTAP)            | 100% dos arquivos passam |       ✅       |
+| `playwright test` — cenários críticos |       100% passam        |       ✅       |
+| Lint + typecheck                      |        sem erros         |       ✅       |
+
+**GitHub Actions (trecho)**
+
+```yaml
+- name: Start Supabase
+  run: supabase start
+- name: Unit + Integration
+  run: npm run test:unit && npm run test:int
+- name: RLS (pgTAP)
+  run: npm run test:rls
+- name: E2E
+  run: npx playwright install --with-deps && npm run test:e2e
+- name: Coverage gate
+  run: npm run test:coverage -- --reporter=json-summary
+- name: Upload coverage
+  uses: actions/upload-artifact@v4
+```
+
+### 12.8 Test PRs inseridos em cada sprint
+
+> Nenhum sprint é considerado "concluído" sem seu PR de testes. Abaixo a adição canônica a cada sprint (já referenciada em §11):
+
+| Sprint | PR de testes                                                    | Escopo                                                                  |
+| :----: | :-------------------------------------------------------------- | :---------------------------------------------------------------------- |
+|   S0   | #03                                                             | Script `check-rls.sql` no CI                                            |
+|   S1   | **#08.5 — test(db): pgTAP para helpers e bootstrap**            | `has_permission`, `user_company_ids`, `bootstrap_company_rbac` cobertos |
+|   S2   | **#11.5 — test(tenancy): switcher + resolve-company**           | Cookie honrado; fallback; rota `/admin` bloqueia não-admin              |
+|   S3   | **#14 (já previsto) + #14.5 — test(audit)**                     | Une com `authz`; cobre registro e consulta com RLS                      |
+|   S4   | **#18.5 — test(auth): fluxo convite → aceite**                  | Estados de `membership.status`, login após aceite                       |
+|   S5   | **#29 (já previsto) + component tests**                         | Isolamento cross-tenant + `<Can>` esconde botões corretamente           |
+|   S6   | **#32.5 — test(admin): criação de empresa e toggle de módulos** | Bootstrap roles + reseed de permissões                                  |
+|   S7   | **#35.5 — test(settings): CRUD de roles + matriz**              | Role customizada aplicada em tempo real                                 |
+|   S8   | **#38.5 — test(regression): suite full rodando sem a flag**     | Todo fluxo passa sem `MULTITENANCY_ENABLED`                             |
+|   S9   | **#39–#40 (já previstos)**                                      | Isolation suite + RLS gate obrigatório                                  |
+
+### 12.9 Test helpers reutilizáveis
+
+Criar em `src/tests/helpers/` funções que todo teste de integração consome:
+
+```ts
+// src/tests/helpers/factories.ts
+export async function createTestCompany(opts?: Partial<{ slug: string; modules: string[] }>) {
+  const slug = opts?.slug ?? `test-${crypto.randomUUID().slice(0, 8)}`;
+  // ... cria em companies, habilita módulos, chama bootstrap_company_rbac
+}
+
+export async function createTestUser(opts: {
+  role: "owner" | "manager" | "operator";
+  company: Company;
+}) {
+  // ... cria em auth.users, cria membership, associa role de sistema
+}
+
+export async function signInAs(user: TestUser): Promise<SupabaseClient> {
+  // ... retorna client autenticado via auth.signInWithPassword
+}
+
+export async function resetDb() {
+  // ... supabase db reset + aplica seeds mínimos + snapshot para speed
+}
+```
+
+> **Princípio:** um teste não deve saber nada sobre SQL interno. Todo setup vem do _factory_. Isso evita vazamento de detalhes e facilita refactor.
+
+### 12.10 Definition of Done (checklist de review)
+
+Em cada PR, o revisor confere:
+
+- [ ] PR inclui testes cobrindo o comportamento novo/alterado
+- [ ] Nome dos testes descreve o comportamento em português
+- [ ] Cenário de "acesso negado" testado (quando a feature é gated por permissão)
+- [ ] Cenário de isolamento multi-tenant testado (quando toca tabela com `company_id`)
+- [ ] Cobertura local não caiu abaixo do gate
+- [ ] E2E do fluxo tocado ainda passa
+- [ ] Testes rodam em < 2 min em dev local
+
+---
+
+> **Resumo executivo:** Empresas são tenants isolados por `company_id` + RLS; módulos e permissões são **dados declarativos** (não código) registrados em tabelas; usuários entram em empresas via `memberships` e acumulam `roles`; o backend valida cinco camadas (middleware → layout → guard de módulo → `withPermission` → RLS); novos módulos são acrescentados inserindo linhas em `modules` + `permissions` e aplicando o mesmo _template_ de RLS — **zero refatoração do core**. A integração ao MVP atual acontece em **10 sprints** (S0–S9) e **42 PRs** pequenos, usando a estratégia _Expand → Migrate → Contract_ com flag de feature e `default-company` para garantir zero-downtime. **Toda feature é entregue com testes automatizados** cobrindo unit/integration/e2e/RLS, e nenhum PR passa no review sem atender à §12.10 (Definition of Done).

--- a/docs/ARCHITECTURE-MULTITENANT.md
+++ b/docs/ARCHITECTURE-MULTITENANT.md
@@ -1499,13 +1499,13 @@ src/modules/audit/
 - [x] S2 · #09–#11 · módulo `tenancy` + switcher + `/admin/companies` — **mergeado (PR #2)**
 - [x] S3 · #12–#14 · `authz` + `audit` + `<Can>` — **mergeado (PR #3)**
 - [x] S4 · #15–#18 · refactor `auth` (memberships) — **mergeado (PR #4)**
-- [x] S5 · #19–#29 · refactor `inventory` (company_id → RLS → withPermission → tests) — **PR #5 aberto, validado manualmente** · branch `feat/multitenant-s5`
-- [ ] S6 · #30–#32 · painel platform admin
+- [x] S5 · #19–#29 · refactor `inventory` (company_id → RLS → withPermission → tests) — **mergeado (PR #5)**
+- [x] S6 · #30–#32 · painel platform admin — **branch `feat/multitenant-s6`**
 - [ ] S7 · #33–#35 · gestão de membros/roles por empresa
 - [ ] S8 · #36–#38 · _contract_ — remover legado
 - [ ] S9 · #39–#42 · hardening — RLS check, isolation tests, observabilidade
 
-> **Próximo:** S6 — painel platform admin (`/admin/companies` wizard + toggle módulos + audit global)
+> **Próximo:** S7 — gestão de membros & roles por empresa (`/[companySlug]/settings/members` + roles + matriz de permissões)
 
 ### 11.15 Riscos e mitigações
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -24,6 +24,7 @@
 ## 1. Visão Geral e Princípios Arquiteturais
 
 ### 1.1 Objetivo
+
 Entregar um ERP web, escalável e modular, com MVP focado em três domínios: **Auth**, **Produtos** e **Movimentações de Estoque**. A base deve permitir que novos módulos (Orçamentos, Clientes, Financeiro, etc.) sejam anexados sem tocar no _core_.
 
 ### 1.2 Princípios
@@ -186,6 +187,7 @@ pnpm dlx shadcn@latest add button input label form card table \
 ### 3.2 Variáveis de Ambiente
 
 **`.env.local.example`**
+
 ```env
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=
@@ -197,6 +199,7 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 ```
 
 **`src/core/config/env.ts`** — validação com Zod na inicialização:
+
 ```ts
 import { z } from "zod";
 
@@ -218,6 +221,7 @@ export const env = envSchema.parse({
 ### 3.3 Clients Supabase (SSR)
 
 **`src/lib/supabase/server.ts`**
+
 ```ts
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
@@ -233,10 +237,14 @@ export function createClient() {
       cookies: {
         get: (name) => cookieStore.get(name)?.value,
         set: (name, value, options: CookieOptions) => {
-          try { cookieStore.set({ name, value, ...options }); } catch {}
+          try {
+            cookieStore.set({ name, value, ...options });
+          } catch {}
         },
         remove: (name, options: CookieOptions) => {
-          try { cookieStore.set({ name, value: "", ...options }); } catch {}
+          try {
+            cookieStore.set({ name, value: "", ...options });
+          } catch {}
         },
       },
     },
@@ -245,19 +253,18 @@ export function createClient() {
 ```
 
 **`src/lib/supabase/client.ts`**
+
 ```ts
 import { createBrowserClient } from "@supabase/ssr";
 import type { Database } from "@/types/database.types";
 import { env } from "@/core/config/env";
 
 export const createClient = () =>
-  createBrowserClient<Database>(
-    env.NEXT_PUBLIC_SUPABASE_URL,
-    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  );
+  createBrowserClient<Database>(env.NEXT_PUBLIC_SUPABASE_URL, env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
 ```
 
 **`src/middleware.ts`** — refresh de sessão + guard de rotas protegidas:
+
 ```ts
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerClient } from "@supabase/ssr";
@@ -284,7 +291,9 @@ export async function middleware(request: NextRequest) {
     },
   );
 
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   const { pathname } = request.nextUrl;
   const isPublic = PUBLIC_ROUTES.some((p) => pathname.startsWith(p));
 
@@ -333,12 +342,14 @@ pnpm supabase start            # Postgres local
 ### 4.2 Migrations
 
 **`supabase/migrations/20260420_00_init.sql`**
+
 ```sql
 create extension if not exists "pgcrypto";
 create extension if not exists "uuid-ossp";
 ```
 
 **`supabase/migrations/20260420_01_profiles.sql`**
+
 ```sql
 create type public.user_role as enum ('admin', 'manager', 'operator');
 
@@ -370,6 +381,7 @@ for each row execute function public.handle_new_user();
 ```
 
 **`supabase/migrations/20260420_02_products.sql`**
+
 ```sql
 create table public.products (
   id           uuid primary key default gen_random_uuid(),
@@ -392,6 +404,7 @@ create index idx_products_name on public.products using gin (to_tsvector('portug
 ```
 
 **`supabase/migrations/20260420_03_stock_movements.sql`**
+
 ```sql
 create type public.movement_type as enum ('in', 'out', 'adjustment');
 
@@ -434,6 +447,7 @@ for each row execute function public.apply_stock_movement();
 ```
 
 **`supabase/migrations/20260420_04_rls_policies.sql`**
+
 ```sql
 -- Helper: role do usuário logado
 create or replace function public.current_user_role()
@@ -478,6 +492,7 @@ pnpm supabase gen types typescript \
 ```
 
 Adicionar script ao `package.json`:
+
 ```json
 {
   "scripts": {
@@ -502,26 +517,29 @@ export const signInSchema = z.object({
   password: z.string().min(8, "Mínimo 8 caracteres"),
 });
 
-export const signUpSchema = z.object({
-  fullName: z.string().min(3, "Informe seu nome"),
-  email: z.string().email(),
-  password: z.string().min(8),
-  confirmPassword: z.string(),
-}).refine((d) => d.password === d.confirmPassword, {
-  path: ["confirmPassword"],
-  message: "As senhas não coincidem",
-});
+export const signUpSchema = z
+  .object({
+    fullName: z.string().min(3, "Informe seu nome"),
+    email: z.string().email(),
+    password: z.string().min(8),
+    confirmPassword: z.string(),
+  })
+  .refine((d) => d.password === d.confirmPassword, {
+    path: ["confirmPassword"],
+    message: "As senhas não coincidem",
+  });
 
 export const recoverSchema = z.object({ email: z.string().email() });
 
-export type SignInInput   = z.infer<typeof signInSchema>;
-export type SignUpInput   = z.infer<typeof signUpSchema>;
-export type RecoverInput  = z.infer<typeof recoverSchema>;
+export type SignInInput = z.infer<typeof signInSchema>;
+export type SignUpInput = z.infer<typeof signUpSchema>;
+export type RecoverInput = z.infer<typeof recoverSchema>;
 ```
 
 ### 5.2 Server Actions
 
 **`src/modules/auth/actions/sign-in.ts`**
+
 ```ts
 "use server";
 import { redirect } from "next/navigation";
@@ -530,10 +548,7 @@ import { createClient } from "@/lib/supabase/server";
 import { signInSchema } from "../schemas";
 import type { ActionResult } from "@/lib/errors";
 
-export async function signInAction(
-  _prev: ActionResult,
-  formData: FormData,
-): Promise<ActionResult> {
+export async function signInAction(_prev: ActionResult, formData: FormData): Promise<ActionResult> {
   const parsed = signInSchema.safeParse(Object.fromEntries(formData));
   if (!parsed.success) {
     return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
@@ -548,6 +563,7 @@ export async function signInAction(
 ```
 
 **`src/modules/auth/actions/sign-up.ts`**
+
 ```ts
 "use server";
 import { createClient } from "@/lib/supabase/server";
@@ -555,10 +571,7 @@ import { signUpSchema } from "../schemas";
 import { env } from "@/core/config/env";
 import type { ActionResult } from "@/lib/errors";
 
-export async function signUpAction(
-  _prev: ActionResult,
-  formData: FormData,
-): Promise<ActionResult> {
+export async function signUpAction(_prev: ActionResult, formData: FormData): Promise<ActionResult> {
   const parsed = signUpSchema.safeParse(Object.fromEntries(formData));
   if (!parsed.success) {
     return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
@@ -579,6 +592,7 @@ export async function signUpAction(
 ```
 
 **`src/modules/auth/actions/sign-in-google.ts`**
+
 ```ts
 "use server";
 import { redirect } from "next/navigation";
@@ -597,6 +611,7 @@ export async function signInGoogleAction() {
 ```
 
 **`src/modules/auth/actions/recover-password.ts`**
+
 ```ts
 "use server";
 import { createClient } from "@/lib/supabase/server";
@@ -622,6 +637,7 @@ export async function recoverPasswordAction(
 ```
 
 **`src/modules/auth/actions/sign-out.ts`**
+
 ```ts
 "use server";
 import { redirect } from "next/navigation";
@@ -639,6 +655,7 @@ export async function signOutAction() {
 ### 5.3 Route Handler — Callback OAuth
 
 **`src/app/api/auth/callback/route.ts`**
+
 ```ts
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
@@ -660,6 +677,7 @@ export async function GET(request: NextRequest) {
 ### 5.4 UI — Formulário de Login
 
 **`src/modules/auth/components/sign-in-form.tsx`**
+
 ```tsx
 "use client";
 import { useFormState, useFormStatus } from "react-dom";
@@ -678,12 +696,22 @@ export function SignInForm() {
       <div className="space-y-2">
         <Label htmlFor="email">Email</Label>
         <Input id="email" name="email" type="email" required autoComplete="email" />
-        {state.fieldErrors?.email && <p className="text-sm text-red-600">{state.fieldErrors.email[0]}</p>}
+        {state.fieldErrors?.email && (
+          <p className="text-sm text-red-600">{state.fieldErrors.email[0]}</p>
+        )}
       </div>
       <div className="space-y-2">
         <Label htmlFor="password">Senha</Label>
-        <Input id="password" name="password" type="password" required autoComplete="current-password" />
-        {state.fieldErrors?.password && <p className="text-sm text-red-600">{state.fieldErrors.password[0]}</p>}
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          required
+          autoComplete="current-password"
+        />
+        {state.fieldErrors?.password && (
+          <p className="text-sm text-red-600">{state.fieldErrors.password[0]}</p>
+        )}
       </div>
       {state.message && !state.ok && <p className="text-sm text-red-600">{state.message}</p>}
       <SubmitButton />
@@ -697,7 +725,11 @@ export function SignInForm() {
 
 function SubmitButton() {
   const { pending } = useFormStatus();
-  return <Button type="submit" className="w-full" disabled={pending}>{pending ? "Entrando..." : "Entrar"}</Button>;
+  return (
+    <Button type="submit" className="w-full" disabled={pending}>
+      {pending ? "Entrando..." : "Entrar"}
+    </Button>
+  );
 }
 ```
 
@@ -718,7 +750,11 @@ function SubmitButton() {
 import { z } from "zod";
 
 export const productSchema = z.object({
-  sku: z.string().min(1).max(32).regex(/^[A-Z0-9\-]+$/i, "SKU alfanumérico"),
+  sku: z
+    .string()
+    .min(1)
+    .max(32)
+    .regex(/^[A-Z0-9\-]+$/i, "SKU alfanumérico"),
   name: z.string().min(2).max(120),
   description: z.string().max(2000).optional().nullable(),
   unit: z.enum(["UN", "KG", "L", "CX", "M"]),
@@ -743,18 +779,21 @@ export const listProductsSchema = z.object({
   onlyActive: z.coerce.boolean().default(true),
 });
 
-export type ProductInput  = z.infer<typeof productSchema>;
+export type ProductInput = z.infer<typeof productSchema>;
 export type MovementInput = z.infer<typeof movementSchema>;
 ```
 
 ### 6.2 Service (regra de negócio pura)
 
 **`src/modules/inventory/services/stock-service.ts`**
+
 ```ts
 import type { MovementInput } from "../schemas";
 
 export class InsufficientStockError extends Error {
-  constructor(productId: string) { super(`Estoque insuficiente: ${productId}`); }
+  constructor(productId: string) {
+    super(`Estoque insuficiente: ${productId}`);
+  }
 }
 
 /** Valida localmente antes de chamar o banco (UX). Banco tem a verdade via trigger. */
@@ -768,6 +807,7 @@ export function validateMovement(input: MovementInput, currentStock: number): vo
 ### 6.3 Server Actions
 
 **`src/modules/inventory/actions/create-product.ts`**
+
 ```ts
 "use server";
 import { revalidatePath } from "next/cache";
@@ -784,7 +824,9 @@ export async function createProductAction(
     return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
   }
   const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) return { ok: false, message: "Não autenticado" };
 
   const { error } = await supabase.from("products").insert({
@@ -806,6 +848,7 @@ export async function createProductAction(
 ```
 
 **`src/modules/inventory/actions/register-movement.ts`**
+
 ```ts
 "use server";
 import { revalidatePath } from "next/cache";
@@ -823,15 +866,23 @@ export async function registerMovementAction(
     return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
   }
   const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) return { ok: false, message: "Não autenticado" };
 
   // Pré-validação (UX)
   const { data: product, error: pErr } = await supabase
-    .from("products").select("stock").eq("id", parsed.data.productId).single();
+    .from("products")
+    .select("stock")
+    .eq("id", parsed.data.productId)
+    .single();
   if (pErr || !product) return { ok: false, message: "Produto não encontrado" };
-  try { validateMovement(parsed.data, Number(product.stock)); }
-  catch (e) { return { ok: false, message: (e as Error).message }; }
+  try {
+    validateMovement(parsed.data, Number(product.stock));
+  } catch (e) {
+    return { ok: false, message: (e as Error).message };
+  }
 
   const { error } = await supabase.from("stock_movements").insert({
     product_id: parsed.data.productId,
@@ -852,6 +903,7 @@ export async function registerMovementAction(
 ### 6.4 Queries (leitura)
 
 **`src/modules/inventory/queries/list-products.ts`**
+
 ```ts
 import "server-only";
 import { createClient } from "@/lib/supabase/server";
@@ -860,11 +912,14 @@ import { listProductsSchema } from "../schemas";
 export async function listProducts(raw: Record<string, unknown>) {
   const { q, page, pageSize, onlyActive } = listProductsSchema.parse(raw);
   const from = (page - 1) * pageSize;
-  const to   = from + pageSize - 1;
+  const to = from + pageSize - 1;
 
   const supabase = createClient();
-  let query = supabase.from("products").select("*", { count: "exact" })
-    .order("name").range(from, to);
+  let query = supabase
+    .from("products")
+    .select("*", { count: "exact" })
+    .order("name")
+    .range(from, to);
   if (onlyActive) query = query.eq("is_active", true);
   if (q) query = query.or(`name.ilike.%${q}%,sku.ilike.%${q}%`);
 
@@ -880,11 +935,16 @@ export async function listProducts(raw: Record<string, unknown>) {
 export type FieldErrors = Record<string, string[] | undefined>;
 
 export type ActionResult =
-  | { ok: true;  message?: string }
+  | { ok: true; message?: string }
   | { ok: false; message?: string; fieldErrors?: FieldErrors };
 
 export class AppError extends Error {
-  constructor(message: string, public code: string = "APP_ERROR") { super(message); }
+  constructor(
+    message: string,
+    public code: string = "APP_ERROR",
+  ) {
+    super(message);
+  }
 }
 ```
 
@@ -895,6 +955,7 @@ export class AppError extends Error {
 ### 7.1 Listagem de Produtos (Server Component)
 
 **`src/app/(dashboard)/inventory/page.tsx`**
+
 ```tsx
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -913,8 +974,12 @@ export default async function InventoryPage({ searchParams }: Props) {
           <p className="text-sm text-muted-foreground">{total} produtos cadastrados</p>
         </div>
         <div className="flex gap-2">
-          <Button asChild variant="outline"><Link href="/inventory/movements">Movimentações</Link></Button>
-          <Button asChild><Link href="/inventory/new">+ Novo produto</Link></Button>
+          <Button asChild variant="outline">
+            <Link href="/inventory/movements">Movimentações</Link>
+          </Button>
+          <Button asChild>
+            <Link href="/inventory/new">+ Novo produto</Link>
+          </Button>
         </div>
       </header>
       <ProductTable items={data} page={page} pageSize={pageSize} total={total} />
@@ -926,9 +991,17 @@ export default async function InventoryPage({ searchParams }: Props) {
 ### 7.2 Tabela de Produtos
 
 **`src/modules/inventory/components/product-table.tsx`**
+
 ```tsx
 import Link from "next/link";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import type { Database } from "@/types/database.types";
 
@@ -954,15 +1027,21 @@ export function ProductTable({ items }: Props) {
           <TableRow key={p.id}>
             <TableCell className="font-mono text-xs">{p.sku}</TableCell>
             <TableCell>
-              <Link href={`/inventory/${p.id}`} className="hover:underline">{p.name}</Link>
+              <Link href={`/inventory/${p.id}`} className="hover:underline">
+                {p.name}
+              </Link>
             </TableCell>
-            <TableCell className="text-right">{Number(p.stock).toFixed(3)} {p.unit}</TableCell>
+            <TableCell className="text-right">
+              {Number(p.stock).toFixed(3)} {p.unit}
+            </TableCell>
             <TableCell className="text-right">R$ {Number(p.cost_price).toFixed(2)}</TableCell>
             <TableCell className="text-right">R$ {Number(p.sale_price).toFixed(2)}</TableCell>
             <TableCell>
-              {Number(p.stock) <= Number(p.min_stock)
-                ? <Badge variant="destructive">Baixo</Badge>
-                : <Badge variant="secondary">OK</Badge>}
+              {Number(p.stock) <= Number(p.min_stock) ? (
+                <Badge variant="destructive">Baixo</Badge>
+              ) : (
+                <Badge variant="secondary">OK</Badge>
+              )}
             </TableCell>
           </TableRow>
         ))}
@@ -975,13 +1054,20 @@ export function ProductTable({ items }: Props) {
 ### 7.3 Formulário de Produto (client)
 
 **`src/modules/inventory/components/product-form.tsx`**
+
 ```tsx
 "use client";
 import { useFormState, useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { createProductAction } from "../actions/create-product";
 
@@ -993,39 +1079,66 @@ export function ProductForm() {
     <form action={action} className="grid grid-cols-1 gap-4 md:grid-cols-2">
       <Field label="SKU" name="sku" error={state.fieldErrors?.sku?.[0]} required />
       <Field label="Nome" name="name" error={state.fieldErrors?.name?.[0]} required />
-      <div className="md:col-span-2 space-y-2">
+      <div className="space-y-2 md:col-span-2">
         <Label htmlFor="description">Descrição</Label>
         <Textarea id="description" name="description" rows={3} />
       </div>
       <div className="space-y-2">
         <Label htmlFor="unit">Unidade</Label>
         <Select name="unit" defaultValue="UN">
-          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
           <SelectContent>
-            {["UN", "KG", "L", "CX", "M"].map((u) => <SelectItem key={u} value={u}>{u}</SelectItem>)}
+            {["UN", "KG", "L", "CX", "M"].map((u) => (
+              <SelectItem key={u} value={u}>
+                {u}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>
       <Field label="Custo" name="costPrice" type="number" step="0.01" />
       <Field label="Venda" name="salePrice" type="number" step="0.01" />
       <Field label="Estoque mínimo" name="minStock" type="number" step="0.001" />
-      <div className="md:col-span-2 flex justify-end">
+      <div className="flex justify-end md:col-span-2">
         <Submit />
       </div>
       {state.message && (
-        <p className={`md:col-span-2 text-sm ${state.ok ? "text-emerald-600" : "text-red-600"}`}>{state.message}</p>
+        <p className={`text-sm md:col-span-2 ${state.ok ? "text-emerald-600" : "text-red-600"}`}>
+          {state.message}
+        </p>
       )}
     </form>
   );
 }
 
-function Field({ label, name, type = "text", required, error, step }: {
-  label: string; name: string; type?: string; required?: boolean; error?: string; step?: string;
+function Field({
+  label,
+  name,
+  type = "text",
+  required,
+  error,
+  step,
+}: {
+  label: string;
+  name: string;
+  type?: string;
+  required?: boolean;
+  error?: string;
+  step?: string;
 }) {
   return (
     <div className="space-y-2">
       <Label htmlFor={name}>{label}</Label>
-      <Input id={name} name={name} type={type} step={step} required={required} aria-invalid={!!error} />
+      <Input
+        id={name}
+        name={name}
+        type={type}
+        step={step}
+        required={required}
+        aria-invalid={!!error}
+      />
       {error && <p className="text-sm text-red-600">{error}</p>}
     </div>
   );
@@ -1033,20 +1146,31 @@ function Field({ label, name, type = "text", required, error, step }: {
 
 function Submit() {
   const { pending } = useFormStatus();
-  return <Button type="submit" disabled={pending}>{pending ? "Salvando..." : "Salvar"}</Button>;
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? "Salvando..." : "Salvar"}
+    </Button>
+  );
 }
 ```
 
 ### 7.4 Registro de Movimentação
 
 **`src/modules/inventory/components/movement-form.tsx`**
+
 ```tsx
 "use client";
 import { useFormState, useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { registerMovementAction } from "../actions/register-movement";
 
 const initial = { ok: false } as const;
@@ -1060,16 +1184,24 @@ export function MovementForm({ products }: { products: Product[] }) {
       <div className="space-y-2 md:col-span-2">
         <Label>Produto</Label>
         <Select name="productId">
-          <SelectTrigger><SelectValue placeholder="Selecione..." /></SelectTrigger>
+          <SelectTrigger>
+            <SelectValue placeholder="Selecione..." />
+          </SelectTrigger>
           <SelectContent>
-            {products.map((p) => <SelectItem key={p.id} value={p.id}>{p.sku} — {p.name}</SelectItem>)}
+            {products.map((p) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.sku} — {p.name}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>
       <div className="space-y-2">
         <Label>Tipo</Label>
         <Select name="type" defaultValue="in">
-          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
           <SelectContent>
             <SelectItem value="in">Entrada</SelectItem>
             <SelectItem value="out">Saída</SelectItem>
@@ -1085,11 +1217,13 @@ export function MovementForm({ products }: { products: Product[] }) {
         <Label htmlFor="reason">Motivo (opcional)</Label>
         <Input id="reason" name="reason" />
       </div>
-      <div className="md:col-span-2 flex justify-end">
+      <div className="flex justify-end md:col-span-2">
         <Submit />
       </div>
       {state.message && (
-        <p className={`md:col-span-2 text-sm ${state.ok ? "text-emerald-600" : "text-red-600"}`}>{state.message}</p>
+        <p className={`text-sm md:col-span-2 ${state.ok ? "text-emerald-600" : "text-red-600"}`}>
+          {state.message}
+        </p>
       )}
     </form>
   );
@@ -1097,13 +1231,18 @@ export function MovementForm({ products }: { products: Product[] }) {
 
 function Submit() {
   const { pending } = useFormStatus();
-  return <Button type="submit" disabled={pending}>{pending ? "Registrando..." : "Registrar"}</Button>;
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? "Registrando..." : "Registrar"}
+    </Button>
+  );
 }
 ```
 
 ### 7.5 Shell do Dashboard
 
 **`src/app/(dashboard)/layout.tsx`**
+
 ```tsx
 import { redirect } from "next/navigation";
 import Link from "next/link";
@@ -1114,7 +1253,9 @@ import { MODULES_MENU } from "@/core/navigation/menu";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
   return (
@@ -1123,7 +1264,11 @@ export default async function DashboardLayout({ children }: { children: React.Re
         <h2 className="mb-6 text-lg font-semibold">ERP</h2>
         <nav className="flex flex-col gap-1">
           {MODULES_MENU.map((item) => (
-            <Link key={item.href} href={item.href} className="rounded px-3 py-2 text-sm hover:bg-accent">
+            <Link
+              key={item.href}
+              href={item.href}
+              className="rounded px-3 py-2 text-sm hover:bg-accent"
+            >
               {item.label}
             </Link>
           ))}
@@ -1131,7 +1276,11 @@ export default async function DashboardLayout({ children }: { children: React.Re
       </aside>
       <main className="p-8">
         <div className="mb-4 flex justify-end">
-          <form action={signOutAction}><Button variant="ghost" size="sm">Sair</Button></form>
+          <form action={signOutAction}>
+            <Button variant="ghost" size="sm">
+              Sair
+            </Button>
+          </form>
         </div>
         {children}
       </main>
@@ -1141,13 +1290,14 @@ export default async function DashboardLayout({ children }: { children: React.Re
 ```
 
 **`src/core/navigation/menu.ts`** — registro central para o sistema "plug and play":
+
 ```ts
 export type MenuItem = { label: string; href: string; icon?: string; roles?: string[] };
 
 export const MODULES_MENU: MenuItem[] = [
-  { label: "Início",         href: "/" },
-  { label: "Estoque",        href: "/inventory" },
-  { label: "Movimentações",  href: "/inventory/movements" },
+  { label: "Início", href: "/" },
+  { label: "Estoque", href: "/inventory" },
+  { label: "Movimentações", href: "/inventory/movements" },
   // Novos módulos se registram aqui sem alterar o layout.
 ];
 ```
@@ -1157,15 +1307,18 @@ export const MODULES_MENU: MenuItem[] = [
 ## 8. Convenções e Padrões de Projeto
 
 ### 8.1 Commits e branches
+
 - **Conventional Commits** (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:`).
 - Branches: `main` (produção) · `develop` (staging) · `feature/<modulo>-<descricao>`.
 
 ### 8.2 Qualidade de código
+
 - `tsconfig.json` com `"strict": true`, `"noUncheckedIndexedAccess": true`.
 - ESLint `next/core-web-vitals` + regra customizada que **impede `import` de arquivos internos de outro módulo** (forçar uso do `index.ts`).
 - Prettier + `prettier-plugin-tailwindcss`.
 
 ### 8.3 Padrões de Design (code level)
+
 - **Barrel pattern** por módulo (`index.ts` como única porta de entrada).
 - **Service/Repository** dentro de cada módulo separa regra de negócio de acesso a dados.
 - **Dependency injection** leve via parâmetros (nada de globais).
@@ -1174,15 +1327,66 @@ export const MODULES_MENU: MenuItem[] = [
 - **Composição > herança** nos componentes (Shadcn já segue esse padrão).
 
 ### 8.4 Erros
+
 - Nunca lançar `Error` cru nas actions — sempre retornar `ActionResult` tipado.
 - Nível de transporte (Supabase) → mapear para mensagens humanas em português.
 
-### 8.5 Testes (sugerido)
-- **Vitest** + **@testing-library/react** para componentes.
-- **Playwright** para e2e dos fluxos críticos (login, cadastro, criar produto, registrar movimento).
-- Testes de `services/` são obrigatórios (lógica pura).
+### 8.5 Testes (obrigatório em toda feature)
+
+> **Política do projeto:** toda PR que altera comportamento **precisa vir com testes automatizados**. PRs sem testes são bloqueados no review. A estratégia completa (pirâmide, ferramentas, gates, Definition of Done) está detalhada em [`ARCHITECTURE-MULTITENANT.md` §12](./ARCHITECTURE-MULTITENANT.md#12-estratégia-de-testes-obrigatória-em-toda-feature) e se aplica ao MVP desde a Fase 1.
+
+**Stack de testes**
+
+- **Vitest** — testes unitários (services, schemas, helpers).
+- **@testing-library/react** — componentes (render + interação).
+- **Vitest + @supabase local** — Server Actions de ponta a ponta (com RLS real).
+- **pgTAP** (`supabase test db`) — triggers e policies RLS direto no Postgres.
+- **Playwright** — e2e dos fluxos críticos (login, cadastro, criar produto, registrar movimento).
+
+**Matriz mínima por feature**
+
+| Cenário                                            | Tipo             |    Obrigatório    |
+| :------------------------------------------------- | :--------------- | :---------------: |
+| Input válido → sucesso                             | integration      |        ✅         |
+| Input inválido → `fieldErrors` do Zod              | unit/integration |        ✅         |
+| Usuário não autenticado → negado                   | integration      |        ✅         |
+| Regra de negócio específica (ex: estoque negativo) | unit no service  |        ✅         |
+| Trigger/policy do banco                            | pgTAP            | ✅ (se aplicável) |
+
+**Scripts**
+
+```bash
+pnpm test           # vitest run
+pnpm test:watch     # vitest em modo watch
+pnpm test:rls       # supabase test db (pgTAP)
+pnpm test:e2e       # playwright
+pnpm test:coverage  # relatório HTML + gate 80%
+pnpm test:ci        # suite completa (roda no GitHub Actions)
+```
+
+**Gates de cobertura**
+
+- Total: **80%** de linhas.
+- `modules/**/services/**`: **95%**.
+- `modules/**/actions/**`: **85%**.
+- pgTAP: 100% dos arquivos passam.
+- Playwright: 100% dos cenários críticos.
+
+**Setup na Fase 1**
+
+A configuração do runner de testes faz parte do Sprint Zero — não é opcional:
+
+```bash
+pnpm add -D vitest @vitejs/plugin-react jsdom \
+  @testing-library/react @testing-library/user-event @testing-library/jest-dom \
+  @playwright/test @vitest/coverage-v8
+pnpm exec playwright install --with-deps
+```
+
+Adicionar `vitest.config.ts` com `projects` separados (`unit` e `integration`), e `playwright.config.ts` com fixtures de personas (Owner/Manager/Operator) a serem reutilizadas nos e2e.
 
 ### 8.6 Observabilidade
+
 - Vercel Analytics + Speed Insights.
 - `console.error` → `@sentry/nextjs` (pós-MVP).
 - Logs estruturados em Server Actions com `request_id` (UUID por request).
@@ -1192,6 +1396,7 @@ export const MODULES_MENU: MenuItem[] = [
 ## 9. Checklist Geral do MVP
 
 ### Fase 1 — Setup
+
 - [ ] `pnpm create next-app` executado com App Router + TS + Tailwind
 - [ ] Supabase SDK (`@supabase/supabase-js`, `@supabase/ssr`) instalado
 - [ ] Shadcn/UI inicializado e componentes base adicionados
@@ -1200,32 +1405,56 @@ export const MODULES_MENU: MenuItem[] = [
 - [ ] Clients Supabase (`server.ts`, `client.ts`) + `middleware.ts` protegendo rotas
 - [ ] Husky + lint-staged + Prettier configurados
 - [ ] Projeto conectado ao Git e à Vercel
+- [ ] **Runner de testes instalado:** Vitest + Testing Library + Playwright + @vitest/coverage-v8
+- [ ] **`vitest.config.ts` com projects `unit` e `integration`**
+- [ ] **`playwright.config.ts` com fixtures de personas (owner/manager/operator)**
+- [ ] **Pipeline CI (GitHub Actions) executa `test:ci` em todo PR**
+- [ ] **Teste "hello world" rodando em cada camada (unit / integration / e2e) para validar setup**
 
 ### Fase 2 — Banco
+
 - [ ] Projeto Supabase criado e linkado (`supabase link`)
 - [ ] Migrations criadas: `profiles`, `products`, `stock_movements`, RLS
 - [ ] Trigger `handle_new_user` funcionando
 - [ ] Trigger `apply_stock_movement` atualizando saldo
 - [ ] RLS habilitado e policies testadas (admin/manager/operator)
 - [ ] `src/types/database.types.ts` gerado via `pnpm db:types`
+- [ ] **pgTAP: `01_triggers.test.sql` cobre `apply_stock_movement` (entrada, saída, saída negativa → erro)**
+- [ ] **pgTAP: `02_triggers.test.sql` cobre `handle_new_user` (cria profile ao inserir auth.user)**
+- [ ] **pgTAP: `03_rls.test.sql` cobre policies de products e movements**
+- [ ] **`pnpm test:rls` passa no CI**
 
 ### Fase 3 — Auth
+
 - [ ] Server Actions: `signIn`, `signUp`, `signOut`, `recoverPassword`, `signInGoogle`
 - [ ] Google OAuth habilitado no Supabase (client/secret configurados)
 - [ ] Callback `/api/auth/callback` trocando code por sessão
 - [ ] Páginas `/login`, `/register`, `/recover` com formulários validados
 - [ ] Redirect para `/login` quando não autenticado (middleware)
 - [ ] `getCurrentUser()` exposto via `src/modules/auth/index.ts`
+- [ ] **Unit: `schemas/index.test.ts` cobre `signInSchema`, `signUpSchema`, `recoverSchema` (happy + edge cases)**
+- [ ] **Integration: `sign-in.test.ts` — credenciais válidas, inválidas, email não-confirmado**
+- [ ] **Integration: `sign-up.test.ts` — cria user + profile via trigger; rejeita senhas fracas**
+- [ ] **Integration: `recover-password.test.ts` — envia email mesmo para email inexistente (antienum)**
+- [ ] **Component: `sign-in-form.test.tsx` — exibe `fieldErrors`, desabilita submit durante pending**
+- [ ] **E2E: `auth.e2e.ts` — fluxo completo login → dashboard → logout**
 
 ### Fase 4 — Estoque (Backend)
+
 - [ ] Schemas Zod para `product` e `movement`
 - [ ] Actions: `createProduct`, `updateProduct`, `deleteProduct`, `registerMovement`
 - [ ] Queries: `listProducts` (paginado + busca), `getProduct`, `listMovements`
 - [ ] `stock-service.ts` com regras puras + testes unitários
 - [ ] `revalidatePath` em todas as mutações
 - [ ] Erros tratados e retornados como `ActionResult`
+- [ ] **Unit: `stock-service.test.ts` — `validateMovement` em todos os 4 cenários (in, out ok, out > stock, adjustment)**
+- [ ] **Integration: `create-product.test.ts` — sucesso, SKU duplicado, validação Zod, não-autenticado**
+- [ ] **Integration: `register-movement.test.ts` — entrada atualiza stock, saída insuficiente → erro, ajuste sobrescreve**
+- [ ] **Integration: `list-products.test.ts` — paginação, busca por nome/SKU, filtro `onlyActive`**
+- [ ] **Cobertura ≥ 95% em `services/`, ≥ 85% em `actions/`**
 
 ### Fase 5 — Estoque (Frontend)
+
 - [ ] Página `/inventory` (listagem paginada + busca)
 - [ ] Página `/inventory/new` (form de criação)
 - [ ] Página `/inventory/[id]` (detalhe + edição)
@@ -1234,28 +1463,37 @@ export const MODULES_MENU: MenuItem[] = [
 - [ ] Badge de "estoque baixo" quando `stock <= min_stock`
 - [ ] Toasts (Sonner) em sucesso/erro das actions
 - [ ] Layout `(dashboard)` com sidebar consumindo `MODULES_MENU`
+- [ ] **Component: `product-form.test.tsx` — validação, erros, estado pending**
+- [ ] **Component: `product-table.test.tsx` — render, badge "Baixo" quando aplicável, link para detalhe**
+- [ ] **Component: `movement-form.test.tsx` — seleção de produto, tipo, quantidade, submit**
+- [ ] **E2E: `inventory.e2e.ts` — criar produto → registrar entrada → ver saldo atualizado → registrar saída**
+- [ ] **E2E: `inventory-negative.e2e.ts` — tentar saída > estoque e confirmar mensagem de erro**
 
 ### Qualidade
+
 - [ ] `pnpm lint` sem erros
 - [ ] `pnpm typecheck` sem erros
 - [ ] Build Vercel (`pnpm build`) passando
-- [ ] Testes de serviços rodando no CI
-- [ ] README com passo-a-passo de setup local
+- [ ] **`pnpm test:ci` verde — unit + integration + pgTAP + e2e**
+- [ ] **Cobertura total ≥ 80% (gate no CI)**
+- [ ] **Nenhum teste `skip` ou `only` no main**
+- [ ] **Tempo total da suíte de testes ≤ 5 min em CI**
+- [ ] README com passo-a-passo de setup local **+ como rodar os testes**
 
 ---
 
 ## 10. Roadmap Pós-MVP
 
-| Ordem | Módulo | Notas |
-| :---: | :--- | :--- |
-| 1 | **Orçamentos** | `src/modules/quotes` — reaproveita `products` + `profiles`. |
-| 2 | **Clientes (CRM light)** | `src/modules/customers` — PF/PJ, contatos, endereços. |
-| 3 | **Fornecedores** | `src/modules/suppliers` — integra com movimentos de entrada. |
-| 4 | **Financeiro básico** | Contas a pagar/receber, conciliação manual. |
-| 5 | **Relatórios** | Curva ABC, giro de estoque, DRE gerencial. |
-| 6 | **Auditoria** | `audit_logs` + middleware para registrar actions. |
-| 7 | **Multi-tenant (Orgs)** | Coluna `org_id` em todas as tabelas + RLS por org. |
-| 8 | **Mobile (PWA)** | Leitura de código de barras para movimentações. |
+| Ordem | Módulo                   | Notas                                                        |
+| :---: | :----------------------- | :----------------------------------------------------------- |
+|   1   | **Orçamentos**           | `src/modules/quotes` — reaproveita `products` + `profiles`.  |
+|   2   | **Clientes (CRM light)** | `src/modules/customers` — PF/PJ, contatos, endereços.        |
+|   3   | **Fornecedores**         | `src/modules/suppliers` — integra com movimentos de entrada. |
+|   4   | **Financeiro básico**    | Contas a pagar/receber, conciliação manual.                  |
+|   5   | **Relatórios**           | Curva ABC, giro de estoque, DRE gerencial.                   |
+|   6   | **Auditoria**            | `audit_logs` + middleware para registrar actions.            |
+|   7   | **Multi-tenant (Orgs)**  | Coluna `org_id` em todas as tabelas + RLS por org.           |
+|   8   | **Mobile (PWA)**         | Leitura de código de barras para movimentações.              |
 
 Cada novo módulo segue o mesmo _blueprint_: migration própria → RLS → schemas → actions → queries → componentes → registro em `MODULES_MENU`. **Nenhum core é modificado.**
 

--- a/docs/PRICING-PLAN.md
+++ b/docs/PRICING-PLAN.md
@@ -1,0 +1,423 @@
+# Plano de Precificação — ERP
+
+> Documento de referência cobrindo (1) estratégia comercial de precificação e (2) blueprint técnico do módulo `billing` dentro da arquitetura do projeto (Next.js 15 + Supabase + RLS, padrão modular com `ActionResult`).
+
+---
+
+## Parte 1 — Estratégia comercial
+
+### 1.1. Princípios
+
+1. **Precificar por valor, não por custo.** O ERP reduz retrabalho, erros de estoque e atrasos fiscais. Ancore a mensagem em ROI (ex.: "evita R$ X em rupturas de estoque"), não em "R$ por funcionalidade".
+2. **Modelo híbrido em 3 camadas:** tier flat (pacote de features + limites) + seats (usuários extras) + overages (quando ultrapassar o limite de volume). Isso cobre os três modelos que você escolheu sem canibalizar nenhum.
+3. **Boa-escada (good / better / best / enterprise):** quatro tiers para criar "preço âncora", facilitar upsell e capturar desde a pequena loja até a grande operação.
+4. **Annual discount de 17–20%** (equivalente a "2 meses grátis") para previsibilidade de receita e redução de churn.
+5. **Trial de 14 dias** no Pro/Business (sem cartão) + **Free forever** limitado (entrada de funil).
+
+### 1.2. Tiers sugeridos
+
+| Plano          | Preço (mensal, anual) | Público           | Usuários inclusos | Limite de produtos | Movimentações/mês |
+| -------------- | --------------------- | ----------------- | ----------------- | ------------------ | ----------------- |
+| **Free**       | R$ 0                  | Teste / micro     | 1                 | 50                 | 200               |
+| **Starter**    | R$ 79 / R$ 790 ano    | Pequenas empresas | 3                 | 500                | 2.000             |
+| **Pro**        | R$ 249 / R$ 2.490 ano | Médias            | 10                | 5.000              | 20.000            |
+| **Business**   | R$ 599 / R$ 5.990 ano | Médias-grandes    | 25                | 50.000             | 200.000           |
+| **Enterprise** | Sob consulta          | Grandes           | Ilimitado         | Ilimitado          | Ilimitado + SLA   |
+
+**Add-ons transversais (qualquer plano pago):**
+
+- **Usuário adicional:** R$ 29/mês (Starter), R$ 39/mês (Pro), R$ 49/mês (Business).
+- **Overage de movimentação:** R$ 0,02 por movimentação acima do limite (ou upgrade automático sugerido).
+- **Integrações premium:** NF-e, marketplaces, ERP contábil — R$ 49–149/mês cada.
+- **Onboarding assistido:** R$ 990 one-time (obrigatório no Enterprise, opcional no Business).
+
+### 1.3. Matriz de features por tier (gating)
+
+| Feature                                     | Free | Starter |   Pro    | Business | Enterprise |
+| ------------------------------------------- | :--: | :-----: | :------: | :------: | :--------: |
+| Produtos e estoque                          |  ✓   |    ✓    |    ✓     |    ✓     |     ✓      |
+| Movimentações de estoque                    |  ✓   |    ✓    |    ✓     |    ✓     |     ✓      |
+| Relatórios básicos                          |  ✓   |    ✓    |    ✓     |    ✓     |     ✓      |
+| Controle de papéis (admin/manager/operator) |  —   |    ✓    |    ✓     |    ✓     |     ✓      |
+| Múltiplos depósitos                         |  —   |    —    |    ✓     |    ✓     |     ✓      |
+| Integração NF-e                             |  —   |    —    |  Add-on  |    ✓     |     ✓      |
+| API pública + Webhooks                      |  —   |    —    | Limitado |    ✓     |     ✓      |
+| Auditoria completa                          |  —   |    —    |    ✓     |    ✓     |     ✓      |
+| SSO (Google/Microsoft)                      |  —   |    —    |    —     |    ✓     |     ✓      |
+| Relatórios customizáveis / BI               |  —   |    —    |    —     |    ✓     |     ✓      |
+| SLA contratual                              |  —   |    —    |    —     |    —     |     ✓      |
+| Ambiente dedicado / on-premises             |  —   |    —    |    —     |    —     |     ✓      |
+| Gerente de conta                            |  —   |    —    |    —     |    —     |     ✓      |
+
+### 1.4. Posicionamento e comunicação
+
+- **Free** — "Experimente o ERP completo, sem cartão." (captura de leads, SEO, comunidade).
+- **Starter** — "Organize seu estoque e fiscal do seu jeito." (foco em dor: planilha caótica).
+- **Pro** — "Escale sem caos: múltiplos depósitos e auditoria." (marco de crescimento).
+- **Business** — "Operação madura com SSO, BI e integrações." (compras comitê, TI envolvido).
+- **Enterprise** — "Parceria estratégica: SLA, ambiente dedicado e customizações."
+
+### 1.5. Precificação psicológica
+
+- Preço-âncora: mostrar Business destacado na tabela, fazendo o Pro parecer "a escolha inteligente".
+- Terminações em 9 (79, 249, 599) — conversão ~15% maior que preços redondos em B2B SMB.
+- Exibir economia anual: "Economize R$ 598 pagando anual" em vez de "17% off".
+- Calculadora interativa de ROI no site (ex.: "quantas rupturas você evita?").
+
+### 1.6. Descontos e políticas
+
+- **Anual:** 17–20% off (padrão).
+- **ONGs/Educacional:** 50% off (mediante comprovação).
+- **Multi-empresa (grupo):** 10% a partir de 3 subscrições Business.
+- **Nunca negociar no Starter/Pro** (margem enxuta, canibalizaria o Business). Descontos só em Business/Enterprise, sempre com contrapartida (contrato 12m, case de sucesso, etc.).
+
+### 1.7. Roadmap de precificação
+
+1. **Mês 1–3:** Lançar Free + Starter + Pro. Validar willingness-to-pay. Não lance Business ainda.
+2. **Mês 4–6:** Com ~30 clientes pagantes, introduzir Business e medir conversão Pro→Business.
+3. **Mês 7+:** Enterprise sob consulta + expansion revenue (add-ons, overages). Revisar preços anualmente ajustando por IPCA e valor percebido.
+
+---
+
+## Parte 2 — Blueprint técnico (módulo `billing`)
+
+Seguindo a arquitetura definida em `CLAUDE.md`: cada feature em `src/modules/<domain>/` com barrel `index.ts`, Server Actions retornando `ActionResult`, queries com `"server-only"`, Zod nas entradas e RLS como camada de autoridade.
+
+### 2.1. Estrutura de pastas
+
+```
+src/modules/billing/
+├── actions/
+│   ├── subscribe.ts               # cria/atualiza assinatura (checkout)
+│   ├── change-plan.ts             # upgrade/downgrade
+│   ├── cancel-subscription.ts     # cancela ao fim do período
+│   ├── add-seat.ts                # adiciona usuário extra
+│   └── apply-coupon.ts
+├── queries/
+│   ├── get-current-subscription.ts
+│   ├── get-plan-catalog.ts
+│   ├── get-usage.ts               # consumo atual do período
+│   └── get-invoices.ts
+├── components/
+│   ├── pricing-table.tsx          # vitrine pública (4 tiers)
+│   ├── plan-card.tsx              # card isolado e reutilizável
+│   ├── usage-meter.tsx            # barra com limite/consumo
+│   ├── upgrade-cta.tsx            # CTA contextual quando perto do limite
+│   ├── plan-gate.tsx              # <PlanGate feature="multi_warehouse">…
+│   └── billing-portal-link.tsx
+├── services/
+│   ├── subscription-service.ts    # lógica pura de transição de plano
+│   ├── usage-service.ts           # cálculo de uso e overages
+│   ├── feature-gate.ts            # canUseFeature(orgId, key)
+│   └── price-calculator.ts        # seats + overages + desconto
+├── schemas/
+│   ├── subscription.ts
+│   └── checkout.ts
+├── types/
+│   └── index.ts                   # derivado de Database['public']['Tables']
+└── index.ts                       # barrel público
+```
+
+**Regra:** todo consumo externo importa por `@/modules/billing`, nunca `@/modules/billing/services/...` (regra já validada pelo ESLint do projeto).
+
+### 2.2. Modelo de dados (migrations Supabase)
+
+Arquivo sugerido: `supabase/migrations/20260424_01_billing.sql`.
+
+```sql
+-- Catálogo de planos (seed-controlled)
+create table public.plans (
+  id            text primary key,              -- 'free','starter','pro','business','enterprise'
+  name          text not null,
+  price_cents   integer not null,              -- preço mensal em centavos (BRL)
+  annual_cents  integer,                       -- preço anual em centavos
+  seats_included integer not null default 1,
+  extra_seat_cents integer,                    -- preço do seat adicional
+  product_limit integer,                       -- null = ilimitado
+  movement_limit integer,                      -- null = ilimitado
+  features      jsonb not null default '{}'::jsonb,
+  is_active     boolean not null default true,
+  sort_order    integer not null default 0
+);
+
+-- Assinaturas por organização
+create type public.subscription_status as enum
+  ('trialing','active','past_due','canceled','paused');
+
+create table public.subscriptions (
+  id                  uuid primary key default gen_random_uuid(),
+  org_id              uuid not null references public.organizations(id) on delete cascade,
+  plan_id             text not null references public.plans(id),
+  status              public.subscription_status not null default 'trialing',
+  billing_cycle       text not null check (billing_cycle in ('monthly','annual')),
+  seats               integer not null default 1,
+  current_period_start timestamptz not null,
+  current_period_end   timestamptz not null,
+  trial_end           timestamptz,
+  cancel_at_period_end boolean not null default false,
+  external_provider   text,                    -- 'stripe','iugu','asaas'
+  external_id         text,                    -- id da subscription no provider
+  created_at          timestamptz not null default now(),
+  updated_at          timestamptz not null default now(),
+  unique (org_id)                              -- 1 subscription ativa por org
+);
+
+-- Contadores de uso (reset por período)
+create table public.usage_counters (
+  org_id      uuid not null references public.organizations(id) on delete cascade,
+  metric      text not null,                   -- 'movements','products','api_calls'
+  period_start date not null,
+  value       bigint not null default 0,
+  primary key (org_id, metric, period_start)
+);
+
+-- Histórico de faturas (espelho do provider)
+create table public.invoices (
+  id            uuid primary key default gen_random_uuid(),
+  org_id        uuid not null references public.organizations(id) on delete cascade,
+  subscription_id uuid references public.subscriptions(id) on delete set null,
+  amount_cents  integer not null,
+  status        text not null,                 -- 'open','paid','failed'
+  external_id   text,
+  issued_at     timestamptz not null default now(),
+  paid_at       timestamptz
+);
+```
+
+**Triggers e funções:**
+
+```sql
+-- Helper: plano atual da org logada (use em RLS e queries)
+create or replace function public.current_org_plan()
+returns text language sql stable security definer as $$
+  select s.plan_id
+  from public.subscriptions s
+  join public.profiles p on p.org_id = s.org_id
+  where p.id = auth.uid() and s.status in ('trialing','active')
+  limit 1;
+$$;
+
+-- Trigger no stock_movements: incrementa contador de uso por período
+create or replace function public.increment_movement_usage()
+returns trigger language plpgsql security definer as $$
+declare
+  v_period date := date_trunc('month', now())::date;
+begin
+  insert into public.usage_counters (org_id, metric, period_start, value)
+  values (new.org_id, 'movements', v_period, 1)
+  on conflict (org_id, metric, period_start)
+    do update set value = usage_counters.value + 1;
+  return new;
+end;
+$$;
+
+create trigger trg_increment_movement_usage
+  after insert on public.stock_movements
+  for each row execute function public.increment_movement_usage();
+```
+
+### 2.3. RLS (autorização por tenant e por plano)
+
+```sql
+alter table public.subscriptions enable row level security;
+alter table public.usage_counters enable row level security;
+alter table public.invoices enable row level security;
+
+-- Leitura restrita à própria org
+create policy "subs_read_own_org" on public.subscriptions
+  for select using (
+    org_id = (select org_id from public.profiles where id = auth.uid())
+  );
+
+-- Apenas admin pode escrever (UI chama via Server Action; webhook do provider usa service_role)
+create policy "subs_write_admin" on public.subscriptions
+  for all using (
+    org_id = (select org_id from public.profiles where id = auth.uid())
+    and public.current_user_role() = 'admin'
+  );
+```
+
+**Gate de features no banco (defesa em profundidade):**
+
+```sql
+-- Bloqueia insert de produto se exceder limite do plano
+create or replace function public.enforce_product_limit()
+returns trigger language plpgsql as $$
+declare
+  v_limit integer;
+  v_count integer;
+begin
+  select p.product_limit into v_limit
+  from public.plans p
+  join public.subscriptions s on s.plan_id = p.id
+  where s.org_id = new.org_id and s.status in ('trialing','active');
+
+  if v_limit is null then return new; end if;
+
+  select count(*) into v_count from public.products where org_id = new.org_id;
+  if v_count >= v_limit then
+    raise exception 'Limite de produtos do plano atingido. Faça upgrade para continuar.'
+      using errcode = 'P0001';
+  end if;
+  return new;
+end;
+$$;
+
+create trigger trg_enforce_product_limit
+  before insert on public.products
+  for each row execute function public.enforce_product_limit();
+```
+
+### 2.4. Serviços (TS puro, testável)
+
+`src/modules/billing/services/feature-gate.ts`:
+
+```ts
+import "server-only";
+import type { FeatureKey, PlanId } from "../types";
+
+const MATRIX: Record<PlanId, ReadonlySet<FeatureKey>> = {
+  free: new Set(["basic_reports"]),
+  starter: new Set(["basic_reports", "roles"]),
+  pro: new Set(["basic_reports", "roles", "multi_warehouse", "audit_log", "api_basic"]),
+  business: new Set([
+    "basic_reports",
+    "roles",
+    "multi_warehouse",
+    "audit_log",
+    "api_full",
+    "sso",
+    "bi_reports",
+    "nfe",
+  ]),
+  enterprise: new Set(["*"]),
+};
+
+export function canUseFeature(plan: PlanId, feature: FeatureKey): boolean {
+  const set = MATRIX[plan];
+  return set.has("*" as FeatureKey) || set.has(feature);
+}
+```
+
+`src/modules/billing/services/price-calculator.ts`:
+
+```ts
+import "server-only";
+import type { Plan, BillingCycle } from "../types";
+
+const ANNUAL_DISCOUNT = 0.17;
+
+export function calculateTotal(args: {
+  plan: Plan;
+  cycle: BillingCycle;
+  extraSeats: number;
+  movementOverage: number;
+}): { subtotal: number; discount: number; total: number } {
+  const base =
+    args.cycle === "annual"
+      ? (args.plan.annual_cents ?? args.plan.price_cents * 12)
+      : args.plan.price_cents;
+
+  const seats = args.extraSeats * (args.plan.extra_seat_cents ?? 0);
+  const overage = args.movementOverage * 2; // R$ 0,02 por movimentação extra
+
+  const subtotal = base + seats + overage;
+  const discount =
+    args.cycle === "annual" ? Math.round(args.plan.price_cents * 12 * ANNUAL_DISCOUNT) : 0;
+
+  return { subtotal, discount, total: subtotal - discount };
+}
+```
+
+### 2.5. Server Actions (contrato `ActionResult`)
+
+`src/modules/billing/actions/change-plan.ts`:
+
+```ts
+"use server";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { getCurrentUser } from "@/modules/auth";
+import { createServerClient } from "@/lib/supabase/server";
+import { changePlanSchema } from "../schemas/subscription";
+import type { ActionResult } from "@/lib/errors";
+
+export async function changePlan(_: ActionResult, formData: FormData): Promise<ActionResult> {
+  const user = await getCurrentUser();
+  if (!user) return { ok: false, message: "Não autenticado." };
+
+  const parsed = changePlanSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  const supabase = await createServerClient();
+  const { error } = await supabase.rpc("change_subscription_plan", {
+    p_plan_id: parsed.data.planId,
+    p_cycle: parsed.data.cycle,
+  });
+
+  if (error) return { ok: false, message: error.message };
+  revalidatePath("/billing");
+  return { ok: true, message: "Plano atualizado." };
+}
+```
+
+### 2.6. Componentes (componentização + reuso)
+
+- **`<PricingTable />`** — recebe array de `Plan` e renderiza `<PlanCard />` para cada. Usada na landing pública e dentro do app.
+- **`<PlanCard variant="current" | "recommended" | "default" />`** — card isolado com preço, features e CTA.
+- **`<UsageMeter metric="movements" />`** — barra de progresso que vira amarela a 80% e vermelha a 95%, com link para upgrade.
+- **`<PlanGate feature="multi_warehouse" fallback={<UpgradeCTA />}>`** — HOC server-side para esconder/bloquear features por plano.
+- **`<UpgradeCTA context="movements_limit" />`** — CTA contextual, copy dinâmica de acordo com o motivo.
+
+### 2.7. Provider de pagamento
+
+Para pt-BR, recomendo priorizar **Iugu** ou **Asaas** (PIX + boleto + cartão, NF-e integrada). Stripe como segunda opção se o foco for internacional. Abstraia atrás de uma interface:
+
+```ts
+// src/modules/billing/services/payment-provider.ts
+export interface PaymentProvider {
+  createCheckout(args: CheckoutArgs): Promise<{ url: string }>;
+  cancelSubscription(externalId: string): Promise<void>;
+  handleWebhook(payload: unknown, signature: string): Promise<WebhookEvent>;
+}
+```
+
+Implementações concretas (`IuguProvider`, `StripeProvider`) ficam intercambiáveis. Webhook chega em `app/api/billing/webhook/route.ts` e usa `service_role` para atualizar `subscriptions` sem esbarrar em RLS.
+
+### 2.8. Integração com módulos existentes
+
+- **`modules/inventory`**: adicionar chamada a `assertWithinPlan('products' | 'movements', orgId)` nos serviços antes de `validateMovement`. O gate de banco (trigger) é a rede de segurança.
+- **`modules/auth`**: ao criar usuário via convite, chamar `assertWithinPlan('seats', orgId)`; se exceder, oferecer compra de seat extra.
+- **`core/navigation/menu.ts`**: adicionar entrada `{ id: 'billing', label: 'Planos e cobrança', roles: ['admin'] }`.
+
+### 2.9. Roadmap de implementação (sprints)
+
+1. **Sprint 1** — Migrations (`plans`, `subscriptions`, `usage_counters`, `invoices`), seed do catálogo, RLS básico, regeneração de `database.types.ts`.
+2. **Sprint 2** — Módulo `billing` com `feature-gate`, `price-calculator`, queries e action stub (sem provider ainda). `<PricingTable />` pública.
+3. **Sprint 3** — Integração com provider (Iugu/Stripe), webhook, checkout real, `<UsageMeter />` e gating nos módulos existentes.
+4. **Sprint 4** — Enterprise flow (orçamento manual), painel admin interno de métricas (MRR, churn, ARPU), testes E2E.
+
+---
+
+## Parte 3 — KPIs que você deve acompanhar
+
+| Métrica                             | Meta inicial           | Como medir                                   |
+| ----------------------------------- | ---------------------- | -------------------------------------------- |
+| **MRR** (Monthly Recurring Revenue) | Crescimento 10–15%/mês | Soma de `subscriptions.price` ativas         |
+| **ARPU** (Average Revenue per User) | ≥ R$ 180 após mês 6    | MRR / nº de orgs pagantes                    |
+| **Churn mensal**                    | < 5%                   | Orgs canceladas / ativas no início do mês    |
+| **Conversão Free → Pago**           | 3–5%                   | Orgs pagantes / Orgs criadas no Free         |
+| **Net Revenue Retention**           | > 100%                 | (MRR final + expansão − churn) / MRR inicial |
+| **Payback CAC**                     | < 12 meses             | CAC / (ARPU × margem)                        |
+
+---
+
+## Resumo executivo
+
+1. **Comece enxuto**: Free + Starter + Pro nos primeiros 3 meses. Não tente lançar 5 tiers de uma vez.
+2. **Modelo híbrido**: flat por plano + seats + overages — cobre os três modelos que você listou sem conflito.
+3. **Implemente `billing` como módulo isolado** no padrão do projeto (barrel, ActionResult, Zod, RLS).
+4. **Gate em duas camadas**: `feature-gate.ts` na UI/UX + triggers no Postgres como autoridade.
+5. **Meça MRR, churn e conversão Free→Pago** desde o dia 1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
@@ -1625,6 +1626,83 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
@@ -1964,6 +2042,30 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
@@ -1464,6 +1465,75 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.47.0",
         "class-variance-authority": "^0.7.1",
@@ -2078,6 +2079,76 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
       "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.47.0",
     "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/src/app/(dashboard)/[companySlug]/settings/general/company-settings-form.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/general/company-settings-form.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { updateCompanySettingsAction } from "@/modules/tenancy";
+import type { ActionResult } from "@/lib/errors";
+import type { Tables } from "@/types/database.types";
+
+type Company = Tables<"companies">;
+
+const initial: ActionResult = { ok: false };
+
+export function CompanySettingsForm({
+  company,
+  readOnly,
+}: {
+  company: Company;
+  readOnly: boolean;
+}) {
+  const [state, formAction] = useActionState(updateCompanySettingsAction, initial);
+  const fieldErrors = state.ok ? undefined : state.fieldErrors;
+
+  return (
+    <form action={formAction} className="space-y-6">
+      <input type="hidden" name="id" value={company.id} />
+
+      {!state.ok && state.message && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {state.message}
+        </div>
+      )}
+      {state.ok && state.message && (
+        <div className="rounded-md border border-green-500/50 bg-green-500/10 p-3 text-sm text-green-700">
+          {state.message}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="name">
+            Nome <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            id="name"
+            name="name"
+            required
+            disabled={readOnly}
+            defaultValue={company.name}
+            aria-invalid={!!fieldErrors?.name}
+          />
+          {fieldErrors?.name && <p className="text-sm text-red-600">{fieldErrors.name[0]}</p>}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="slug">Slug</Label>
+          <Input id="slug" value={company.slug} disabled readOnly />
+          <p className="text-xs text-muted-foreground">O slug não pode ser alterado.</p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="plan">
+            Plano <span className="text-red-500">*</span>
+          </Label>
+          <Select name="plan" defaultValue={company.plan} disabled={readOnly}>
+            <SelectTrigger id="plan">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="starter">Starter</SelectItem>
+              <SelectItem value="pro">Pro</SelectItem>
+              <SelectItem value="enterprise">Enterprise</SelectItem>
+            </SelectContent>
+          </Select>
+          {fieldErrors?.plan && <p className="text-sm text-red-600">{fieldErrors.plan[0]}</p>}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="document">CNPJ / CPF</Label>
+          <Input
+            id="document"
+            name="document"
+            placeholder="00.000.000/0001-00"
+            disabled={readOnly}
+            defaultValue={company.document ?? ""}
+          />
+          {fieldErrors?.document && (
+            <p className="text-sm text-red-600">{fieldErrors.document[0]}</p>
+          )}
+        </div>
+      </div>
+
+      {!readOnly && (
+        <div className="flex justify-end">
+          <SubmitButton />
+        </div>
+      )}
+    </form>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? "Salvando..." : "Salvar alterações"}
+    </Button>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/general/company-settings-form.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/general/company-settings-form.tsx
@@ -5,13 +5,6 @@ import { useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { updateCompanySettingsAction } from "@/modules/tenancy";
 import type { ActionResult } from "@/lib/errors";
 import type { Tables } from "@/types/database.types";
@@ -27,13 +20,12 @@ export function CompanySettingsForm({
   company: Company;
   readOnly: boolean;
 }) {
-  const [state, formAction] = useActionState(updateCompanySettingsAction, initial);
+  const boundAction = updateCompanySettingsAction.bind(null, company.id);
+  const [state, formAction] = useActionState(boundAction, initial);
   const fieldErrors = state.ok ? undefined : state.fieldErrors;
 
   return (
     <form action={formAction} className="space-y-6">
-      <input type="hidden" name="id" value={company.id} />
-
       {!state.ok && state.message && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
           {state.message}
@@ -68,20 +60,9 @@ export function CompanySettingsForm({
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="plan">
-            Plano <span className="text-red-500">*</span>
-          </Label>
-          <Select name="plan" defaultValue={company.plan} disabled={readOnly}>
-            <SelectTrigger id="plan">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="starter">Starter</SelectItem>
-              <SelectItem value="pro">Pro</SelectItem>
-              <SelectItem value="enterprise">Enterprise</SelectItem>
-            </SelectContent>
-          </Select>
-          {fieldErrors?.plan && <p className="text-sm text-red-600">{fieldErrors.plan[0]}</p>}
+          <Label htmlFor="plan">Plano</Label>
+          <Input id="plan" value={company.plan} disabled readOnly />
+          <p className="text-xs text-muted-foreground">O plano é gerenciado pela plataforma.</p>
         </div>
 
         <div className="space-y-2">

--- a/src/app/(dashboard)/[companySlug]/settings/general/company-settings-form.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/general/company-settings-form.tsx
@@ -5,7 +5,7 @@ import { useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { updateCompanySettingsAction } from "@/modules/tenancy";
+import { updateCompanySettingsAction } from "@/modules/tenancy/client";
 import type { ActionResult } from "@/lib/errors";
 import type { Tables } from "@/types/database.types";
 

--- a/src/app/(dashboard)/[companySlug]/settings/general/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/general/page.tsx
@@ -1,0 +1,40 @@
+import { notFound } from "next/navigation";
+import { resolveCompany } from "@/modules/tenancy";
+import { hasPermission } from "@/modules/authz";
+import { AppError } from "@/lib/errors";
+import { CompanySettingsForm } from "./company-settings-form";
+
+type Props = {
+  params: Promise<{ companySlug: string }>;
+};
+
+export const metadata = { title: "Configurações Gerais — ERP" };
+
+export default async function SettingsGeneralPage({ params }: Props) {
+  const { companySlug } = await params;
+
+  let company: Awaited<ReturnType<typeof resolveCompany>>;
+  try {
+    company = await resolveCompany(companySlug);
+  } catch (e) {
+    if (e instanceof AppError) notFound();
+    throw e;
+  }
+
+  const canUpdate = await hasPermission(company.id, "core:company:update");
+
+  return (
+    <section className="max-w-2xl space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">Dados da empresa</h2>
+        <p className="text-sm text-muted-foreground">
+          {canUpdate
+            ? "Edite as informações da empresa abaixo."
+            : "Você não tem permissão para editar os dados da empresa."}
+        </p>
+      </div>
+
+      <CompanySettingsForm company={company} readOnly={!canUpdate} />
+    </section>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/layout.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/layout.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { resolveCompany } from "@/modules/tenancy";
+import { AppError } from "@/lib/errors";
+
+type Props = {
+  children: ReactNode;
+  params: Promise<{ companySlug: string }>;
+};
+
+export default async function SettingsLayout({ children, params }: Props) {
+  const { companySlug } = await params;
+
+  let company: Awaited<ReturnType<typeof resolveCompany>>;
+  try {
+    company = await resolveCompany(companySlug);
+  } catch (e) {
+    if (e instanceof AppError) {
+      return <div className="p-8 text-center text-muted-foreground">{e.message}</div>;
+    }
+    throw e;
+  }
+
+  const tabs = [
+    { label: "Geral", href: `/${companySlug}/settings/general` },
+    { label: "Membros", href: `/${companySlug}/settings/members` },
+    { label: "Roles", href: `/${companySlug}/settings/roles` },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Configurações — {company.name}</h1>
+        <p className="text-sm text-muted-foreground">Gerencie os dados e membros da empresa</p>
+      </div>
+
+      <nav className="flex gap-1 border-b">
+        {tabs.map((tab) => (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className="px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+
+      {children}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/layout.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/layout.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import type { ReactNode } from "react";
 import { resolveCompany } from "@/modules/tenancy";
 import { AppError } from "@/lib/errors";
+import { SettingsTabs } from "./settings-tabs";
 
 type Props = {
   children: ReactNode;
@@ -21,12 +21,6 @@ export default async function SettingsLayout({ children, params }: Props) {
     throw e;
   }
 
-  const tabs = [
-    { label: "Geral", href: `/${companySlug}/settings/general` },
-    { label: "Membros", href: `/${companySlug}/settings/members` },
-    { label: "Roles", href: `/${companySlug}/settings/roles` },
-  ];
-
   return (
     <div className="space-y-6">
       <div>
@@ -34,17 +28,7 @@ export default async function SettingsLayout({ children, params }: Props) {
         <p className="text-sm text-muted-foreground">Gerencie os dados e membros da empresa</p>
       </div>
 
-      <nav className="flex gap-1 border-b">
-        {tabs.map((tab) => (
-          <Link
-            key={tab.href}
-            href={tab.href}
-            className="px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-          >
-            {tab.label}
-          </Link>
-        ))}
-      </nav>
+      <SettingsTabs slug={companySlug} />
 
       {children}
     </div>

--- a/src/app/(dashboard)/[companySlug]/settings/members/[memberId]/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/[memberId]/page.tsx
@@ -1,0 +1,92 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { resolveCompany, listCompanyMembers, listCompanyRoles } from "@/modules/tenancy";
+import { requirePermission, ForbiddenError } from "@/modules/authz";
+import { AppError } from "@/lib/errors";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { UpdateMemberRolesForm } from "./update-member-roles-form";
+
+export const metadata = { title: "Editar Membro — ERP" };
+
+type Props = {
+  params: Promise<{ companySlug: string; memberId: string }>;
+};
+
+export default async function MemberEditPage({ params }: Props) {
+  const { companySlug, memberId } = await params;
+
+  let company: Awaited<ReturnType<typeof resolveCompany>>;
+  try {
+    company = await resolveCompany(companySlug);
+  } catch (e) {
+    if (e instanceof AppError) notFound();
+    throw e;
+  }
+
+  try {
+    await requirePermission(company.id, "core:member:manage");
+  } catch (e) {
+    if (e instanceof ForbiddenError) {
+      return (
+        <div className="p-8 text-center text-muted-foreground">
+          Acesso negado: você não tem permissão para gerenciar membros.
+        </div>
+      );
+    }
+    throw e;
+  }
+
+  const [members, roles] = await Promise.all([
+    listCompanyMembers(company.id),
+    listCompanyRoles(company.id),
+  ]);
+
+  const member = members.find((m) => m.membershipId === memberId);
+  if (!member) notFound();
+
+  const currentRoleIds = member.roles.map((r) => r.id);
+
+  return (
+    <section className="max-w-lg space-y-6">
+      <div className="flex items-center gap-4">
+        <Button asChild variant="ghost" size="sm">
+          <Link href={`/${companySlug}/settings/members`}>← Membros</Link>
+        </Button>
+        <div>
+          <h2 className="text-lg font-semibold">{member.fullName}</h2>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span>Status:</span>
+            <Badge
+              variant={
+                member.status === "active"
+                  ? "default"
+                  : member.status === "invited"
+                    ? "secondary"
+                    : "destructive"
+              }
+            >
+              {member.status}
+            </Badge>
+            {member.isOwner && <Badge variant="outline">owner</Badge>}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="font-medium">Roles do membro</h3>
+        <p className="text-sm text-muted-foreground">
+          Selecione as roles que este membro deve ter nesta empresa.
+        </p>
+      </div>
+
+      <UpdateMemberRolesForm
+        companyId={company.id}
+        membershipId={memberId}
+        availableRoles={roles}
+        currentRoleIds={currentRoleIds}
+        backHref={`/${companySlug}/settings/members`}
+      />
+    </section>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/members/[memberId]/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/[memberId]/page.tsx
@@ -7,6 +7,13 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { UpdateMemberRolesForm } from "./update-member-roles-form";
 
+function statusLabel(status: string): string {
+  if (status === "active") return "Ativo";
+  if (status === "invited") return "Convidado";
+  if (status === "suspended") return "Suspenso";
+  return status;
+}
+
 export const metadata = { title: "Editar Membro — ERP" };
 
 type Props = {
@@ -66,7 +73,7 @@ export default async function MemberEditPage({ params }: Props) {
                     : "destructive"
               }
             >
-              {member.status}
+              {statusLabel(member.status)}
             </Badge>
             {member.isOwner && <Badge variant="outline">owner</Badge>}
           </div>

--- a/src/app/(dashboard)/[companySlug]/settings/members/[memberId]/update-member-roles-form.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/[memberId]/update-member-roles-form.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { updateMemberRolesAction } from "@/modules/tenancy";
+import { updateMemberRolesAction } from "@/modules/tenancy/client";
 import type { CompanyRole } from "@/modules/tenancy";
 
 type Props = {

--- a/src/app/(dashboard)/[companySlug]/settings/members/[memberId]/update-member-roles-form.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/[memberId]/update-member-roles-form.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { updateMemberRolesAction } from "@/modules/tenancy";
+import type { CompanyRole } from "@/modules/tenancy";
+
+type Props = {
+  companyId: string;
+  membershipId: string;
+  availableRoles: CompanyRole[];
+  currentRoleIds: string[];
+  backHref: string;
+};
+
+export function UpdateMemberRolesForm({
+  companyId,
+  membershipId,
+  availableRoles,
+  currentRoleIds,
+  backHref,
+}: Props) {
+  const router = useRouter();
+  const [selected, setSelected] = useState<string[]>(currentRoleIds);
+  const [message, setMessage] = useState<{ ok: boolean; text: string } | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function toggleRole(id: string) {
+    setSelected((prev) => (prev.includes(id) ? prev.filter((r) => r !== id) : [...prev, id]));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setMessage(null);
+    startTransition(async () => {
+      const result = await updateMemberRolesAction(companyId, membershipId, selected);
+      setMessage({ ok: result.ok, text: result.message ?? (result.ok ? "Salvo" : "Erro") });
+      if (result.ok) {
+        router.push(backHref);
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-2">
+        <Label>Roles disponíveis</Label>
+        {availableRoles.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Nenhuma role cadastrada nesta empresa.</p>
+        ) : (
+          <div className="space-y-2 rounded-md border p-4">
+            {availableRoles.map((role) => (
+              <label key={role.id} className="flex cursor-pointer items-center gap-3 text-sm">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4"
+                  checked={selected.includes(role.id)}
+                  onChange={() => toggleRole(role.id)}
+                />
+                <div>
+                  <span className="font-medium">{role.name}</span>
+                  {role.isSystem && (
+                    <span className="ml-2 rounded bg-muted px-1 py-0.5 text-xs text-muted-foreground">
+                      sistema
+                    </span>
+                  )}
+                </div>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {message && (
+        <p className={`text-sm ${message.ok ? "text-green-700" : "text-destructive"}`}>
+          {message.text}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push(backHref)}
+          disabled={isPending}
+        >
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Salvando..." : "Salvar roles"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/members/invite-member-dialog.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/invite-member-dialog.tsx
@@ -4,6 +4,13 @@ import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { inviteMemberAction } from "@/modules/tenancy";
 import type { CompanyRole } from "@/modules/tenancy";
 
@@ -41,18 +48,15 @@ export function InviteMemberDialog({ companyId, roles }: Props) {
     });
   }
 
-  if (!open) {
-    return (
-      <Button onClick={() => setOpen(true)} size="sm">
-        + Convidar membro
-      </Button>
-    );
-  }
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
-        <h3 className="mb-4 text-lg font-semibold">Convidar membro</h3>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm">+ Convidar membro</Button>
+      </DialogTrigger>
+      <DialogContent className="w-full max-w-md">
+        <DialogHeader>
+          <DialogTitle>Convidar membro</DialogTitle>
+        </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
@@ -111,7 +115,7 @@ export function InviteMemberDialog({ companyId, roles }: Props) {
             </Button>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/app/(dashboard)/[companySlug]/settings/members/invite-member-dialog.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/invite-member-dialog.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { inviteMemberAction } from "@/modules/tenancy";
+import type { CompanyRole } from "@/modules/tenancy";
+
+type Props = {
+  companyId: string;
+  roles: CompanyRole[];
+};
+
+export function InviteMemberDialog({ companyId, roles }: Props) {
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
+  const [message, setMessage] = useState<{ ok: boolean; text: string } | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function toggleRole(id: string) {
+    setSelectedRoles((prev) => (prev.includes(id) ? prev.filter((r) => r !== id) : [...prev, id]));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email) return;
+    setMessage(null);
+    startTransition(async () => {
+      const result = await inviteMemberAction(companyId, email, selectedRoles);
+      if (result.ok) {
+        setEmail("");
+        setSelectedRoles([]);
+        setOpen(false);
+      }
+      setMessage({
+        ok: result.ok,
+        text: result.message ?? (result.ok ? "Convite enviado" : "Erro"),
+      });
+    });
+  }
+
+  if (!open) {
+    return (
+      <Button onClick={() => setOpen(true)} size="sm">
+        + Convidar membro
+      </Button>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
+        <h3 className="mb-4 text-lg font-semibold">Convidar membro</h3>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="invite-email">
+              E-mail <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="invite-email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="usuario@exemplo.com"
+            />
+          </div>
+
+          {roles.length > 0 && (
+            <div className="space-y-2">
+              <Label>Roles</Label>
+              <div className="space-y-1">
+                {roles.map((role) => (
+                  <label key={role.id} className="flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4"
+                      checked={selectedRoles.includes(role.id)}
+                      onChange={() => toggleRole(role.id)}
+                    />
+                    {role.name}
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {message && (
+            <p className={`text-sm ${message.ok ? "text-green-700" : "text-destructive"}`}>
+              {message.text}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setOpen(false);
+                setMessage(null);
+              }}
+              disabled={isPending}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Enviando..." : "Enviar convite"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/members/invite-member-dialog.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/invite-member-dialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { inviteMemberAction } from "@/modules/tenancy";
+import { inviteMemberAction } from "@/modules/tenancy/client";
 import type { CompanyRole } from "@/modules/tenancy";
 
 type Props = {

--- a/src/app/(dashboard)/[companySlug]/settings/members/member-status-button.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/member-status-button.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
-import { updateMemberStatusAction } from "@/modules/tenancy";
+import { updateMemberStatusAction } from "@/modules/tenancy/client";
 
 type Props = {
   companyId: string;

--- a/src/app/(dashboard)/[companySlug]/settings/members/member-status-button.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/member-status-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { updateMemberStatusAction } from "@/modules/tenancy";
 
@@ -12,47 +12,53 @@ type Props = {
 
 export function MemberStatusButton({ companyId, membershipId, currentStatus }: Props) {
   const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
 
   function handleAction(status: "active" | "suspended" | "removed") {
+    setError(null);
     startTransition(async () => {
-      await updateMemberStatusAction(companyId, membershipId, status);
+      const result = await updateMemberStatusAction(companyId, membershipId, status);
+      if (!result.ok) setError(result.message ?? "Erro ao atualizar status");
     });
   }
 
   return (
-    <>
-      {currentStatus === "active" && (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-destructive hover:text-destructive"
-          disabled={isPending}
-          onClick={() => handleAction("suspended")}
-        >
-          Suspender
-        </Button>
-      )}
-      {currentStatus === "suspended" && (
-        <Button
-          variant="ghost"
-          size="sm"
-          disabled={isPending}
-          onClick={() => handleAction("active")}
-        >
-          Reativar
-        </Button>
-      )}
-      {(currentStatus === "invited" || currentStatus === "suspended") && (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-destructive hover:text-destructive"
-          disabled={isPending}
-          onClick={() => handleAction("removed")}
-        >
-          Remover
-        </Button>
-      )}
-    </>
+    <div className="flex flex-col items-end gap-1">
+      <div className="flex items-center gap-1">
+        {currentStatus === "active" && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            disabled={isPending}
+            onClick={() => handleAction("suspended")}
+          >
+            Suspender
+          </Button>
+        )}
+        {currentStatus === "suspended" && (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={isPending}
+            onClick={() => handleAction("active")}
+          >
+            Reativar
+          </Button>
+        )}
+        {(currentStatus === "invited" || currentStatus === "suspended") && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            disabled={isPending}
+            onClick={() => handleAction("removed")}
+          >
+            Remover
+          </Button>
+        )}
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
   );
 }

--- a/src/app/(dashboard)/[companySlug]/settings/members/member-status-button.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/member-status-button.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { updateMemberStatusAction } from "@/modules/tenancy";
+
+type Props = {
+  companyId: string;
+  membershipId: string;
+  currentStatus: string;
+};
+
+export function MemberStatusButton({ companyId, membershipId, currentStatus }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleAction(status: "active" | "suspended" | "removed") {
+    startTransition(async () => {
+      await updateMemberStatusAction(companyId, membershipId, status);
+    });
+  }
+
+  return (
+    <>
+      {currentStatus === "active" && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-destructive hover:text-destructive"
+          disabled={isPending}
+          onClick={() => handleAction("suspended")}
+        >
+          Suspender
+        </Button>
+      )}
+      {currentStatus === "suspended" && (
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={isPending}
+          onClick={() => handleAction("active")}
+        >
+          Reativar
+        </Button>
+      )}
+      {(currentStatus === "invited" || currentStatus === "suspended") && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-destructive hover:text-destructive"
+          disabled={isPending}
+          onClick={() => handleAction("removed")}
+        >
+          Remover
+        </Button>
+      )}
+    </>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/members/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/page.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { resolveCompany, listCompanyMembers, listCompanyRoles } from "@/modules/tenancy";
+import { Can } from "@/modules/authz";
+import { AppError } from "@/lib/errors";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { InviteMemberDialog } from "./invite-member-dialog";
+import { MemberStatusButton } from "./member-status-button";
+
+export const metadata = { title: "Membros — ERP" };
+
+type Props = {
+  params: Promise<{ companySlug: string }>;
+};
+
+function statusVariant(status: string): "default" | "secondary" | "destructive" {
+  if (status === "active") return "default";
+  if (status === "invited") return "secondary";
+  return "destructive";
+}
+
+function statusLabel(status: string): string {
+  if (status === "active") return "Ativo";
+  if (status === "invited") return "Convidado";
+  if (status === "suspended") return "Suspenso";
+  return status;
+}
+
+export default async function SettingsMembersPage({ params }: Props) {
+  const { companySlug } = await params;
+
+  let company: Awaited<ReturnType<typeof resolveCompany>>;
+  try {
+    company = await resolveCompany(companySlug);
+  } catch (e) {
+    if (e instanceof AppError) notFound();
+    throw e;
+  }
+
+  const [members, roles] = await Promise.all([
+    listCompanyMembers(company.id),
+    listCompanyRoles(company.id),
+  ]);
+
+  return (
+    <section className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Membros</h2>
+          <p className="text-sm text-muted-foreground">
+            {members.length} {members.length === 1 ? "membro" : "membros"} nesta empresa
+          </p>
+        </div>
+        <Can permission="core:member:invite">
+          <InviteMemberDialog companyId={company.id} roles={roles} />
+        </Can>
+      </div>
+
+      {members.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Nenhum membro cadastrado.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nome</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Roles</TableHead>
+              <TableHead>Entrou em</TableHead>
+              <TableHead className="w-[160px]">Ações</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {members.map((member) => (
+              <TableRow key={member.membershipId}>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{member.fullName}</span>
+                    {member.isOwner && (
+                      <Badge variant="outline" className="text-xs">
+                        owner
+                      </Badge>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={statusVariant(member.status)}>{statusLabel(member.status)}</Badge>
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1">
+                    {member.roles.map((role) => (
+                      <Badge key={role.id} variant="secondary" className="text-xs">
+                        {role.name}
+                      </Badge>
+                    ))}
+                    {member.roles.length === 0 && (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {member.joinedAt ? new Date(member.joinedAt).toLocaleDateString("pt-BR") : "—"}
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <Can permission="core:member:manage">
+                      <Button asChild variant="ghost" size="sm">
+                        <Link href={`/${companySlug}/settings/members/${member.membershipId}`}>
+                          Editar roles
+                        </Link>
+                      </Button>
+                      {!member.isOwner && (
+                        <MemberStatusButton
+                          companyId={company.id}
+                          membershipId={member.membershipId}
+                          currentStatus={member.status}
+                        />
+                      )}
+                    </Can>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </section>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/page.tsx
@@ -1,12 +1,18 @@
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
-import { resolveCompany, updateRoleAction } from "@/modules/tenancy";
+import {
+  resolveCompany,
+  updateRoleAction,
+  listRolePermissionMatrix,
+  updateRolePermissionsAction,
+} from "@/modules/tenancy";
 import { requirePermission, ForbiddenError } from "@/modules/authz";
 import { AppError } from "@/lib/errors";
 import { createClient } from "@/lib/supabase/server";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { RoleForm } from "../role-form";
+import { PermissionMatrix } from "./permission-matrix";
 
 export const metadata = { title: "Editar Role — ERP" };
 
@@ -45,6 +51,9 @@ export default async function EditRolePage({ params }: Props) {
 
   const backHref = `/${companySlug}/settings/roles`;
 
+  const matrix = await listRolePermissionMatrix(company.id, role.id);
+  const permAction = updateRolePermissionsAction.bind(null, company.id, role.id);
+
   if (role.is_system) {
     return (
       <section className="max-w-lg space-y-6">
@@ -75,8 +84,15 @@ export default async function EditRolePage({ params }: Props) {
           Role de sistema — não editável
         </p>
 
-        <div className="rounded-md border border-dashed p-4">
-          <p className="text-sm text-muted-foreground">Matriz de permissões — em breve (PR #35)</p>
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">Matriz de permissões</h3>
+          <PermissionMatrix
+            matrix={matrix}
+            roleId={role.id}
+            companyId={company.id}
+            isSystem={role.is_system}
+            action={permAction}
+          />
         </div>
       </section>
     );
@@ -106,8 +122,15 @@ export default async function EditRolePage({ params }: Props) {
         }}
       />
 
-      <div className="rounded-md border border-dashed p-4">
-        <p className="text-sm text-muted-foreground">Matriz de permissões — em breve (PR #35)</p>
+      <div className="space-y-2">
+        <h3 className="text-sm font-semibold">Matriz de permissões</h3>
+        <PermissionMatrix
+          matrix={matrix}
+          roleId={role.id}
+          companyId={company.id}
+          isSystem={role.is_system}
+          action={permAction}
+        />
       </div>
     </section>
   );

--- a/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/page.tsx
@@ -1,0 +1,107 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { resolveCompany, updateRoleAction } from "@/modules/tenancy";
+import { AppError } from "@/lib/errors";
+import { createClient } from "@/lib/supabase/server";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { RoleForm } from "../role-form";
+
+export const metadata = { title: "Editar Role — ERP" };
+
+type Props = {
+  params: Promise<{ companySlug: string; roleId: string }>;
+};
+
+export default async function EditRolePage({ params }: Props) {
+  const { companySlug, roleId } = await params;
+
+  let company: Awaited<ReturnType<typeof resolveCompany>>;
+  try {
+    company = await resolveCompany(companySlug);
+  } catch (e) {
+    if (e instanceof AppError) notFound();
+    throw e;
+  }
+
+  const supabase = await createClient();
+  const { data: role, error } = await supabase
+    .from("roles")
+    .select("id, code, name, description, is_system")
+    .eq("id", roleId)
+    .eq("company_id", company.id)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!role) notFound();
+
+  const backHref = `/${companySlug}/settings/roles`;
+
+  if (role.is_system) {
+    return (
+      <section className="max-w-lg space-y-6">
+        <div className="flex items-center gap-4">
+          <Button asChild variant="ghost" size="sm">
+            <Link href={backHref}>← Roles</Link>
+          </Button>
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold">{role.name}</h2>
+            <Badge variant="secondary">Sistema</Badge>
+          </div>
+        </div>
+
+        <div className="space-y-3 rounded-md border p-4">
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-muted-foreground">Código</p>
+            <p className="font-mono text-sm">{role.code}</p>
+          </div>
+          {role.description && (
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-muted-foreground">Descrição</p>
+              <p className="text-sm">{role.description}</p>
+            </div>
+          )}
+        </div>
+
+        <p className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+          Role de sistema — não editável
+        </p>
+
+        <div className="rounded-md border border-dashed p-4">
+          <p className="text-sm text-muted-foreground">Matriz de permissões — em breve (PR #35)</p>
+        </div>
+      </section>
+    );
+  }
+
+  const action = updateRoleAction.bind(null, company.id);
+
+  return (
+    <section className="max-w-lg space-y-6">
+      <div className="flex items-center gap-4">
+        <Button asChild variant="ghost" size="sm">
+          <Link href={backHref}>← Roles</Link>
+        </Button>
+        <div className="flex items-center gap-2">
+          <h2 className="text-lg font-semibold">Editar role</h2>
+          <Badge variant="outline">Custom</Badge>
+        </div>
+      </div>
+
+      <RoleForm
+        action={action}
+        backHref={backHref}
+        submitLabel="Salvar alterações"
+        defaultValues={{
+          roleId: role.id,
+          name: role.name,
+          description: role.description ?? undefined,
+        }}
+      />
+
+      <div className="rounded-md border border-dashed p-4">
+        <p className="text-sm text-muted-foreground">Matriz de permissões — em breve (PR #35)</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/page.tsx
@@ -1,6 +1,7 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { resolveCompany, updateRoleAction } from "@/modules/tenancy";
+import { requirePermission, ForbiddenError } from "@/modules/authz";
 import { AppError } from "@/lib/errors";
 import { createClient } from "@/lib/supabase/server";
 import { Button } from "@/components/ui/button";
@@ -21,6 +22,13 @@ export default async function EditRolePage({ params }: Props) {
     company = await resolveCompany(companySlug);
   } catch (e) {
     if (e instanceof AppError) notFound();
+    throw e;
+  }
+
+  try {
+    await requirePermission(company.id, "core:role:manage");
+  } catch (e) {
+    if (e instanceof ForbiddenError) redirect(`/${companySlug}/settings/roles`);
     throw e;
   }
 
@@ -74,7 +82,7 @@ export default async function EditRolePage({ params }: Props) {
     );
   }
 
-  const action = updateRoleAction.bind(null, company.id);
+  const action = updateRoleAction.bind(null, company.id, role.id);
 
   return (
     <section className="max-w-lg space-y-6">
@@ -93,7 +101,6 @@ export default async function EditRolePage({ params }: Props) {
         backHref={backHref}
         submitLabel="Salvar alterações"
         defaultValues={{
-          roleId: role.id,
           name: role.name,
           description: role.description ?? undefined,
         }}

--- a/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/permission-matrix.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/permission-matrix.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { Button } from "@/components/ui/button";
+import type { ActionResult } from "@/lib/errors";
+import type { ModulePermissions } from "@/modules/tenancy";
+
+type Props = {
+  matrix: ModulePermissions[];
+  roleId: string;
+  companyId: string;
+  isSystem: boolean;
+  action: (_prev: ActionResult, formData: FormData) => Promise<ActionResult>;
+};
+
+const initialState: ActionResult = { ok: false };
+
+function SubmitButton({ isSystem }: { isSystem: boolean }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={isSystem || pending}>
+      {pending ? "Salvando..." : "Salvar permissões"}
+    </Button>
+  );
+}
+
+export function PermissionMatrix({ matrix, isSystem, action }: Props) {
+  const [state, formAction] = useActionState(action, initialState);
+
+  if (matrix.length === 0) {
+    return (
+      <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+        Nenhum módulo habilitado nesta empresa.
+      </p>
+    );
+  }
+
+  return (
+    <form action={formAction} className="space-y-6">
+      {matrix.map((mod) => (
+        <div key={mod.moduleCode} className="space-y-3 rounded-md border p-4">
+          <h3 className="text-sm font-semibold">{mod.moduleName}</h3>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {mod.permissions.map((perm) => (
+              <label key={perm.code} className="flex cursor-pointer select-none items-start gap-2">
+                <input
+                  type="checkbox"
+                  name="permission_code"
+                  value={perm.code}
+                  defaultChecked={perm.granted}
+                  disabled={isSystem}
+                  className="mt-0.5 h-4 w-4 shrink-0 accent-primary"
+                />
+                <span className="text-sm leading-snug">
+                  <span className="font-medium capitalize">{perm.action}</span>
+                  {" — "}
+                  <span className="text-muted-foreground">{perm.description ?? perm.resource}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {!state.ok && state.message && <p className="text-sm text-destructive">{state.message}</p>}
+      {state.ok && state.message && <p className="text-sm text-green-700">{state.message}</p>}
+
+      <div className="flex justify-end">
+        <SubmitButton isSystem={isSystem} />
+      </div>
+    </form>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/permission-matrix.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/permission-matrix.tsx
@@ -43,7 +43,10 @@ export function PermissionMatrix({ matrix, isSystem, action }: Props) {
           <h3 className="text-sm font-semibold">{mod.moduleName}</h3>
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             {mod.permissions.map((perm) => (
-              <label key={perm.code} className="flex cursor-pointer select-none items-start gap-2">
+              <label
+                key={perm.code}
+                className={`flex select-none items-start gap-2 ${isSystem ? "cursor-not-allowed opacity-60" : "cursor-pointer"}`}
+              >
                 <input
                   type="checkbox"
                   name="permission_code"

--- a/src/app/(dashboard)/[companySlug]/settings/roles/delete-role-button.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/delete-role-button.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { deleteRoleAction } from "@/modules/tenancy";
+
+type Props = {
+  companyId: string;
+  roleId: string;
+  roleName: string;
+};
+
+export function DeleteRoleButton({ companyId, roleId, roleName }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleDelete() {
+    if (!window.confirm(`Tem certeza que deseja excluir a role "${roleName}"?`)) return;
+    setError(null);
+    startTransition(async () => {
+      const result = await deleteRoleAction(companyId, roleId);
+      if (!result.ok) setError(result.message ?? "Erro ao excluir role");
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-destructive hover:text-destructive"
+        disabled={isPending}
+        onClick={handleDelete}
+      >
+        {isPending ? "Excluindo..." : "Excluir"}
+      </Button>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/roles/delete-role-button.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/delete-role-button.tsx
@@ -2,6 +2,17 @@
 
 import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { deleteRoleAction } from "@/modules/tenancy";
 
 type Props = {
@@ -15,7 +26,6 @@ export function DeleteRoleButton({ companyId, roleId, roleName }: Props) {
   const [error, setError] = useState<string | null>(null);
 
   function handleDelete() {
-    if (!window.confirm(`Tem certeza que deseja excluir a role "${roleName}"?`)) return;
     setError(null);
     startTransition(async () => {
       const result = await deleteRoleAction(companyId, roleId);
@@ -25,15 +35,31 @@ export function DeleteRoleButton({ companyId, roleId, roleName }: Props) {
 
   return (
     <div className="flex flex-col items-end gap-1">
-      <Button
-        variant="ghost"
-        size="sm"
-        className="text-destructive hover:text-destructive"
-        disabled={isPending}
-        onClick={handleDelete}
-      >
-        {isPending ? "Excluindo..." : "Excluir"}
-      </Button>
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            disabled={isPending}
+          >
+            {isPending ? "Excluindo..." : "Excluir"}
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Excluir role</AlertDialogTitle>
+            <AlertDialogDescription>
+              Tem certeza que deseja excluir a role &quot;{roleName}&quot;? Esta ação não pode ser
+              desfeita.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete}>Excluir</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       {error && <p className="text-xs text-destructive">{error}</p>}
     </div>
   );

--- a/src/app/(dashboard)/[companySlug]/settings/roles/delete-role-button.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/delete-role-button.tsx
@@ -13,7 +13,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { deleteRoleAction } from "@/modules/tenancy";
+import { deleteRoleAction } from "@/modules/tenancy/client";
 
 type Props = {
   companyId: string;

--- a/src/app/(dashboard)/[companySlug]/settings/roles/new/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/new/page.tsx
@@ -1,0 +1,53 @@
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { resolveCompany, createRoleAction } from "@/modules/tenancy";
+import { requirePermission, ForbiddenError } from "@/modules/authz";
+import { AppError } from "@/lib/errors";
+import { Button } from "@/components/ui/button";
+import { RoleForm } from "../role-form";
+
+export const metadata = { title: "Nova Role — ERP" };
+
+type Props = {
+  params: Promise<{ companySlug: string }>;
+};
+
+export default async function NewRolePage({ params }: Props) {
+  const { companySlug } = await params;
+
+  let company: Awaited<ReturnType<typeof resolveCompany>>;
+  try {
+    company = await resolveCompany(companySlug);
+  } catch (e) {
+    if (e instanceof AppError) notFound();
+    throw e;
+  }
+
+  try {
+    await requirePermission(company.id, "core:role:manage");
+  } catch (e) {
+    if (e instanceof ForbiddenError) {
+      redirect(`/${companySlug}/settings/roles`);
+    }
+    throw e;
+  }
+
+  const action = createRoleAction.bind(null, company.id);
+
+  return (
+    <section className="max-w-lg space-y-6">
+      <div className="flex items-center gap-4">
+        <Button asChild variant="ghost" size="sm">
+          <Link href={`/${companySlug}/settings/roles`}>← Roles</Link>
+        </Button>
+        <h2 className="text-lg font-semibold">Nova role</h2>
+      </div>
+
+      <RoleForm
+        action={action}
+        backHref={`/${companySlug}/settings/roles`}
+        submitLabel="Criar role"
+      />
+    </section>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/roles/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/page.tsx
@@ -1,7 +1,10 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { resolveCompany, listCompanyRoles } from "@/modules/tenancy";
+import { hasPermission } from "@/modules/authz";
 import { AppError } from "@/lib/errors";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -10,6 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { DeleteRoleButton } from "./delete-role-button";
 
 export const metadata = { title: "Roles — ERP" };
 
@@ -28,15 +32,25 @@ export default async function SettingsRolesPage({ params }: Props) {
     throw e;
   }
 
-  const roles = await listCompanyRoles(company.id);
+  const [roles, canManage] = await Promise.all([
+    listCompanyRoles(company.id),
+    hasPermission(company.id, "core:role:manage"),
+  ]);
 
   return (
     <section className="space-y-6">
-      <div>
-        <h2 className="text-lg font-semibold">Roles</h2>
-        <p className="text-sm text-muted-foreground">
-          {roles.length} {roles.length === 1 ? "role" : "roles"} configuradas
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Roles</h2>
+          <p className="text-sm text-muted-foreground">
+            {roles.length} {roles.length === 1 ? "role" : "roles"} configuradas
+          </p>
+        </div>
+        {canManage && (
+          <Button asChild size="sm">
+            <Link href={`/${companySlug}/settings/roles/new`}>+ Nova role</Link>
+          </Button>
+        )}
       </div>
 
       {roles.length === 0 ? (
@@ -47,7 +61,9 @@ export default async function SettingsRolesPage({ params }: Props) {
             <TableRow>
               <TableHead>Nome</TableHead>
               <TableHead>Código</TableHead>
+              <TableHead>Descrição</TableHead>
               <TableHead>Tipo</TableHead>
+              {canManage && <TableHead className="w-[180px]">Ações</TableHead>}
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -57,13 +73,32 @@ export default async function SettingsRolesPage({ params }: Props) {
                 <TableCell className="font-mono text-sm text-muted-foreground">
                   {role.code}
                 </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {role.description ?? "—"}
+                </TableCell>
                 <TableCell>
                   {role.isSystem ? (
-                    <Badge variant="secondary">sistema</Badge>
+                    <Badge variant="secondary">Sistema</Badge>
                   ) : (
-                    <Badge variant="outline">personalizada</Badge>
+                    <Badge variant="outline">Custom</Badge>
                   )}
                 </TableCell>
+                {canManage && (
+                  <TableCell>
+                    {!role.isSystem && (
+                      <div className="flex items-center gap-1">
+                        <Button asChild variant="ghost" size="sm">
+                          <Link href={`/${companySlug}/settings/roles/${role.id}`}>Editar</Link>
+                        </Button>
+                        <DeleteRoleButton
+                          companyId={company.id}
+                          roleId={role.id}
+                          roleName={role.name}
+                        />
+                      </div>
+                    )}
+                  </TableCell>
+                )}
               </TableRow>
             ))}
           </TableBody>

--- a/src/app/(dashboard)/[companySlug]/settings/roles/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/page.tsx
@@ -1,0 +1,74 @@
+import { notFound } from "next/navigation";
+import { resolveCompany, listCompanyRoles } from "@/modules/tenancy";
+import { AppError } from "@/lib/errors";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export const metadata = { title: "Roles — ERP" };
+
+type Props = {
+  params: Promise<{ companySlug: string }>;
+};
+
+export default async function SettingsRolesPage({ params }: Props) {
+  const { companySlug } = await params;
+
+  let company: Awaited<ReturnType<typeof resolveCompany>>;
+  try {
+    company = await resolveCompany(companySlug);
+  } catch (e) {
+    if (e instanceof AppError) notFound();
+    throw e;
+  }
+
+  const roles = await listCompanyRoles(company.id);
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">Roles</h2>
+        <p className="text-sm text-muted-foreground">
+          {roles.length} {roles.length === 1 ? "role" : "roles"} configuradas
+        </p>
+      </div>
+
+      {roles.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Nenhuma role cadastrada.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nome</TableHead>
+              <TableHead>Código</TableHead>
+              <TableHead>Tipo</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {roles.map((role) => (
+              <TableRow key={role.id}>
+                <TableCell className="font-medium">{role.name}</TableCell>
+                <TableCell className="font-mono text-sm text-muted-foreground">
+                  {role.code}
+                </TableCell>
+                <TableCell>
+                  {role.isSystem ? (
+                    <Badge variant="secondary">sistema</Badge>
+                  ) : (
+                    <Badge variant="outline">personalizada</Badge>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </section>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/roles/role-form.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/role-form.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useActionState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { ActionResult } from "@/lib/errors";
+
+type Props = {
+  action: (_prev: ActionResult, formData: FormData) => Promise<ActionResult>;
+  backHref: string;
+  submitLabel: string;
+  defaultValues?: { name?: string; description?: string; roleId?: string };
+};
+
+const initialState: ActionResult = { ok: false };
+
+export function RoleForm({ action, backHref, submitLabel, defaultValues }: Props) {
+  const router = useRouter();
+  const [state, formAction, isPending] = useActionState(action, initialState);
+
+  useEffect(() => {
+    if (state.ok) {
+      router.push(backHref);
+    }
+  }, [state.ok, router, backHref]);
+
+  const fieldErrors = !state.ok ? (state.fieldErrors ?? {}) : {};
+
+  return (
+    <form action={formAction} className="space-y-6">
+      {defaultValues?.roleId && <input type="hidden" name="roleId" value={defaultValues.roleId} />}
+
+      <div className="space-y-2">
+        <Label htmlFor="name">Nome</Label>
+        <Input
+          id="name"
+          name="name"
+          defaultValue={defaultValues?.name ?? ""}
+          required
+          minLength={2}
+          maxLength={50}
+          placeholder="Ex.: Financeiro"
+        />
+        {fieldErrors.name && <p className="text-sm text-destructive">{fieldErrors.name[0]}</p>}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="description">Descrição (opcional)</Label>
+        <Textarea
+          id="description"
+          name="description"
+          defaultValue={defaultValues?.description ?? ""}
+          maxLength={200}
+          rows={3}
+          placeholder="Descreva o propósito desta role"
+        />
+        {fieldErrors.description && (
+          <p className="text-sm text-destructive">{fieldErrors.description[0]}</p>
+        )}
+      </div>
+
+      {!state.ok && state.message && <p className="text-sm text-destructive">{state.message}</p>}
+      {state.ok && state.message && <p className="text-sm text-green-700">{state.message}</p>}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push(backHref)}
+          disabled={isPending}
+        >
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Salvando..." : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/settings/roles/role-form.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/role-form.tsx
@@ -12,7 +12,7 @@ type Props = {
   action: (_prev: ActionResult, formData: FormData) => Promise<ActionResult>;
   backHref: string;
   submitLabel: string;
-  defaultValues?: { name?: string; description?: string; roleId?: string };
+  defaultValues?: { name?: string; description?: string };
 };
 
 const initialState: ActionResult = { ok: false };
@@ -31,8 +31,6 @@ export function RoleForm({ action, backHref, submitLabel, defaultValues }: Props
 
   return (
     <form action={formAction} className="space-y-6">
-      {defaultValues?.roleId && <input type="hidden" name="roleId" value={defaultValues.roleId} />}
-
       <div className="space-y-2">
         <Label htmlFor="name">Nome</Label>
         <Input

--- a/src/app/(dashboard)/[companySlug]/settings/settings-tabs.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/settings-tabs.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+export function SettingsTabs({ slug }: { slug: string }) {
+  const pathname = usePathname();
+  const tabs = [
+    { label: "Geral", href: `/${slug}/settings/general` },
+    { label: "Membros", href: `/${slug}/settings/members` },
+    { label: "Roles", href: `/${slug}/settings/roles` },
+  ];
+  return (
+    <nav className="mb-6 flex gap-4 border-b">
+      {tabs.map((tab) => (
+        <Link
+          key={tab.href}
+          href={tab.href}
+          className={cn(
+            "-mb-px border-b-2 pb-2 text-sm font-medium",
+            pathname.startsWith(tab.href)
+              ? "border-primary text-primary"
+              : "border-transparent text-muted-foreground",
+          )}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/src/app/(dashboard)/admin/audit/page.tsx
+++ b/src/app/(dashboard)/admin/audit/page.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import { listAuditLogsGlobal, AuditLogTable } from "@/modules/audit";
+import { listAllCompanies } from "@/modules/tenancy";
+
+type Props = {
+  searchParams: Promise<{ companyId?: string; action?: string; status?: string }>;
+};
+
+export default async function GlobalAuditPage({ searchParams }: Props) {
+  const filters = await searchParams;
+  const [logs, companies] = await Promise.all([
+    listAuditLogsGlobal({
+      companyId: filters.companyId,
+      action: filters.action,
+      status: filters.status,
+    }),
+    listAllCompanies(),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Auditoria Global</h1>
+        <p className="text-sm text-muted-foreground">
+          Todos os eventos da plataforma — {logs.length} registros
+        </p>
+      </div>
+
+      <form className="flex flex-wrap gap-3">
+        <select
+          name="companyId"
+          defaultValue={filters.companyId ?? ""}
+          className="rounded-md border bg-background px-3 py-2 text-sm"
+        >
+          <option value="">Todas as empresas</option>
+          {companies.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+
+        <input
+          name="action"
+          defaultValue={filters.action ?? ""}
+          placeholder="Filtrar por ação..."
+          className="rounded-md border bg-background px-3 py-2 text-sm"
+        />
+
+        <select
+          name="status"
+          defaultValue={filters.status ?? ""}
+          className="rounded-md border bg-background px-3 py-2 text-sm"
+        >
+          <option value="">Todos os status</option>
+          <option value="success">success</option>
+          <option value="denied">denied</option>
+          <option value="error">error</option>
+        </select>
+
+        <button
+          type="submit"
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Filtrar
+        </button>
+
+        {(filters.companyId || filters.action || filters.status) && (
+          <Link
+            href="/admin/audit"
+            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+          >
+            Limpar
+          </Link>
+        )}
+      </form>
+
+      <AuditLogTable logs={logs} />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/companies/[id]/layout.tsx
+++ b/src/app/(dashboard)/admin/companies/[id]/layout.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ id: string }>;
+};
+
+export default async function CompanyAdminLayout({ children, params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: company, error } = await supabase
+    .from("companies")
+    .select("id, name, slug, is_active, plan")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error || !company) notFound();
+
+  const tabs = [
+    { label: "Visão geral", href: `/admin/companies/${id}` },
+    { label: "Módulos", href: `/admin/companies/${id}/modules` },
+    { label: "Membros", href: `/admin/companies/${id}/members` },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button asChild variant="ghost" size="sm">
+          <Link href="/admin/companies">← Empresas</Link>
+        </Button>
+        <div className="flex items-center gap-3">
+          <div>
+            <h1 className="text-2xl font-bold">{company.name}</h1>
+            <p className="font-mono text-sm text-muted-foreground">{company.slug}</p>
+          </div>
+          <Badge variant={company.is_active ? "default" : "secondary"}>
+            {company.is_active ? "Ativa" : "Inativa"}
+          </Badge>
+          <Badge variant="outline" className="capitalize">
+            {company.plan}
+          </Badge>
+        </div>
+      </div>
+
+      <nav className="flex gap-1 border-b">
+        {tabs.map((tab) => (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className="px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+
+      {children}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/companies/[id]/members/page.tsx
+++ b/src/app/(dashboard)/admin/companies/[id]/members/page.tsx
@@ -1,0 +1,94 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { listCompanyMembers } from "@/modules/tenancy";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+function statusVariant(status: string): "default" | "secondary" | "destructive" {
+  if (status === "active") return "default";
+  if (status === "invited") return "secondary";
+  return "destructive";
+}
+
+export default async function CompanyMembersPage({ params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: company } = await supabase
+    .from("companies")
+    .select("id")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (!company) notFound();
+
+  const members = await listCompanyMembers(id);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Membros</h2>
+        <p className="text-sm text-muted-foreground">
+          {members.length} {members.length === 1 ? "membro" : "membros"} nesta empresa
+        </p>
+      </div>
+
+      {members.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Nenhum membro cadastrado.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nome</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Roles</TableHead>
+              <TableHead>Entrou em</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {members.map((member) => (
+              <TableRow key={member.membershipId}>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{member.fullName}</span>
+                    {member.isOwner && (
+                      <Badge variant="outline" className="text-xs">
+                        owner
+                      </Badge>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={statusVariant(member.status)}>{member.status}</Badge>
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1">
+                    {member.roles.map((role) => (
+                      <Badge key={role.id} variant="secondary" className="text-xs">
+                        {role.name}
+                      </Badge>
+                    ))}
+                  </div>
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {member.joinedAt ? new Date(member.joinedAt).toLocaleDateString("pt-BR") : "—"}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/companies/[id]/modules/page.tsx
+++ b/src/app/(dashboard)/admin/companies/[id]/modules/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { listCompanyModules, ModuleToggleList } from "@/modules/tenancy";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function CompanyModulesPage({ params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: company } = await supabase
+    .from("companies")
+    .select("id")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (!company) notFound();
+
+  const modules = await listCompanyModules(id);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Módulos</h2>
+        <p className="text-sm text-muted-foreground">
+          Habilite ou desabilite módulos para esta empresa. Alterações refletem imediatamente nas
+          permissões das roles-sistema.
+        </p>
+      </div>
+      <ModuleToggleList companyId={id} modules={modules} />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/companies/[id]/page.tsx
+++ b/src/app/(dashboard)/admin/companies/[id]/page.tsx
@@ -3,41 +3,74 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { UpdateCompanyForm } from "@/modules/tenancy";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 type Props = {
   params: Promise<{ id: string }>;
 };
 
-/**
- * Página de edição de empresa — /admin/companies/[id]
- */
-export default async function EditCompanyPage({ params }: Props) {
+export default async function CompanyOverviewPage({ params }: Props) {
   const { id } = await params;
-
   const supabase = await createClient();
-  const { data: company, error } = await supabase
-    .from("companies")
-    .select("*")
-    .eq("id", id)
-    .maybeSingle();
 
-  if (error || !company) {
-    notFound();
-  }
+  const [
+    { data: company, error },
+    { count: membersCount },
+    { count: modulesCount },
+    { count: logsCount },
+  ] = await Promise.all([
+    supabase.from("companies").select("*").eq("id", id).maybeSingle(),
+    supabase.from("memberships").select("*", { count: "exact", head: true }).eq("company_id", id),
+    supabase
+      .from("company_modules")
+      .select("*", { count: "exact", head: true })
+      .eq("company_id", id),
+    supabase.from("audit_logs").select("*", { count: "exact", head: true }).eq("company_id", id),
+  ]);
+
+  if (error || !company) notFound();
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-4">
-        <Button asChild variant="ghost" size="sm">
-          <Link href="/admin/companies">← Voltar</Link>
-        </Button>
-        <div>
-          <h1 className="text-2xl font-bold">Editar empresa</h1>
-          <p className="font-mono text-sm text-muted-foreground">{company.slug}</p>
-        </div>
+      <div className="grid grid-cols-3 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Membros</CardTitle>
+          </CardHeader>
+          <CardContent className="flex items-center justify-between">
+            <span className="text-2xl font-bold">{membersCount ?? 0}</span>
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/admin/companies/${id}/members`}>Ver</Link>
+            </Button>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Módulos ativos
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex items-center justify-between">
+            <span className="text-2xl font-bold">{modulesCount ?? 0}</span>
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/admin/companies/${id}/modules`}>Gerenciar</Link>
+            </Button>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Eventos auditados
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span className="text-2xl font-bold">{logsCount ?? 0}</span>
+          </CardContent>
+        </Card>
       </div>
 
       <div className="max-w-2xl">
+        <h2 className="mb-4 text-lg font-semibold">Dados da empresa</h2>
         <UpdateCompanyForm company={company} />
       </div>
     </div>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -30,8 +31,7 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn("rounded-xl border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn("flex flex-col space-y-1.5 p-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="card-content" className={cn("p-6 pt-0", className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center p-6 pt-0", className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+
+import { cn } from "@/lib/utils";
+
+function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "shadow-xs peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block size-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/core/navigation/menu.ts
+++ b/src/core/navigation/menu.ts
@@ -24,6 +24,12 @@ export const MODULES_MENU: MenuItem[] = [
     requiresPermission: "movements:movement:read",
   },
   { label: "Auditoria", href: "/audit", requiresSlug: true, requiresPermission: "core:audit:read" },
+  {
+    label: "Configurações",
+    href: "/settings/general",
+    requiresSlug: true,
+    requiresPermission: "core:company:update",
+  },
 ];
 
 export const ADMIN_MENU: MenuItem[] = [

--- a/src/core/navigation/menu.ts
+++ b/src/core/navigation/menu.ts
@@ -26,4 +26,7 @@ export const MODULES_MENU: MenuItem[] = [
   { label: "Auditoria", href: "/audit", requiresSlug: true, requiresPermission: "core:audit:read" },
 ];
 
-export const ADMIN_MENU: MenuItem[] = [{ label: "Empresas", href: "/admin/companies" }];
+export const ADMIN_MENU: MenuItem[] = [
+  { label: "Empresas", href: "/admin/companies" },
+  { label: "Auditoria Global", href: "/admin/audit" },
+];

--- a/src/lib/supabase/service.ts
+++ b/src/lib/supabase/service.ts
@@ -1,0 +1,10 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database.types";
+import { env } from "@/core/config/env";
+
+export function createServiceClient() {
+  return createClient<Database>(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.SUPABASE_SERVICE_ROLE_KEY as string,
+  );
+}

--- a/src/modules/audit/index.ts
+++ b/src/modules/audit/index.ts
@@ -2,5 +2,7 @@
 
 export { audit } from "./services/audit-service";
 export { listAuditLogs } from "./queries/list-audit-logs";
+export { listAuditLogsGlobal } from "./queries/list-audit-logs-global";
 export type { AuditLog } from "./queries/list-audit-logs";
+export type { GlobalAuditFilters } from "./queries/list-audit-logs-global";
 export { AuditLogTable } from "./components/audit-log-table";

--- a/src/modules/audit/queries/list-audit-logs-global.ts
+++ b/src/modules/audit/queries/list-audit-logs-global.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+import type { AuditLog } from "./list-audit-logs";
+
+export type { AuditLog };
+
+export type GlobalAuditFilters = {
+  companyId?: string;
+  action?: string;
+  status?: string;
+};
+
+export async function listAuditLogsGlobal(filters: GlobalAuditFilters = {}): Promise<AuditLog[]> {
+  const supabase = await createClient();
+
+  let query = supabase
+    .from("audit_logs")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(500);
+
+  if (filters.companyId) query = query.eq("company_id", filters.companyId);
+  if (filters.action) query = query.ilike("action", `%${filters.action}%`);
+  if (filters.status) query = query.eq("status", filters.status);
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return data ?? [];
+}

--- a/src/modules/tenancy/actions/__tests__/create-company.test.ts
+++ b/src/modules/tenancy/actions/__tests__/create-company.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mocks declarados antes dos imports que os consomem
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/modules/audit", () => ({ audit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@supabase/supabase-js", () => ({ createClient: vi.fn() }));
+vi.mock("@/core/config/env", () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: "http://localhost:54321",
+    SUPABASE_SERVICE_ROLE_KEY: undefined, // sem service role nos testes
+    NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+  },
+}));
+
+import { createClient } from "@/lib/supabase/server";
+import { createCompanyAction } from "../create-company";
+import type { ActionResult } from "@/lib/errors";
+
+// Estado anterior vazio usado como primeiro arg de useActionState
+const PREV: ActionResult = { ok: false };
+
+// -------------------------------------------------------------------
+// Helpers para construir FormData de teste
+// -------------------------------------------------------------------
+function makeValidFormData(overrides: Record<string, string | string[]> = {}) {
+  const fd = new FormData();
+  fd.append("name", "Acme Ltda");
+  fd.append("slug", "acme-ltda");
+  fd.append("plan", "starter");
+  fd.append("modules", "inventory");
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (Array.isArray(value)) {
+      for (const v of value) fd.append(key, v);
+    } else {
+      fd.set(key, value);
+    }
+  }
+  return fd;
+}
+
+// -------------------------------------------------------------------
+// Fábrica de mock do Supabase — constrói chains por tabela
+// -------------------------------------------------------------------
+type SupabaseMockOptions = {
+  isPlatformAdmin?: boolean;
+  rpcError?: { message: string } | null;
+  companyInsertError?: { message: string } | null;
+  companyId?: string;
+  modulesInsertError?: { message: string } | null;
+  rbacError?: { message: string } | null;
+};
+
+function makeSupabaseMock({
+  isPlatformAdmin = true,
+  rpcError = null,
+  companyInsertError = null,
+  companyId = "company-uuid-1",
+  modulesInsertError = null,
+  rbacError = null,
+}: SupabaseMockOptions = {}) {
+  // Chain para companies: .insert().select().single()
+  const companiesSingle = vi
+    .fn()
+    .mockResolvedValue(
+      companyInsertError
+        ? { data: null, error: companyInsertError }
+        : { data: { id: companyId }, error: null },
+    );
+  const companiesSelect = vi.fn().mockReturnValue({ single: companiesSingle });
+  const companiesInsert = vi.fn().mockReturnValue({ select: companiesSelect });
+
+  // Chain para company_modules: .insert() terminal
+  const companyModulesInsert = vi
+    .fn()
+    .mockResolvedValue(
+      modulesInsertError ? { data: null, error: modulesInsertError } : { data: null, error: null },
+    );
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } }, error: null }),
+    },
+    rpc: vi.fn().mockImplementation((name: string) => {
+      if (name === "is_platform_admin") {
+        return Promise.resolve({ data: isPlatformAdmin, error: rpcError });
+      }
+      if (name === "bootstrap_company_rbac") {
+        return Promise.resolve({ data: null, error: rbacError });
+      }
+      return Promise.resolve({ data: null, error: null });
+    }),
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "companies") {
+        return { insert: companiesInsert };
+      }
+      if (table === "company_modules") {
+        return { insert: companyModulesInsert };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    }),
+  };
+}
+
+// -------------------------------------------------------------------
+// Testes
+// -------------------------------------------------------------------
+describe("createCompanyAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retorna { ok: false } e lança AppError quando usuário não é platform admin", async () => {
+    const mock = makeSupabaseMock({ isPlatformAdmin: false });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    await expect(createCompanyAction(PREV, makeValidFormData())).rejects.toThrow("Acesso negado");
+  });
+
+  it("retorna { ok: false, fieldErrors } com FormData sem name e sem slug", async () => {
+    const mock = makeSupabaseMock({ isPlatformAdmin: true });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = new FormData();
+    // Omite name e slug propositalmente; plan também inválido
+    const result = await createCompanyAction(PREV, fd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.fieldErrors).toBeDefined();
+      expect(result.fieldErrors?.name).toBeDefined();
+      expect(result.fieldErrors?.slug).toBeDefined();
+    }
+  });
+
+  it("retorna { ok: false, fieldErrors } com FormData sem módulos selecionados", async () => {
+    const mock = makeSupabaseMock({ isPlatformAdmin: true });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    // FormData válido exceto sem modules
+    const fd = new FormData();
+    fd.append("name", "Empresa X");
+    fd.append("slug", "empresa-x");
+    fd.append("plan", "starter");
+    // modules omitido
+
+    const result = await createCompanyAction(PREV, fd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.fieldErrors?.modules).toBeDefined();
+    }
+  });
+
+  it("retorna { ok: false, message } quando insert em companies falha por slug duplicado", async () => {
+    const mock = makeSupabaseMock({
+      isPlatformAdmin: true,
+      companyInsertError: {
+        message: 'duplicate key value violates unique constraint "companies_slug_key"',
+      },
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await createCompanyAction(PREV, makeValidFormData());
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Já existe uma empresa com este slug");
+    }
+  });
+
+  it("retorna { ok: false, message } quando insert em companies falha por erro genérico", async () => {
+    const mock = makeSupabaseMock({
+      isPlatformAdmin: true,
+      companyInsertError: { message: "Erro interno no banco de dados" },
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await createCompanyAction(PREV, makeValidFormData());
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Erro interno no banco de dados");
+    }
+  });
+
+  it("retorna { ok: true } com FormData válido (name, slug, plan, modules)", async () => {
+    const mock = makeSupabaseMock({ isPlatformAdmin: true });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await createCompanyAction(PREV, makeValidFormData({ modules: ["inventory"] }));
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message).toContain("Acme Ltda");
+    }
+  });
+
+  it("retorna { ok: true } com múltiplos módulos selecionados", async () => {
+    const mock = makeSupabaseMock({ isPlatformAdmin: true });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await createCompanyAction(
+      PREV,
+      makeValidFormData({ modules: ["inventory", "movements"] }),
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("retorna { ok: false, message } quando bootstrap_company_rbac falha", async () => {
+    const mock = makeSupabaseMock({
+      isPlatformAdmin: true,
+      rbacError: { message: "Falha ao inicializar RBAC" },
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await createCompanyAction(PREV, makeValidFormData());
+
+    expect(mock.from).toHaveBeenCalledWith("companies");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Falha ao inicializar RBAC");
+    }
+  });
+});

--- a/src/modules/tenancy/actions/__tests__/create-role.test.ts
+++ b/src/modules/tenancy/actions/__tests__/create-role.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/modules/audit", () => ({ audit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/modules/authz", () => ({
+  requirePermission: vi.fn().mockResolvedValue(undefined),
+  ForbiddenError: class ForbiddenError extends Error {
+    constructor(public permission: string) {
+      super(`forbidden:${permission}`);
+    }
+  },
+}));
+
+import { createClient } from "@/lib/supabase/server";
+import { requirePermission } from "@/modules/authz";
+import { createRoleAction } from "../create-role";
+
+// -------------------------------------------------------------------
+// Sequência de produção (create-role.ts):
+//   1. requirePermission(companyId, "core:role:manage")
+//   2. createRoleSchema.safeParse(formData)
+//   3. createClient() → roles.insert().select("id").single()
+//   4. audit()
+//   5. revalidatePath()
+// -------------------------------------------------------------------
+
+type RoleMockOptions = {
+  insertError?: { message: string; code?: string } | null;
+  roleId?: string;
+};
+
+function makeSupabaseMock({ insertError = null, roleId = "role-new-id" }: RoleMockOptions = {}) {
+  // roles: .insert().select("id").single() — terminal
+  const rolesSingle = vi
+    .fn()
+    .mockResolvedValue(
+      insertError ? { data: null, error: insertError } : { data: { id: roleId }, error: null },
+    );
+  const rolesInsertSelect = vi.fn().mockReturnValue({ single: rolesSingle });
+  const rolesInsert = vi.fn().mockReturnValue({ select: rolesInsertSelect });
+
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "roles") {
+        return { insert: rolesInsert };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    }),
+    rolesInsert,
+  };
+
+  return mockClient;
+}
+
+function makeFormData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    fd.append(key, value);
+  }
+  return fd;
+}
+
+describe("createRoleAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retorna { ok: false } quando core:role:manage é negado", async () => {
+    // Arrange
+    vi.mocked(requirePermission).mockRejectedValueOnce(new Error("forbidden:core:role:manage"));
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Nova Role" });
+
+    // Act
+    const result = await createRoleAction("company-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("permissão");
+    }
+  });
+
+  it("retorna { ok: false, fieldErrors } quando name está vazio (FormData inválido)", async () => {
+    // Arrange
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "" });
+
+    // Act
+    const result = await createRoleAction("company-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.fieldErrors).toBeDefined();
+      expect(result.fieldErrors?.name).toBeDefined();
+    }
+  });
+
+  it("retorna { ok: false } quando name é muito curto (< 2 caracteres)", async () => {
+    // Arrange
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "A" });
+
+    // Act
+    const result = await createRoleAction("company-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.fieldErrors).toBeDefined();
+    }
+  });
+
+  it("retorna { ok: false, message } quando insert falha por conflito de code (23505)", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({
+      insertError: { message: "duplicate key value", code: "23505" },
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Gerente" });
+
+    // Act
+    const result = await createRoleAction("company-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("nome");
+    }
+  });
+
+  it("retorna { ok: false, message } quando insert falha por outro erro de banco", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({ insertError: { message: "conexão perdida" } });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Operador" });
+
+    // Act
+    const result = await createRoleAction("company-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("conexão perdida");
+    }
+  });
+
+  it("retorna { ok: true } no caminho feliz e verifica que code foi gerado a partir do name", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({ roleId: "role-abc-123" });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Supervisor Geral", description: "Supervisiona tudo" });
+
+    // Act
+    const result = await createRoleAction("company-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message).toContain("Supervisor Geral");
+    }
+    // Verifica que o insert foi chamado com o code gerado a partir do name
+    expect(mock.rolesInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "supervisor-geral",
+        name: "Supervisor Geral",
+        is_system: false,
+        company_id: "company-1",
+      }),
+    );
+  });
+
+  it("gera code sem acentos e caracteres especiais", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({ roleId: "role-xyz" });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Técnico de Manutenção" });
+
+    // Act
+    await createRoleAction("company-1", { ok: true }, fd);
+
+    // Assert
+    expect(mock.rolesInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "tecnico-de-manutencao",
+      }),
+    );
+  });
+});

--- a/src/modules/tenancy/actions/__tests__/create-role.test.ts
+++ b/src/modules/tenancy/actions/__tests__/create-role.test.ts
@@ -122,6 +122,7 @@ describe("createRoleAction", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.fieldErrors).toBeDefined();
+      expect(result.fieldErrors?.name).toBeDefined();
     }
   });
 

--- a/src/modules/tenancy/actions/__tests__/delete-role.test.ts
+++ b/src/modules/tenancy/actions/__tests__/delete-role.test.ts
@@ -183,7 +183,7 @@ describe("deleteRoleAction", () => {
     // Assert
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.message).toContain("excluída");
+      expect(result.message).toBe("Role excluída");
     }
     // Verifica que delete foi chamado
     expect(mock.rolesDeleteFn).toHaveBeenCalled();

--- a/src/modules/tenancy/actions/__tests__/delete-role.test.ts
+++ b/src/modules/tenancy/actions/__tests__/delete-role.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/modules/audit", () => ({ audit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/modules/authz", () => ({
+  requirePermission: vi.fn().mockResolvedValue(undefined),
+  ForbiddenError: class ForbiddenError extends Error {
+    constructor(public permission: string) {
+      super(`forbidden:${permission}`);
+    }
+  },
+}));
+
+import { createClient } from "@/lib/supabase/server";
+import { requirePermission } from "@/modules/authz";
+import { deleteRoleAction } from "../delete-role";
+
+// -------------------------------------------------------------------
+// Sequência de produção (delete-role.ts):
+//   1. requirePermission(companyId, "core:role:manage")
+//   2. createClient() → roles.select().eq().eq().maybeSingle()
+//   3. checks: fetchError, not found, is_system
+//   4. membership_roles.select("id", {count:"exact", head:true}).eq("role_id")
+//   5. check: count > 0
+//   6. roles.delete().eq("id").eq("company_id")
+//   7. audit()
+//   8. revalidatePath()
+// -------------------------------------------------------------------
+
+type RoleData = {
+  id: string;
+  is_system: boolean;
+  company_id: string;
+} | null;
+
+type DeleteMockOptions = {
+  roleData?: RoleData;
+  roleFetchError?: { message: string } | null;
+  memberCount?: number | null;
+  countError?: { message: string } | null;
+  deleteError?: { message: string } | null;
+};
+
+function makeSupabaseMock({
+  roleData = { id: "role-1", is_system: false, company_id: "company-1" },
+  roleFetchError = null,
+  memberCount = 0,
+  countError = null,
+  deleteError = null,
+}: DeleteMockOptions = {}) {
+  // roles select: .select().eq().eq().maybeSingle()
+  const rolesMaybeSingle = vi.fn().mockResolvedValue({
+    data: roleFetchError ? null : roleData,
+    error: roleFetchError,
+  });
+  const rolesEq2Select = vi.fn().mockReturnValue({ maybeSingle: rolesMaybeSingle });
+  const rolesEq1Select = vi.fn().mockReturnValue({ eq: rolesEq2Select });
+  const rolesSelectFetch = vi.fn().mockReturnValue({ eq: rolesEq1Select });
+
+  // roles delete: .delete().eq().eq()
+  const rolesDeleteEq2 = vi.fn().mockResolvedValue({
+    data: null,
+    error: deleteError,
+  });
+  const rolesDeleteEq1 = vi.fn().mockReturnValue({ eq: rolesDeleteEq2 });
+  const rolesDeleteFn = vi.fn().mockReturnValue({ eq: rolesDeleteEq1 });
+
+  // membership_roles count: .select("id", {count:"exact", head:true}).eq()
+  const mrEq = vi.fn().mockResolvedValue({
+    count: memberCount,
+    error: countError,
+  });
+  const mrSelect = vi.fn().mockReturnValue({ eq: mrEq });
+
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "roles") {
+        return {
+          select: rolesSelectFetch,
+          delete: rolesDeleteFn,
+        };
+      }
+      if (table === "membership_roles") {
+        return { select: mrSelect };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        delete: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    }),
+    rolesDeleteFn,
+  };
+
+  return mockClient;
+}
+
+describe("deleteRoleAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retorna { ok: false } quando core:role:manage é negado", async () => {
+    // Arrange
+    vi.mocked(requirePermission).mockRejectedValueOnce(new Error("forbidden:core:role:manage"));
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    // Act
+    const result = await deleteRoleAction("company-1", "role-1");
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("permissão");
+    }
+  });
+
+  it("retorna { ok: false } quando role não é encontrada", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({ roleData: null });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    // Act
+    const result = await deleteRoleAction("company-1", "role-inexistente");
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("encontrada");
+    }
+  });
+
+  it("retorna { ok: false } quando role é is_system = true", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({
+      roleData: { id: "role-system", is_system: true, company_id: "company-1" },
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    // Act
+    const result = await deleteRoleAction("company-1", "role-system");
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sistema");
+    }
+  });
+
+  it("retorna { ok: false } quando há membros com essa role (membership_roles count > 0)", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({
+      roleData: { id: "role-1", is_system: false, company_id: "company-1" },
+      memberCount: 3,
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    // Act
+    const result = await deleteRoleAction("company-1", "role-1");
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("membros");
+    }
+  });
+
+  it("retorna { ok: true } quando role custom não possui membros", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({
+      roleData: { id: "role-custom", is_system: false, company_id: "company-1" },
+      memberCount: 0,
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    // Act
+    const result = await deleteRoleAction("company-1", "role-custom");
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message).toContain("excluída");
+    }
+    // Verifica que delete foi chamado
+    expect(mock.rolesDeleteFn).toHaveBeenCalled();
+  });
+
+  it("retorna { ok: false, message } quando delete falha com erro do banco", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({
+      roleData: { id: "role-1", is_system: false, company_id: "company-1" },
+      memberCount: 0,
+      deleteError: { message: "Erro ao excluir role" },
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    // Act
+    const result = await deleteRoleAction("company-1", "role-1");
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Erro ao excluir role");
+    }
+  });
+
+  it("retorna { ok: false } quando fetch de role retorna erro do banco", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({
+      roleFetchError: { message: "Falha na consulta" },
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    // Act
+    const result = await deleteRoleAction("company-1", "role-1");
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Falha na consulta");
+    }
+  });
+});

--- a/src/modules/tenancy/actions/__tests__/invite-member.test.ts
+++ b/src/modules/tenancy/actions/__tests__/invite-member.test.ts
@@ -136,7 +136,6 @@ function makeServiceMock({
         inviteUserByEmail,
       },
     },
-    inviteUserByEmail,
   };
 }
 
@@ -149,22 +148,22 @@ describe("inviteMemberAction", () => {
     // Arrange: sobrescreve o módulo env temporariamente com chave ausente
     const { env } = await import("@/core/config/env");
     const originalKey = env.SUPABASE_SERVICE_ROLE_KEY;
-    (env as Record<string, unknown>).SUPABASE_SERVICE_ROLE_KEY = "";
+    try {
+      (env as Record<string, unknown>).SUPABASE_SERVICE_ROLE_KEY = undefined;
+      const mock = makeAnonMock();
+      vi.mocked(createClient).mockResolvedValue(mock as never);
 
-    const anonMock = makeAnonMock();
-    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+      // Act
+      const result = await inviteMemberAction("company-1", "teste@empresa.com", ["role-1"]);
 
-    // Act
-    const result = await inviteMemberAction("company-1", "test@example.com", []);
-
-    // Assert
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.message).toContain("Service role");
+      // Assert
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toContain("Service role");
+      }
+    } finally {
+      (env as Record<string, unknown>).SUPABASE_SERVICE_ROLE_KEY = originalKey;
     }
-
-    // Restaura
-    (env as Record<string, unknown>).SUPABASE_SERVICE_ROLE_KEY = originalKey;
   });
 
   it("retorna { ok: false } quando requirePermission lança ForbiddenError", async () => {
@@ -268,5 +267,39 @@ describe("inviteMemberAction", () => {
     // Assert
     expect(result.ok).toBe(true);
     expect(anonMock.membershipRolesInsert).not.toHaveBeenCalled();
+  });
+
+  it("retorna { ok: false } quando membro já possui convite pendente", async () => {
+    // Arrange
+    const anonMock = makeAnonMock({ existingMembership: { id: "mem-1", status: "invited" } });
+    const serviceMock = makeServiceMock({ invitedUserId: "invited-user-789" });
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+    vi.mocked(createServiceClient).mockReturnValue(serviceMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "convite@empresa.com", ["role-1"]);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("convite");
+    }
+  });
+
+  it("retorna { ok: false } quando usuário não está autenticado", async () => {
+    // Arrange
+    const anonMock = makeAnonMock({ userNull: true });
+    const serviceMock = makeServiceMock();
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+    vi.mocked(createServiceClient).mockReturnValue(serviceMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "teste@empresa.com", ["role-1"]);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("autenticad");
+    }
   });
 });

--- a/src/modules/tenancy/actions/__tests__/invite-member.test.ts
+++ b/src/modules/tenancy/actions/__tests__/invite-member.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/modules/audit", () => ({ audit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/modules/authz", () => ({
+  requirePermission: vi.fn().mockResolvedValue(undefined),
+  ForbiddenError: class ForbiddenError extends Error {
+    constructor(public permission: string) {
+      super(`forbidden:${permission}`);
+    }
+  },
+}));
+vi.mock("@/lib/supabase/service", () => ({ createServiceClient: vi.fn() }));
+vi.mock("@/core/config/env", () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: "http://localhost:54321",
+    SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+    NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+  },
+}));
+
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+import { requirePermission } from "@/modules/authz";
+import { inviteMemberAction } from "../invite-member";
+
+// -------------------------------------------------------------------
+// Sequência de produção (invite-member.ts):
+//   1. env.SUPABASE_SERVICE_ROLE_KEY check
+//   2. createAnonClient() → auth.getUser()
+//   3. requirePermission(companyId, "core:member:invite")
+//   4. createServiceClient() → auth.admin.inviteUserByEmail()
+//   5. anonClient.from("memberships").select().eq().eq().maybeSingle()
+//   6. anonClient.from("memberships").insert().select("id").single()
+//   7. anonClient.from("membership_roles").insert()
+//   8. audit()
+//   9. revalidatePath()
+// -------------------------------------------------------------------
+
+type InviteMockOptions = {
+  userId?: string;
+  userNull?: boolean;
+  inviteError?: { message: string } | null;
+  invitedUserId?: string;
+  existingMembership?: { id: string; status: string } | null;
+  membershipInsertError?: { message: string } | null;
+  membershipId?: string;
+  rolesInsertError?: { message: string } | null;
+};
+
+function makeAnonMock({
+  userId = "user-1",
+  userNull = false,
+  existingMembership = null,
+  membershipInsertError = null,
+  membershipId = "membership-abc",
+  rolesInsertError = null,
+}: InviteMockOptions = {}) {
+  // memberships: select chain .select().eq().eq().maybeSingle()
+  const membershipsMaybeSingle = vi.fn().mockResolvedValue({
+    data: existingMembership,
+    error: null,
+  });
+  const membershipsEq2Select = vi.fn().mockReturnValue({ maybeSingle: membershipsMaybeSingle });
+  const membershipsEq1Select = vi.fn().mockReturnValue({ eq: membershipsEq2Select });
+  const membershipsSelect = vi.fn().mockReturnValue({ eq: membershipsEq1Select });
+
+  // memberships: insert chain .insert().select("id").single()
+  const membershipsSingle = vi
+    .fn()
+    .mockResolvedValue(
+      membershipInsertError
+        ? { data: null, error: membershipInsertError }
+        : { data: { id: membershipId }, error: null },
+    );
+  const membershipsInsertSelect = vi.fn().mockReturnValue({ single: membershipsSingle });
+  const membershipsInsert = vi.fn().mockReturnValue({ select: membershipsInsertSelect });
+
+  // membership_roles: .insert() terminal
+  const membershipRolesInsert = vi
+    .fn()
+    .mockResolvedValue(
+      rolesInsertError ? { data: null, error: rolesInsertError } : { data: null, error: null },
+    );
+
+  const mockClient = {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userNull ? null : { id: userId } },
+        error: null,
+      }),
+    },
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "memberships") {
+        return {
+          select: membershipsSelect,
+          insert: membershipsInsert,
+        };
+      }
+      if (table === "membership_roles") {
+        return { insert: membershipRolesInsert };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    }),
+    // expostos para inspeção
+    membershipRolesInsert,
+    membershipsInsert,
+  };
+
+  return mockClient;
+}
+
+function makeServiceMock({
+  inviteError = null,
+  invitedUserId = "invited-user-id",
+}: { inviteError?: { message: string } | null; invitedUserId?: string } = {}) {
+  const inviteUserByEmail = vi
+    .fn()
+    .mockResolvedValue(
+      inviteError
+        ? { data: null, error: inviteError }
+        : { data: { user: { id: invitedUserId } }, error: null },
+    );
+
+  return {
+    auth: {
+      admin: {
+        inviteUserByEmail,
+      },
+    },
+    inviteUserByEmail,
+  };
+}
+
+describe("inviteMemberAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retorna { ok: false } quando SUPABASE_SERVICE_ROLE_KEY está ausente", async () => {
+    // Arrange: sobrescreve o módulo env temporariamente com chave ausente
+    const { env } = await import("@/core/config/env");
+    const originalKey = env.SUPABASE_SERVICE_ROLE_KEY;
+    (env as Record<string, unknown>).SUPABASE_SERVICE_ROLE_KEY = "";
+
+    const anonMock = makeAnonMock();
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "test@example.com", []);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("Service role");
+    }
+
+    // Restaura
+    (env as Record<string, unknown>).SUPABASE_SERVICE_ROLE_KEY = originalKey;
+  });
+
+  it("retorna { ok: false } quando requirePermission lança ForbiddenError", async () => {
+    // Arrange
+    const { requirePermission: rp } = await import("@/modules/authz");
+    vi.mocked(rp).mockRejectedValueOnce(new Error("forbidden:core:member:invite"));
+
+    const anonMock = makeAnonMock();
+    const serviceMock = makeServiceMock();
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+    vi.mocked(createServiceClient).mockReturnValue(serviceMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "novo@empresa.com", []);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("permissão");
+    }
+  });
+
+  it("retorna { ok: false } quando auth.admin.inviteUserByEmail falha", async () => {
+    // Arrange
+    const anonMock = makeAnonMock();
+    const serviceMock = makeServiceMock({ inviteError: { message: "E-mail inválido" } });
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+    vi.mocked(createServiceClient).mockReturnValue(serviceMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "bad-email", []);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("E-mail inválido");
+    }
+  });
+
+  it("retorna { ok: true } no caminho feliz com membership e membership_roles inseridas", async () => {
+    // Arrange
+    const anonMock = makeAnonMock({
+      existingMembership: null,
+      membershipId: "mem-xyz",
+    });
+    const serviceMock = makeServiceMock({ invitedUserId: "invited-user-123" });
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+    vi.mocked(createServiceClient).mockReturnValue(serviceMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "novo@empresa.com", [
+      "role-id-1",
+      "role-id-2",
+    ]);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message).toContain("novo@empresa.com");
+    }
+    // Verifica que memberships.insert foi chamado
+    expect(anonMock.membershipsInsert).toHaveBeenCalled();
+    // Verifica que membership_roles.insert foi chamado com os roleIds corretos
+    expect(anonMock.membershipRolesInsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ role_id: "role-id-1", membership_id: "mem-xyz" }),
+        expect.objectContaining({ role_id: "role-id-2", membership_id: "mem-xyz" }),
+      ]),
+    );
+  });
+
+  it("retorna { ok: false } quando membro já existe com status diferente de 'invited'", async () => {
+    // Arrange
+    const anonMock = makeAnonMock({
+      existingMembership: { id: "mem-existing", status: "active" },
+    });
+    const serviceMock = makeServiceMock({ invitedUserId: "invited-user-123" });
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+    vi.mocked(createServiceClient).mockReturnValue(serviceMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "existente@empresa.com", []);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("membro");
+    }
+  });
+
+  it("não insere membership_roles quando lista de roles está vazia", async () => {
+    // Arrange
+    const anonMock = makeAnonMock({ existingMembership: null, membershipId: "mem-empty-roles" });
+    const serviceMock = makeServiceMock({ invitedUserId: "invited-user-456" });
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+    vi.mocked(createServiceClient).mockReturnValue(serviceMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "sem-roles@empresa.com", []);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    expect(anonMock.membershipRolesInsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/tenancy/actions/__tests__/toggle-module.test.ts
+++ b/src/modules/tenancy/actions/__tests__/toggle-module.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/modules/audit", () => ({ audit: vi.fn().mockResolvedValue(undefined) }));
+
+import { createClient } from "@/lib/supabase/server";
+import { toggleModuleAction } from "../toggle-module";
+
+// -------------------------------------------------------------------
+// Tipos compartilhados
+// -------------------------------------------------------------------
+type ToggleMockOptions = {
+  isPlatformAdmin?: boolean;
+  rpcError?: { message: string } | null;
+  insertModuleError?: { message: string } | null;
+  deleteModuleError?: { message: string } | null;
+  systemRoles?: Array<{ id: string; code: string }>;
+  permissions?: Array<{ code: string }>;
+  permsToRemove?: Array<{ code: string }>;
+  companyRoles?: Array<{ id: string }>;
+};
+
+// -------------------------------------------------------------------
+// Factory: mock para o caminho enable=true
+// Sequência de produção:
+//   company_modules.insert()
+//   roles.select("id, code").eq("company_id").eq("is_system", true)
+//   permissions.select("code").eq("module_code").in("action", [...])
+//   role_permissions.upsert(...)
+// -------------------------------------------------------------------
+function makeEnableMock({
+  isPlatformAdmin = true,
+  rpcError = null,
+  insertModuleError = null,
+  systemRoles = [
+    { id: "role-owner", code: "owner" },
+    { id: "role-manager", code: "manager" },
+    { id: "role-operator", code: "operator" },
+  ],
+  permissions = [{ code: "inventory:product:read" }, { code: "inventory:product:create" }],
+}: Pick<
+  ToggleMockOptions,
+  "isPlatformAdmin" | "rpcError" | "insertModuleError" | "systemRoles" | "permissions"
+> = {}) {
+  // company_modules: .insert() terminal
+  const modulesInsert = vi
+    .fn()
+    .mockResolvedValue(
+      insertModuleError ? { data: null, error: insertModuleError } : { data: null, error: null },
+    );
+
+  // roles: .select().eq().eq() — 2 eqs
+  const rolesEq2System = vi.fn().mockResolvedValue({ data: systemRoles, error: null });
+  const rolesEq1System = vi.fn().mockReturnValue({ eq: rolesEq2System });
+  const rolesSelectSystem = vi.fn().mockReturnValue({ eq: rolesEq1System });
+
+  // permissions: .select().eq().in()
+  const permsIn = vi.fn().mockResolvedValue({ data: permissions, error: null });
+  const permsEqEnable = vi.fn().mockReturnValue({ in: permsIn });
+  const permsSelectEnable = vi.fn().mockReturnValue({ eq: permsEqEnable });
+
+  // role_permissions: .upsert() terminal
+  const rolePermsUpsert = vi.fn().mockResolvedValue({ data: null, error: null });
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } }, error: null }),
+    },
+    rpc: vi.fn().mockResolvedValue({ data: isPlatformAdmin, error: rpcError }),
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "company_modules") {
+        return { insert: modulesInsert };
+      }
+      if (table === "roles") {
+        return { select: rolesSelectSystem };
+      }
+      if (table === "permissions") {
+        return { select: permsSelectEnable };
+      }
+      if (table === "role_permissions") {
+        return { upsert: rolePermsUpsert };
+      }
+      // fallback para tabelas não esperadas — joga erro para detectar acessos inesperados
+      return vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        delete: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      });
+    }),
+    // Helpers expostos para inspecionar nos testes
+    modulesInsert,
+    rolePermsUpsert,
+  };
+}
+
+// -------------------------------------------------------------------
+// Factory: mock para o caminho enable=false
+// Sequência de produção:
+//   company_modules.delete().eq("company_id").eq("module_code") — sem return, só checa error
+//   permissions.select("code").eq("module_code", moduleCode)    — uma eq, resolve array
+//   roles.select("id").eq("company_id", companyId)              — uma eq, resolve array
+//   role_permissions.delete().in("role_id", roleIds).in("permission_code", codes) — sem return
+// -------------------------------------------------------------------
+function makeDisableMock({
+  isPlatformAdmin = true,
+  rpcError = null,
+  deleteModuleError = null,
+  permsToRemove = [{ code: "inventory:product:read" }],
+  companyRoles = [{ id: "role-owner" }, { id: "role-manager" }],
+}: Pick<
+  ToggleMockOptions,
+  "isPlatformAdmin" | "rpcError" | "deleteModuleError" | "permsToRemove" | "companyRoles"
+> = {}) {
+  // company_modules: .delete().eq().eq() — terminal
+  const modulesDeleteEq2 = vi
+    .fn()
+    .mockResolvedValue(
+      deleteModuleError ? { data: null, error: deleteModuleError } : { data: null, error: null },
+    );
+  const modulesDeleteEq1 = vi.fn().mockReturnValue({ eq: modulesDeleteEq2 });
+  const modulesDeleteFn = vi.fn().mockReturnValue({ eq: modulesDeleteEq1 });
+
+  // permissions: .select("code").eq("module_code", moduleCode) — uma eq, resolve array
+  const permsEqDisable = vi.fn().mockResolvedValue({ data: permsToRemove, error: null });
+  const permsSelectDisable = vi.fn().mockReturnValue({ eq: permsEqDisable });
+
+  // roles: .select("id").eq("company_id", companyId) — uma eq, resolve array
+  const rolesEqCompany = vi.fn().mockResolvedValue({ data: companyRoles, error: null });
+  const rolesSelectCompany = vi.fn().mockReturnValue({ eq: rolesEqCompany });
+
+  // role_permissions: .delete().in("role_id").in("permission_code") — sem return
+  const rolePermsDeleteIn2 = vi.fn().mockResolvedValue({ data: null, error: null });
+  const rolePermsDeleteIn1 = vi.fn().mockReturnValue({ in: rolePermsDeleteIn2 });
+  const rolePermsDeleteFn = vi.fn().mockReturnValue({ in: rolePermsDeleteIn1 });
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } }, error: null }),
+    },
+    rpc: vi.fn().mockResolvedValue({ data: isPlatformAdmin, error: rpcError }),
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "company_modules") {
+        return { delete: modulesDeleteFn };
+      }
+      if (table === "permissions") {
+        return { select: permsSelectDisable };
+      }
+      if (table === "roles") {
+        return { select: rolesSelectCompany };
+      }
+      if (table === "role_permissions") {
+        return { delete: rolePermsDeleteFn };
+      }
+      // fallback para tabelas não esperadas — joga erro para detectar acessos inesperados
+      return vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        delete: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      });
+    }),
+    // Helpers expostos para inspecionar nos testes
+    modulesDeleteFn,
+    permsEqDisable,
+    rolePermsDeleteIn2,
+  };
+}
+
+// -------------------------------------------------------------------
+// Wrapper que usa a factory correta por path
+// -------------------------------------------------------------------
+async function callToggle(
+  mock: ReturnType<typeof makeEnableMock> | ReturnType<typeof makeDisableMock>,
+  companyId: string,
+  moduleCode: string,
+  enable: boolean,
+) {
+  vi.mocked(createClient).mockResolvedValue(mock as never);
+  return toggleModuleAction(companyId, moduleCode, enable);
+}
+
+// -------------------------------------------------------------------
+// Testes
+// -------------------------------------------------------------------
+describe("toggleModuleAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retorna { ok: false } e lança AppError quando usuário não é platform admin", async () => {
+    const mock = makeEnableMock({ isPlatformAdmin: false });
+    await expect(callToggle(mock, "company-1", "inventory", true)).rejects.toThrow("Acesso negado");
+  });
+
+  it("retorna { ok: false, message } quando rpc is_platform_admin retorna erro", async () => {
+    const mock = makeEnableMock({
+      isPlatformAdmin: true,
+      rpcError: { message: "RPC indisponível" },
+    });
+    const result = await callToggle(mock, "company-1", "inventory", true);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("RPC indisponível");
+    }
+  });
+
+  it("retorna { ok: true } ao habilitar módulo e chama upsert em role_permissions", async () => {
+    const mock = makeEnableMock({ isPlatformAdmin: true });
+    const result = await callToggle(mock, "company-1", "inventory", true);
+
+    expect(result.ok).toBe(true);
+    // Verifica que upsert foi chamado (ao menos uma vez para alguma role)
+    expect(mock.rolePermsUpsert).toHaveBeenCalled();
+  });
+
+  it("ao habilitar módulo passa os campos corretos para upsert de role_permissions", async () => {
+    const mock = makeEnableMock({
+      isPlatformAdmin: true,
+      systemRoles: [{ id: "role-owner-id", code: "owner" }],
+      permissions: [{ code: "inventory:product:read" }, { code: "inventory:product:create" }],
+    });
+    await callToggle(mock, "company-1", "inventory", true);
+
+    expect(mock.rolePermsUpsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ permission_code: "inventory:product:read" }),
+        expect.objectContaining({ permission_code: "inventory:product:create" }),
+      ]),
+      expect.objectContaining({ onConflict: "role_id,permission_code" }),
+    );
+  });
+
+  it("retorna { ok: true } ao desabilitar módulo", async () => {
+    const mock = makeDisableMock({ isPlatformAdmin: true });
+    const result = await callToggle(mock, "company-1", "inventory", false);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("ao desabilitar módulo chama delete em company_modules", async () => {
+    const mock = makeDisableMock({ isPlatformAdmin: true });
+    await callToggle(mock, "company-1", "inventory", false);
+
+    expect(mock.modulesDeleteFn).toHaveBeenCalled();
+  });
+
+  it("ao desabilitar módulo chama delete em role_permissions com os ids corretos", async () => {
+    const mock = makeDisableMock({
+      isPlatformAdmin: true,
+      companyRoles: [{ id: "role-a" }, { id: "role-b" }],
+      permsToRemove: [{ code: "inventory:product:read" }],
+    });
+    await callToggle(mock, "company-1", "inventory", false);
+
+    expect(mock.permsEqDisable).toHaveBeenCalledWith("module_code", "inventory");
+
+    // Verifica que o segundo .in() foi chamado com os permission_codes corretos
+    expect(mock.rolePermsDeleteIn2).toHaveBeenCalledWith(
+      "permission_code",
+      expect.arrayContaining(["inventory:product:read"]),
+    );
+  });
+
+  it("retorna { ok: false, message } quando insert em company_modules falha ao habilitar", async () => {
+    const mock = makeEnableMock({
+      isPlatformAdmin: true,
+      insertModuleError: { message: "Módulo já habilitado" },
+    });
+    const result = await callToggle(mock, "company-1", "inventory", true);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Módulo já habilitado");
+    }
+  });
+
+  it("retorna { ok: false, message } quando delete em company_modules falha ao desabilitar", async () => {
+    const mock = makeDisableMock({
+      isPlatformAdmin: true,
+      deleteModuleError: { message: "Falha ao remover módulo" },
+    });
+    const result = await callToggle(mock, "company-1", "inventory", false);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Falha ao remover módulo");
+    }
+  });
+
+  it("retorna mensagem de sucesso correta ao habilitar módulo", async () => {
+    const mock = makeEnableMock({ isPlatformAdmin: true });
+    const result = await callToggle(mock, "company-1", "inventory", true);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message).toContain("habilitado");
+    }
+  });
+
+  it("retorna mensagem de sucesso correta ao desabilitar módulo", async () => {
+    const mock = makeDisableMock({ isPlatformAdmin: true });
+    const result = await callToggle(mock, "company-1", "inventory", false);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message).toContain("desabilitado");
+    }
+  });
+});

--- a/src/modules/tenancy/actions/__tests__/update-role-permissions.test.ts
+++ b/src/modules/tenancy/actions/__tests__/update-role-permissions.test.ts
@@ -91,22 +91,15 @@ function makeSupabaseMock({
   // role_permissions upsert: .upsert([...]) — terminal
   const rpUpsert = vi.fn().mockResolvedValue({ data: null, error: upsertError });
 
-  // Controla quantas vezes role_permissions foi chamado para distinguir select vs delete/upsert
-  let rpCallCount = 0;
-
   const mockClient = {
     from: vi.fn().mockImplementation((table: string) => {
       if (table === "roles") {
         return { select: rolesSelect };
       }
       if (table === "role_permissions") {
-        rpCallCount++;
-        // 1ª chamada: select (dentro do Promise.all)
-        if (rpCallCount === 1) {
-          return { select: rpSelectFn };
-        }
-        // Chamadas subsequentes: delete ou upsert
-        return { delete: rpDeleteFn, upsert: rpUpsert };
+        // Todos os métodos expostos simultaneamente — produção chama select 1x (Promise.all),
+        // delete e upsert apenas nos branches condicionais; não há conflito.
+        return { select: rpSelectFn, delete: rpDeleteFn, upsert: rpUpsert };
       }
       if (table === "company_modules") {
         return { select: cmSelectFn };
@@ -125,8 +118,10 @@ function makeSupabaseMock({
       };
     }),
     // expostos para inspeção
+    rpSelectFn,
     rpDeleteIn,
     rpDeleteEq,
+    rpDeleteFn,
     rpUpsert,
     permsIn,
   };

--- a/src/modules/tenancy/actions/__tests__/update-role-permissions.test.ts
+++ b/src/modules/tenancy/actions/__tests__/update-role-permissions.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/modules/audit", () => ({ audit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/modules/authz", () => ({
+  requirePermission: vi.fn().mockResolvedValue(undefined),
+  ForbiddenError: class ForbiddenError extends Error {
+    constructor(public permission: string) {
+      super(`forbidden:${permission}`);
+    }
+  },
+}));
+
+import { createClient } from "@/lib/supabase/server";
+import { requirePermission } from "@/modules/authz";
+import { updateRolePermissionsAction } from "../update-role-permissions";
+
+// -------------------------------------------------------------------
+// Sequência de produção (update-role-permissions.ts):
+//   1. requirePermission(companyId, "core:role:manage")
+//   2. createClient() → roles.select().eq().eq().maybeSingle()
+//   3. checks: roleErr, not found, is_system
+//   4. Promise.all([
+//        role_permissions.select("permission_code").eq("role_id"),
+//        company_modules.select("module_code").eq("company_id"),
+//      ])
+//   5. permissions.select("code").in("module_code", moduleCodes)
+//   6. toRemove → role_permissions.delete().eq("role_id").in("permission_code", toRemove)
+//   7. toAdd    → role_permissions.upsert([...])
+//   8. audit()
+//   9. revalidatePath()
+// -------------------------------------------------------------------
+
+type RoleData = {
+  id: string;
+  is_system: boolean;
+  company_id: string;
+} | null;
+
+type UpdatePermsMockOptions = {
+  roleData?: RoleData;
+  roleFetchError?: { message: string } | null;
+  currentPerms?: Array<{ permission_code: string }>;
+  enabledModules?: Array<{ module_code: string }>;
+  validPerms?: Array<{ code: string }>;
+  deleteError?: { message: string } | null;
+  upsertError?: { message: string } | null;
+};
+
+function makeSupabaseMock({
+  roleData = { id: "role-1", is_system: false, company_id: "company-1" },
+  roleFetchError = null,
+  currentPerms = [],
+  enabledModules = [{ module_code: "inventory" }],
+  validPerms = [
+    { code: "inventory:product:read" },
+    { code: "inventory:product:create" },
+    { code: "inventory:product:delete" },
+  ],
+  deleteError = null,
+  upsertError = null,
+}: UpdatePermsMockOptions = {}) {
+  // roles: .select().eq().eq().maybeSingle()
+  const rolesMaybeSingle = vi.fn().mockResolvedValue({
+    data: roleFetchError ? null : roleData,
+    error: roleFetchError,
+  });
+  const rolesEq2 = vi.fn().mockReturnValue({ maybeSingle: rolesMaybeSingle });
+  const rolesEq1 = vi.fn().mockReturnValue({ eq: rolesEq2 });
+  const rolesSelect = vi.fn().mockReturnValue({ eq: rolesEq1 });
+
+  // role_permissions select: .select("permission_code").eq("role_id") — Promise.all branch 1
+  const rpSelectEq = vi.fn().mockResolvedValue({ data: currentPerms, error: null });
+  const rpSelectFn = vi.fn().mockReturnValue({ eq: rpSelectEq });
+
+  // company_modules: .select("module_code").eq("company_id") — Promise.all branch 2
+  const cmSelectEq = vi.fn().mockResolvedValue({ data: enabledModules, error: null });
+  const cmSelectFn = vi.fn().mockReturnValue({ eq: cmSelectEq });
+
+  // permissions: .select("code").in("module_code", moduleCodes)
+  const permsIn = vi.fn().mockResolvedValue({ data: validPerms, error: null });
+  const permsSelect = vi.fn().mockReturnValue({ in: permsIn });
+
+  // role_permissions delete: .delete().eq("role_id").in("permission_code", toRemove)
+  const rpDeleteIn = vi.fn().mockResolvedValue({ data: null, error: deleteError });
+  const rpDeleteEq = vi.fn().mockReturnValue({ in: rpDeleteIn });
+  const rpDeleteFn = vi.fn().mockReturnValue({ eq: rpDeleteEq });
+
+  // role_permissions upsert: .upsert([...]) — terminal
+  const rpUpsert = vi.fn().mockResolvedValue({ data: null, error: upsertError });
+
+  // Controla quantas vezes role_permissions foi chamado para distinguir select vs delete/upsert
+  let rpCallCount = 0;
+
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "roles") {
+        return { select: rolesSelect };
+      }
+      if (table === "role_permissions") {
+        rpCallCount++;
+        // 1ª chamada: select (dentro do Promise.all)
+        if (rpCallCount === 1) {
+          return { select: rpSelectFn };
+        }
+        // Chamadas subsequentes: delete ou upsert
+        return { delete: rpDeleteFn, upsert: rpUpsert };
+      }
+      if (table === "company_modules") {
+        return { select: cmSelectFn };
+      }
+      if (table === "permissions") {
+        return { select: permsSelect };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        delete: vi.fn().mockReturnThis(),
+        upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    }),
+    // expostos para inspeção
+    rpDeleteIn,
+    rpDeleteEq,
+    rpUpsert,
+    permsIn,
+  };
+
+  return mockClient;
+}
+
+function makeFormData(permissionCodes: string[]): FormData {
+  const fd = new FormData();
+  for (const code of permissionCodes) {
+    fd.append("permission_code", code);
+  }
+  return fd;
+}
+
+describe("updateRolePermissionsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retorna { ok: false } quando core:role:manage é negado", async () => {
+    // Arrange
+    vi.mocked(requirePermission).mockRejectedValueOnce(new Error("forbidden:core:role:manage"));
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData(["inventory:product:read"]);
+
+    // Act
+    const result = await updateRolePermissionsAction("company-1", "role-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("permissão");
+    }
+  });
+
+  it("retorna { ok: false } quando role é is_system = true", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({
+      roleData: { id: "role-sys", is_system: true, company_id: "company-1" },
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData(["inventory:product:read"]);
+
+    // Act
+    const result = await updateRolePermissionsAction("company-1", "role-sys", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sistema");
+    }
+  });
+
+  it("retorna { ok: true } e chama upsert quando adiciona novas permissões", async () => {
+    // Arrange — currentPerms vazio, solicita 2 permissões válidas
+    const mock = makeSupabaseMock({
+      currentPerms: [],
+      enabledModules: [{ module_code: "inventory" }],
+      validPerms: [{ code: "inventory:product:read" }, { code: "inventory:product:create" }],
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData(["inventory:product:read", "inventory:product:create"]);
+
+    // Act
+    const result = await updateRolePermissionsAction("company-1", "role-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    expect(mock.rpUpsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ permission_code: "inventory:product:read" }),
+        expect.objectContaining({ permission_code: "inventory:product:create" }),
+      ]),
+      expect.objectContaining({ onConflict: "role_id,permission_code" }),
+    );
+  });
+
+  it("retorna { ok: true } e chama delete quando remove permissões", async () => {
+    // Arrange — role já tem 2 perms, solicita remover uma delas
+    const mock = makeSupabaseMock({
+      currentPerms: [
+        { permission_code: "inventory:product:read" },
+        { permission_code: "inventory:product:create" },
+      ],
+      enabledModules: [{ module_code: "inventory" }],
+      validPerms: [{ code: "inventory:product:read" }, { code: "inventory:product:create" }],
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    // Solicita manter só read (remove create)
+    const fd = makeFormData(["inventory:product:read"]);
+
+    // Act
+    const result = await updateRolePermissionsAction("company-1", "role-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    // Verifica que delete foi chamado com "inventory:product:create" no toRemove
+    expect(mock.rpDeleteIn).toHaveBeenCalledWith(
+      "permission_code",
+      expect.arrayContaining(["inventory:product:create"]),
+    );
+  });
+
+  it("ignora permissões de módulos não habilitados (não estão no validSet)", async () => {
+    // Arrange — módulo "crm" não está habilitado → permissão "crm:contact:read" não está no validSet
+    const mock = makeSupabaseMock({
+      currentPerms: [],
+      enabledModules: [{ module_code: "inventory" }],
+      validPerms: [{ code: "inventory:product:read" }],
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    // Solicita uma permissão válida + uma de módulo não habilitado
+    const fd = makeFormData(["inventory:product:read", "crm:contact:read"]);
+
+    // Act
+    const result = await updateRolePermissionsAction("company-1", "role-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    // upsert deve ter sido chamado apenas com a permissão válida
+    expect(mock.rpUpsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ permission_code: "inventory:product:read" }),
+      ]),
+      expect.anything(),
+    );
+    // "crm:contact:read" NÃO deve estar no upsert
+    const upsertArgs = mock.rpUpsert.mock.calls[0]?.[0] as Array<{ permission_code: string }>;
+    const insertedCodes = upsertArgs?.map((r) => r.permission_code) ?? [];
+    expect(insertedCodes).not.toContain("crm:contact:read");
+  });
+
+  it("retorna { ok: true } sem chamar delete nem upsert quando não há mudanças", async () => {
+    // Arrange — role já tem exactly as perms solicitadas
+    const mock = makeSupabaseMock({
+      currentPerms: [{ permission_code: "inventory:product:read" }],
+      enabledModules: [{ module_code: "inventory" }],
+      validPerms: [{ code: "inventory:product:read" }],
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData(["inventory:product:read"]);
+
+    // Act
+    const result = await updateRolePermissionsAction("company-1", "role-1", { ok: true }, fd);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    expect(mock.rpDeleteIn).not.toHaveBeenCalled();
+    expect(mock.rpUpsert).not.toHaveBeenCalled();
+  });
+
+  it("retorna { ok: false } quando role não é encontrada", async () => {
+    // Arrange
+    const mock = makeSupabaseMock({ roleData: null });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData([]);
+
+    // Act
+    const result = await updateRolePermissionsAction(
+      "company-1",
+      "role-inexistente",
+      { ok: true },
+      fd,
+    );
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("encontrada");
+    }
+  });
+});

--- a/src/modules/tenancy/actions/create-role.ts
+++ b/src/modules/tenancy/actions/create-role.ts
@@ -35,7 +35,7 @@ export async function createRoleAction(
   if (!parsed.success) {
     return {
       ok: false,
-      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+      fieldErrors: parsed.error.flatten().fieldErrors,
     };
   }
 
@@ -71,6 +71,6 @@ export async function createRoleAction(
     status: "success",
   });
 
-  revalidatePath("/[companySlug]/settings/roles", "page");
+  revalidatePath("/", "layout");
   return { ok: true, message: `Role "${name}" criada com sucesso` };
 }

--- a/src/modules/tenancy/actions/create-role.ts
+++ b/src/modules/tenancy/actions/create-role.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { type ActionResult } from "@/lib/errors";
+import { requirePermission } from "@/modules/authz";
+import { audit } from "@/modules/audit";
+import { createRoleSchema } from "../schemas/create-role";
+
+function generateCode(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export async function createRoleAction(
+  companyId: string,
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  try {
+    await requirePermission(companyId, "core:role:manage");
+  } catch {
+    return { ok: false, message: "Sem permissão para gerenciar roles" };
+  }
+
+  const parsed = createRoleSchema.safeParse({
+    name: formData.get("name"),
+    description: formData.get("description") || undefined,
+  });
+
+  if (!parsed.success) {
+    return {
+      ok: false,
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const { name, description } = parsed.data;
+  const code = generateCode(name);
+
+  const supabase = await createClient();
+
+  const { data: role, error } = await supabase
+    .from("roles")
+    .insert({
+      company_id: companyId,
+      code,
+      name,
+      description: description ?? null,
+      is_system: false,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      return { ok: false, message: "Já existe uma role com este nome" };
+    }
+    return { ok: false, message: error.message };
+  }
+
+  await audit({
+    companyId,
+    action: "role.create",
+    resourceType: "role",
+    resourceId: role.id,
+    status: "success",
+  });
+
+  revalidatePath("/[companySlug]/settings/roles", "page");
+  return { ok: true, message: `Role "${name}" criada com sucesso` };
+}

--- a/src/modules/tenancy/actions/delete-role.ts
+++ b/src/modules/tenancy/actions/delete-role.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { type ActionResult } from "@/lib/errors";
+import { requirePermission } from "@/modules/authz";
+import { audit } from "@/modules/audit";
+
+export async function deleteRoleAction(companyId: string, roleId: string): Promise<ActionResult> {
+  try {
+    await requirePermission(companyId, "core:role:manage");
+  } catch {
+    return { ok: false, message: "Sem permissão para gerenciar roles" };
+  }
+
+  const supabase = await createClient();
+
+  const { data: existing, error: fetchError } = await supabase
+    .from("roles")
+    .select("id, is_system, company_id")
+    .eq("id", roleId)
+    .eq("company_id", companyId)
+    .maybeSingle();
+
+  if (fetchError) return { ok: false, message: fetchError.message };
+  if (!existing) return { ok: false, message: "Role não encontrada" };
+  if (existing.is_system) return { ok: false, message: "Roles de sistema não podem ser excluídas" };
+
+  const { count, error: countError } = await supabase
+    .from("membership_roles")
+    .select("id", { count: "exact", head: true })
+    .eq("role_id", roleId);
+
+  if (countError) return { ok: false, message: countError.message };
+  if (count && count > 0) {
+    return { ok: false, message: "Esta role possui membros. Reatribua-os antes de excluir." };
+  }
+
+  const { error } = await supabase
+    .from("roles")
+    .delete()
+    .eq("id", roleId)
+    .eq("company_id", companyId);
+
+  if (error) return { ok: false, message: error.message };
+
+  await audit({
+    companyId,
+    action: "role.delete",
+    resourceType: "role",
+    resourceId: roleId,
+    status: "success",
+  });
+
+  revalidatePath("/[companySlug]/settings/roles", "page");
+  return { ok: true, message: "Role excluída" };
+}

--- a/src/modules/tenancy/actions/delete-role.ts
+++ b/src/modules/tenancy/actions/delete-role.ts
@@ -52,6 +52,6 @@ export async function deleteRoleAction(companyId: string, roleId: string): Promi
     status: "success",
   });
 
-  revalidatePath("/[companySlug]/settings/roles", "page");
+  revalidatePath("/", "layout");
   return { ok: true, message: "Role excluída" };
 }

--- a/src/modules/tenancy/actions/invite-member.ts
+++ b/src/modules/tenancy/actions/invite-member.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient as createAnonClient } from "@/lib/supabase/server";
-import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { createServiceClient } from "@/lib/supabase/service";
 import { type ActionResult } from "@/lib/errors";
 import { requirePermission } from "@/modules/authz";
 import { audit } from "@/modules/audit";
@@ -30,10 +30,7 @@ export async function inviteMemberAction(
     return { ok: false, message: "Sem permissão para convidar membros" };
   }
 
-  const adminClient = createServiceClient(
-    env.NEXT_PUBLIC_SUPABASE_URL,
-    env.SUPABASE_SERVICE_ROLE_KEY,
-  );
+  const adminClient = createServiceClient();
 
   const { data: invitedUser, error: inviteError } = await adminClient.auth.admin.inviteUserByEmail(
     email,

--- a/src/modules/tenancy/actions/invite-member.ts
+++ b/src/modules/tenancy/actions/invite-member.ts
@@ -1,0 +1,97 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient as createAnonClient } from "@/lib/supabase/server";
+import { createClient as createServiceClient } from "@supabase/supabase-js";
+import { type ActionResult } from "@/lib/errors";
+import { requirePermission } from "@/modules/authz";
+import { audit } from "@/modules/audit";
+import { env } from "@/core/config/env";
+
+export async function inviteMemberAction(
+  companyId: string,
+  email: string,
+  roleIds: string[],
+): Promise<ActionResult> {
+  if (!env.SUPABASE_SERVICE_ROLE_KEY) {
+    return { ok: false, message: "Service role não configurado" };
+  }
+
+  const supabase = await createAnonClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
+
+  try {
+    await requirePermission(companyId, "core:member:invite");
+  } catch {
+    return { ok: false, message: "Sem permissão para convidar membros" };
+  }
+
+  const adminClient = createServiceClient(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+
+  const { data: invitedUser, error: inviteError } = await adminClient.auth.admin.inviteUserByEmail(
+    email,
+    { redirectTo: `${env.NEXT_PUBLIC_APP_URL}/accept-invite` },
+  );
+
+  if (inviteError) return { ok: false, message: inviteError.message };
+
+  const invitedUserId = invitedUser.user.id;
+
+  const { data: existingMembership } = await supabase
+    .from("memberships")
+    .select("id, status")
+    .eq("company_id", companyId)
+    .eq("user_id", invitedUserId)
+    .maybeSingle();
+
+  if (existingMembership) {
+    if (existingMembership.status !== "invited") {
+      return { ok: false, message: "Usuário já é membro desta empresa" };
+    }
+    return { ok: false, message: "Usuário já possui convite pendente" };
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("memberships")
+    .insert({
+      company_id: companyId,
+      user_id: invitedUserId,
+      status: "invited",
+      invited_by: user.id,
+      invited_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+
+  if (membershipError) return { ok: false, message: membershipError.message };
+
+  if (roleIds.length > 0) {
+    const { error: rolesError } = await supabase.from("membership_roles").insert(
+      roleIds.map((roleId) => ({
+        membership_id: membership.id,
+        role_id: roleId,
+        assigned_by: user.id,
+      })),
+    );
+    if (rolesError) return { ok: false, message: rolesError.message };
+  }
+
+  await audit({
+    companyId,
+    action: "member.invite",
+    resourceType: "membership",
+    resourceId: membership.id,
+    status: "success",
+    metadata: { email, roleIds },
+  });
+
+  revalidatePath(`/[companySlug]/settings/members`, "page");
+  return { ok: true, message: `Convite enviado para ${email}` };
+}

--- a/src/modules/tenancy/actions/toggle-module.ts
+++ b/src/modules/tenancy/actions/toggle-module.ts
@@ -1,0 +1,113 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { AppError, type ActionResult } from "@/lib/errors";
+import { audit } from "@/modules/audit";
+
+export async function toggleModuleAction(
+  companyId: string,
+  moduleCode: string,
+  enable: boolean,
+): Promise<ActionResult> {
+  const supabase = await createClient();
+
+  const { data: isPlatformAdmin, error: rpcError } = await supabase.rpc("is_platform_admin");
+  if (rpcError) return { ok: false, message: rpcError.message };
+  if (!isPlatformAdmin) throw new AppError("Acesso negado", "ACCESS_DENIED");
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
+
+  if (enable) {
+    const { error } = await supabase.from("company_modules").insert({
+      company_id: companyId,
+      module_code: moduleCode,
+      enabled_by: user.id,
+    });
+    if (error) return { ok: false, message: error.message };
+
+    // Distribui permissões do módulo nas roles-sistema existentes
+    const { data: systemRoles } = await supabase
+      .from("roles")
+      .select("id, code")
+      .eq("company_id", companyId)
+      .eq("is_system", true);
+
+    for (const role of systemRoles ?? []) {
+      let actionsFilter: string[] = [];
+      if (role.code === "owner") {
+        // owner ganha tudo
+      } else if (role.code === "manager") {
+        actionsFilter = ["read", "create", "update", "delete", "export", "approve"];
+      } else if (role.code === "operator") {
+        actionsFilter = ["read", "create"];
+      }
+
+      const { data: perms } = await supabase
+        .from("permissions")
+        .select("code")
+        .eq("module_code", moduleCode)
+        .in(
+          "action",
+          actionsFilter.length
+            ? actionsFilter
+            : ["read", "create", "update", "delete", "export", "approve", "cancel"],
+        );
+
+      if (perms?.length) {
+        await supabase.from("role_permissions").upsert(
+          perms.map((p) => ({ role_id: role.id, permission_code: p.code })),
+          { onConflict: "role_id,permission_code", ignoreDuplicates: true },
+        );
+      }
+    }
+  } else {
+    const { error } = await supabase
+      .from("company_modules")
+      .delete()
+      .eq("company_id", companyId)
+      .eq("module_code", moduleCode);
+
+    if (error) return { ok: false, message: error.message };
+
+    // Remove permissões do módulo de todas as roles da empresa
+    const { data: permsToRemove } = await supabase
+      .from("permissions")
+      .select("code")
+      .eq("module_code", moduleCode);
+
+    if (permsToRemove?.length) {
+      const { data: companyRoles } = await supabase
+        .from("roles")
+        .select("id")
+        .eq("company_id", companyId);
+
+      const roleIds = (companyRoles ?? []).map((r) => r.id);
+      if (roleIds.length) {
+        await supabase
+          .from("role_permissions")
+          .delete()
+          .in("role_id", roleIds)
+          .in(
+            "permission_code",
+            permsToRemove.map((p) => p.code),
+          );
+      }
+    }
+  }
+
+  await audit({
+    companyId,
+    action: enable ? "module.enable" : "module.disable",
+    resourceType: "module",
+    resourceId: moduleCode,
+    status: "success",
+    metadata: { moduleCode },
+  });
+
+  revalidatePath(`/admin/companies/${companyId}/modules`);
+  return { ok: true, message: `Módulo ${enable ? "habilitado" : "desabilitado"} com sucesso` };
+}

--- a/src/modules/tenancy/actions/update-company-settings.ts
+++ b/src/modules/tenancy/actions/update-company-settings.ts
@@ -8,6 +8,7 @@ import { updateCompanySchema } from "../schemas/update-company";
 import { audit } from "@/modules/audit";
 
 export async function updateCompanySettingsAction(
+  companyId: string,
   _prev: ActionResult,
   formData: FormData,
 ): Promise<ActionResult> {
@@ -28,10 +29,10 @@ export async function updateCompanySettingsAction(
     return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
   }
 
-  const { id, name, plan, document, is_active } = parsed.data;
+  const { name, document } = parsed.data;
 
   try {
-    await requirePermission(id, "core:company:update");
+    await requirePermission(companyId, "core:company:update");
   } catch {
     return { ok: false, message: "Sem permissão para atualizar dados da empresa" };
   }
@@ -40,22 +41,20 @@ export async function updateCompanySettingsAction(
     .from("companies")
     .update({
       name,
-      plan,
       document: document ?? null,
-      is_active,
       updated_at: new Date().toISOString(),
     })
-    .eq("id", id);
+    .eq("id", companyId);
 
   if (error) return { ok: false, message: error.message };
 
   await audit({
-    companyId: id,
+    companyId,
     action: "company.update",
     resourceType: "company",
-    resourceId: id,
+    resourceId: companyId,
     status: "success",
-    metadata: { name, plan, is_active },
+    metadata: { name },
   });
 
   revalidatePath(`/[companySlug]/settings/general`, "page");

--- a/src/modules/tenancy/actions/update-company-settings.ts
+++ b/src/modules/tenancy/actions/update-company-settings.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { type ActionResult } from "@/lib/errors";
+import { requirePermission } from "@/modules/authz";
+import { updateCompanySchema } from "../schemas/update-company";
+import { audit } from "@/modules/audit";
+
+export async function updateCompanySettingsAction(
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
+
+  const rawData = {
+    ...Object.fromEntries(formData),
+    document: (formData.get("document") as string | null) || undefined,
+  };
+
+  const parsed = updateCompanySchema.safeParse(rawData);
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  const { id, name, plan, document, is_active } = parsed.data;
+
+  try {
+    await requirePermission(id, "core:company:update");
+  } catch {
+    return { ok: false, message: "Sem permissão para atualizar dados da empresa" };
+  }
+
+  const { error } = await supabase
+    .from("companies")
+    .update({
+      name,
+      plan,
+      document: document ?? null,
+      is_active,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id);
+
+  if (error) return { ok: false, message: error.message };
+
+  await audit({
+    companyId: id,
+    action: "company.update",
+    resourceType: "company",
+    resourceId: id,
+    status: "success",
+    metadata: { name, plan, is_active },
+  });
+
+  revalidatePath(`/[companySlug]/settings/general`, "page");
+  return { ok: true, message: "Empresa atualizada com sucesso" };
+}

--- a/src/modules/tenancy/actions/update-company.ts
+++ b/src/modules/tenancy/actions/update-company.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { AppError, type ActionResult } from "@/lib/errors";
-import { updateCompanySchema } from "../schemas/update-company";
+import { updateCompanyAdminSchema as updateCompanySchema } from "../schemas/update-company-admin";
 import { audit } from "@/modules/audit";
 
 /**

--- a/src/modules/tenancy/actions/update-member-roles.ts
+++ b/src/modules/tenancy/actions/update-member-roles.ts
@@ -34,6 +34,17 @@ export async function updateMemberRolesAction(
   if (fetchError) return { ok: false, message: fetchError.message };
   if (!membership) return { ok: false, message: "Membro não encontrado" };
 
+  if (roleIds.length > 0) {
+    const { data: validRoles } = await supabase
+      .from("roles")
+      .select("id")
+      .eq("company_id", companyId)
+      .in("id", roleIds);
+    if (!validRoles || validRoles.length !== roleIds.length) {
+      return { ok: false, message: "Uma ou mais roles são inválidas" };
+    }
+  }
+
   const { error: deleteError } = await supabase
     .from("membership_roles")
     .delete()

--- a/src/modules/tenancy/actions/update-member-roles.ts
+++ b/src/modules/tenancy/actions/update-member-roles.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { type ActionResult } from "@/lib/errors";
+import { requirePermission } from "@/modules/authz";
+import { audit } from "@/modules/audit";
+
+export async function updateMemberRolesAction(
+  companyId: string,
+  membershipId: string,
+  roleIds: string[],
+): Promise<ActionResult> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
+
+  try {
+    await requirePermission(companyId, "core:member:manage");
+  } catch {
+    return { ok: false, message: "Sem permissão para gerenciar membros" };
+  }
+
+  const { data: membership, error: fetchError } = await supabase
+    .from("memberships")
+    .select("id, user_id")
+    .eq("id", membershipId)
+    .eq("company_id", companyId)
+    .maybeSingle();
+
+  if (fetchError) return { ok: false, message: fetchError.message };
+  if (!membership) return { ok: false, message: "Membro não encontrado" };
+
+  const { error: deleteError } = await supabase
+    .from("membership_roles")
+    .delete()
+    .eq("membership_id", membershipId);
+
+  if (deleteError) return { ok: false, message: deleteError.message };
+
+  if (roleIds.length > 0) {
+    const { error: insertError } = await supabase.from("membership_roles").insert(
+      roleIds.map((roleId) => ({
+        membership_id: membershipId,
+        role_id: roleId,
+        assigned_by: user.id,
+      })),
+    );
+    if (insertError) return { ok: false, message: insertError.message };
+  }
+
+  await audit({
+    companyId,
+    action: "member.roles_update",
+    resourceType: "membership",
+    resourceId: membershipId,
+    status: "success",
+    metadata: { memberUserId: membership.user_id, roleIds },
+  });
+
+  revalidatePath(`/[companySlug]/settings/members`, "page");
+  return { ok: true, message: "Roles do membro atualizadas" };
+}

--- a/src/modules/tenancy/actions/update-member-status.ts
+++ b/src/modules/tenancy/actions/update-member-status.ts
@@ -1,0 +1,82 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { type ActionResult } from "@/lib/errors";
+import { requirePermission } from "@/modules/authz";
+import { audit } from "@/modules/audit";
+import type { Enums } from "@/types/database.types";
+
+type MembershipStatus = Enums<"membership_status"> | "removed";
+
+export async function updateMemberStatusAction(
+  companyId: string,
+  membershipId: string,
+  status: MembershipStatus,
+): Promise<ActionResult> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
+
+  try {
+    await requirePermission(companyId, "core:member:manage");
+  } catch {
+    return { ok: false, message: "Sem permissão para gerenciar membros" };
+  }
+
+  const { data: membership, error: fetchError } = await supabase
+    .from("memberships")
+    .select("id, user_id, is_owner")
+    .eq("id", membershipId)
+    .eq("company_id", companyId)
+    .maybeSingle();
+
+  if (fetchError) return { ok: false, message: fetchError.message };
+  if (!membership) return { ok: false, message: "Membro não encontrado" };
+
+  if (membership.is_owner && (status === "suspended" || status === "removed")) {
+    return { ok: false, message: "Não é possível suspender ou remover o proprietário da empresa" };
+  }
+
+  if (status === "removed") {
+    const { error } = await supabase
+      .from("memberships")
+      .delete()
+      .eq("id", membershipId)
+      .eq("company_id", companyId);
+
+    if (error) return { ok: false, message: error.message };
+
+    await audit({
+      companyId,
+      action: "member.remove",
+      resourceType: "membership",
+      resourceId: membershipId,
+      status: "success",
+      metadata: { memberUserId: membership.user_id },
+    });
+  } else {
+    const { error } = await supabase
+      .from("memberships")
+      .update({ status })
+      .eq("id", membershipId)
+      .eq("company_id", companyId);
+
+    if (error) return { ok: false, message: error.message };
+
+    await audit({
+      companyId,
+      action: "member.status_update",
+      resourceType: "membership",
+      resourceId: membershipId,
+      status: "success",
+      metadata: { memberUserId: membership.user_id, newStatus: status },
+    });
+  }
+
+  revalidatePath(`/[companySlug]/settings/members`, "page");
+  return { ok: true, message: "Status do membro atualizado" };
+}

--- a/src/modules/tenancy/actions/update-role-permissions.ts
+++ b/src/modules/tenancy/actions/update-role-permissions.ts
@@ -61,6 +61,7 @@ export async function updateRolePermissionsAction(
   const desiredSet = new Set(filteredRequested);
 
   const toAdd = filteredRequested.filter((code) => !currentSet.has(code));
+  // Só remove perms de módulos habilitados — módulos desabilitados são preservados.
   const toRemove = [...currentSet].filter((code) => !desiredSet.has(code) && validSet.has(code));
 
   if (toRemove.length > 0) {
@@ -88,7 +89,7 @@ export async function updateRolePermissionsAction(
     resourceType: "role",
     resourceId: roleId,
     status: "success",
-    metadata: { added: toAdd.length, removed: toRemove.length },
+    metadata: { added: toAdd, removed: toRemove },
   });
 
   revalidatePath("/", "layout");

--- a/src/modules/tenancy/actions/update-role-permissions.ts
+++ b/src/modules/tenancy/actions/update-role-permissions.ts
@@ -1,0 +1,96 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { type ActionResult } from "@/lib/errors";
+import { requirePermission } from "@/modules/authz";
+import { audit } from "@/modules/audit";
+
+export async function updateRolePermissionsAction(
+  companyId: string,
+  roleId: string,
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  try {
+    await requirePermission(companyId, "core:role:manage");
+  } catch {
+    return { ok: false, message: "Sem permissão para gerenciar roles" };
+  }
+
+  const supabase = await createClient();
+
+  const { data: role, error: roleErr } = await supabase
+    .from("roles")
+    .select("id, is_system, company_id")
+    .eq("id", roleId)
+    .eq("company_id", companyId)
+    .maybeSingle();
+
+  if (roleErr) return { ok: false, message: roleErr.message };
+  if (!role) return { ok: false, message: "Role não encontrada" };
+  if (role.is_system)
+    return {
+      ok: false,
+      message: "Permissões de roles de sistema não podem ser alteradas manualmente",
+    };
+
+  const [{ data: currentPerms, error: curErr }, { data: enabledModules, error: modErr }] =
+    await Promise.all([
+      supabase.from("role_permissions").select("permission_code").eq("role_id", roleId),
+      supabase.from("company_modules").select("module_code").eq("company_id", companyId),
+    ]);
+
+  if (curErr) return { ok: false, message: curErr.message };
+  if (modErr) return { ok: false, message: modErr.message };
+
+  const moduleCodes = (enabledModules ?? []).map((m) => m.module_code);
+
+  const { data: validPerms, error: validErr } = await supabase
+    .from("permissions")
+    .select("code")
+    .in("module_code", moduleCodes.length ? moduleCodes : [""]);
+
+  if (validErr) return { ok: false, message: validErr.message };
+
+  const validSet = new Set((validPerms ?? []).map((p) => p.code));
+  const currentSet = new Set((currentPerms ?? []).map((p) => p.permission_code));
+
+  const requested = formData.getAll("permission_code") as string[];
+  const filteredRequested = requested.filter((code) => validSet.has(code));
+  const desiredSet = new Set(filteredRequested);
+
+  const toAdd = filteredRequested.filter((code) => !currentSet.has(code));
+  const toRemove = [...currentSet].filter((code) => !desiredSet.has(code) && validSet.has(code));
+
+  if (toRemove.length > 0) {
+    const { error: delErr } = await supabase
+      .from("role_permissions")
+      .delete()
+      .eq("role_id", roleId)
+      .in("permission_code", toRemove);
+
+    if (delErr) return { ok: false, message: delErr.message };
+  }
+
+  if (toAdd.length > 0) {
+    const { error: insErr } = await supabase.from("role_permissions").upsert(
+      toAdd.map((code) => ({ role_id: roleId, permission_code: code })),
+      { onConflict: "role_id,permission_code", ignoreDuplicates: true },
+    );
+
+    if (insErr) return { ok: false, message: insErr.message };
+  }
+
+  await audit({
+    companyId,
+    action: "role.permissions_update",
+    resourceType: "role",
+    resourceId: roleId,
+    status: "success",
+    metadata: { added: toAdd.length, removed: toRemove.length },
+  });
+
+  revalidatePath("/", "layout");
+  return { ok: true, message: "Permissões atualizadas" };
+}

--- a/src/modules/tenancy/actions/update-role.ts
+++ b/src/modules/tenancy/actions/update-role.ts
@@ -9,6 +9,7 @@ import { updateRoleSchema } from "../schemas/update-role";
 
 export async function updateRoleAction(
   companyId: string,
+  roleId: string,
   _prev: ActionResult,
   formData: FormData,
 ): Promise<ActionResult> {
@@ -19,7 +20,6 @@ export async function updateRoleAction(
   }
 
   const parsed = updateRoleSchema.safeParse({
-    roleId: formData.get("roleId"),
     name: formData.get("name"),
     description: formData.get("description") || undefined,
   });
@@ -27,11 +27,11 @@ export async function updateRoleAction(
   if (!parsed.success) {
     return {
       ok: false,
-      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+      fieldErrors: parsed.error.flatten().fieldErrors,
     };
   }
 
-  const { roleId, name, description } = parsed.data;
+  const { name, description } = parsed.data;
 
   const supabase = await createClient();
 
@@ -61,6 +61,6 @@ export async function updateRoleAction(
     status: "success",
   });
 
-  revalidatePath("/[companySlug]/settings/roles", "page");
+  revalidatePath("/", "layout");
   return { ok: true, message: "Role atualizada" };
 }

--- a/src/modules/tenancy/actions/update-role.ts
+++ b/src/modules/tenancy/actions/update-role.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { type ActionResult } from "@/lib/errors";
+import { requirePermission } from "@/modules/authz";
+import { audit } from "@/modules/audit";
+import { updateRoleSchema } from "../schemas/update-role";
+
+export async function updateRoleAction(
+  companyId: string,
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  try {
+    await requirePermission(companyId, "core:role:manage");
+  } catch {
+    return { ok: false, message: "Sem permissão para gerenciar roles" };
+  }
+
+  const parsed = updateRoleSchema.safeParse({
+    roleId: formData.get("roleId"),
+    name: formData.get("name"),
+    description: formData.get("description") || undefined,
+  });
+
+  if (!parsed.success) {
+    return {
+      ok: false,
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const { roleId, name, description } = parsed.data;
+
+  const supabase = await createClient();
+
+  const { data: existing, error: fetchError } = await supabase
+    .from("roles")
+    .select("id, is_system, company_id")
+    .eq("id", roleId)
+    .eq("company_id", companyId)
+    .maybeSingle();
+
+  if (fetchError) return { ok: false, message: fetchError.message };
+  if (!existing) return { ok: false, message: "Role não encontrada" };
+  if (existing.is_system) return { ok: false, message: "Roles de sistema não podem ser editadas" };
+
+  const { error } = await supabase
+    .from("roles")
+    .update({ name, description: description ?? null, updated_at: new Date().toISOString() })
+    .eq("id", roleId);
+
+  if (error) return { ok: false, message: error.message };
+
+  await audit({
+    companyId,
+    action: "role.update",
+    resourceType: "role",
+    resourceId: roleId,
+    status: "success",
+  });
+
+  revalidatePath("/[companySlug]/settings/roles", "page");
+  return { ok: true, message: "Role atualizada" };
+}

--- a/src/modules/tenancy/client.ts
+++ b/src/modules/tenancy/client.ts
@@ -1,0 +1,12 @@
+// Ponto de entrada para Client Components — exporta apenas Server Actions ("use server").
+// Não re-exporta queries/services com server-only; use @/modules/tenancy para Server Components.
+export { updateCompanySettingsAction } from "./actions/update-company-settings";
+export { inviteMemberAction } from "./actions/invite-member";
+export { updateMemberStatusAction } from "./actions/update-member-status";
+export { updateMemberRolesAction } from "./actions/update-member-roles";
+export { createRoleAction } from "./actions/create-role";
+export { updateRoleAction } from "./actions/update-role";
+export { deleteRoleAction } from "./actions/delete-role";
+export { updateRolePermissionsAction } from "./actions/update-role-permissions";
+export { switchActiveCompanyAction } from "./actions/switch-active-company";
+export { toggleModuleAction } from "./actions/toggle-module";

--- a/src/modules/tenancy/components/module-toggle-list.tsx
+++ b/src/modules/tenancy/components/module-toggle-list.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useTransition } from "react";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+import { toggleModuleAction } from "../actions/toggle-module";
+import type { CompanyModuleStatus } from "../queries/list-company-modules";
+
+export function ModuleToggleList({
+  companyId,
+  modules,
+}: {
+  companyId: string;
+  modules: CompanyModuleStatus[];
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleToggle(moduleCode: string, newEnabled: boolean) {
+    startTransition(async () => {
+      const result = await toggleModuleAction(companyId, moduleCode, newEnabled);
+      if (result.ok) {
+        toast.success(result.message ?? "Alteração salva");
+      } else {
+        toast.error(result.message ?? "Erro ao alterar módulo");
+      }
+    });
+  }
+
+  return (
+    <div className="divide-y rounded-lg border">
+      {modules.map((mod) => (
+        <div key={mod.code} className="flex items-center justify-between p-4">
+          <div className="space-y-0.5">
+            <div className="flex items-center gap-2">
+              <Label htmlFor={`mod-${mod.code}`} className="cursor-pointer text-base font-medium">
+                {mod.name}
+              </Label>
+              {mod.is_system && (
+                <Badge variant="secondary" className="text-xs">
+                  sistema
+                </Badge>
+              )}
+            </div>
+            {mod.description && <p className="text-sm text-muted-foreground">{mod.description}</p>}
+            <p className="font-mono text-xs text-muted-foreground">{mod.code}</p>
+          </div>
+          <Switch
+            id={`mod-${mod.code}`}
+            checked={mod.enabled}
+            disabled={isPending || mod.is_system}
+            onCheckedChange={(checked: boolean) => handleToggle(mod.code, checked)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/modules/tenancy/index.ts
+++ b/src/modules/tenancy/index.ts
@@ -5,6 +5,10 @@ export { switchActiveCompanyAction } from "./actions/switch-active-company";
 export { createCompanyAction } from "./actions/create-company";
 export { updateCompanyAction } from "./actions/update-company";
 export { toggleModuleAction } from "./actions/toggle-module";
+export { inviteMemberAction } from "./actions/invite-member";
+export { updateMemberStatusAction } from "./actions/update-member-status";
+export { updateMemberRolesAction } from "./actions/update-member-roles";
+export { updateCompanySettingsAction } from "./actions/update-company-settings";
 
 // Queries
 export { listMyCompanies } from "./queries/list-my-companies";
@@ -13,6 +17,7 @@ export { listAllCompanies } from "./queries/list-all-companies";
 export { listModules } from "./queries/list-modules";
 export { listCompanyModules } from "./queries/list-company-modules";
 export { listCompanyMembers } from "./queries/list-company-members";
+export { listCompanyRoles } from "./queries/list-company-roles";
 
 // Services
 export { getActiveCompanyId } from "./services/active-company";
@@ -29,3 +34,4 @@ export type { Company } from "./queries/list-my-companies";
 export type { Module } from "./queries/list-modules";
 export type { CompanyModuleStatus } from "./queries/list-company-modules";
 export type { CompanyMember } from "./queries/list-company-members";
+export type { CompanyRole } from "./queries/list-company-roles";

--- a/src/modules/tenancy/index.ts
+++ b/src/modules/tenancy/index.ts
@@ -9,6 +9,9 @@ export { inviteMemberAction } from "./actions/invite-member";
 export { updateMemberStatusAction } from "./actions/update-member-status";
 export { updateMemberRolesAction } from "./actions/update-member-roles";
 export { updateCompanySettingsAction } from "./actions/update-company-settings";
+export { createRoleAction } from "./actions/create-role";
+export { updateRoleAction } from "./actions/update-role";
+export { deleteRoleAction } from "./actions/delete-role";
 
 // Queries
 export { listMyCompanies } from "./queries/list-my-companies";

--- a/src/modules/tenancy/index.ts
+++ b/src/modules/tenancy/index.ts
@@ -4,12 +4,15 @@
 export { switchActiveCompanyAction } from "./actions/switch-active-company";
 export { createCompanyAction } from "./actions/create-company";
 export { updateCompanyAction } from "./actions/update-company";
+export { toggleModuleAction } from "./actions/toggle-module";
 
 // Queries
 export { listMyCompanies } from "./queries/list-my-companies";
 export { resolveCompany } from "./queries/resolve-company";
 export { listAllCompanies } from "./queries/list-all-companies";
 export { listModules } from "./queries/list-modules";
+export { listCompanyModules } from "./queries/list-company-modules";
+export { listCompanyMembers } from "./queries/list-company-members";
 
 // Services
 export { getActiveCompanyId } from "./services/active-company";
@@ -19,7 +22,10 @@ export { CompanySwitcher } from "./components/company-switcher";
 export { CompanyBadge } from "./components/company-badge";
 export { CreateCompanyForm } from "./components/create-company-form";
 export { UpdateCompanyForm } from "./components/update-company-form";
+export { ModuleToggleList } from "./components/module-toggle-list";
 
 // Types
 export type { Company } from "./queries/list-my-companies";
 export type { Module } from "./queries/list-modules";
+export type { CompanyModuleStatus } from "./queries/list-company-modules";
+export type { CompanyMember } from "./queries/list-company-members";

--- a/src/modules/tenancy/index.ts
+++ b/src/modules/tenancy/index.ts
@@ -12,6 +12,7 @@ export { updateCompanySettingsAction } from "./actions/update-company-settings";
 export { createRoleAction } from "./actions/create-role";
 export { updateRoleAction } from "./actions/update-role";
 export { deleteRoleAction } from "./actions/delete-role";
+export { updateRolePermissionsAction } from "./actions/update-role-permissions";
 
 // Queries
 export { listMyCompanies } from "./queries/list-my-companies";
@@ -21,6 +22,8 @@ export { listModules } from "./queries/list-modules";
 export { listCompanyModules } from "./queries/list-company-modules";
 export { listCompanyMembers } from "./queries/list-company-members";
 export { listCompanyRoles } from "./queries/list-company-roles";
+export { listRolePermissionMatrix } from "./queries/list-role-permission-matrix";
+export type { ModulePermissions, PermissionRow } from "./queries/list-role-permission-matrix";
 
 // Services
 export { getActiveCompanyId } from "./services/active-company";

--- a/src/modules/tenancy/queries/list-company-members.ts
+++ b/src/modules/tenancy/queries/list-company-members.ts
@@ -1,0 +1,58 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+
+export type CompanyMember = {
+  membershipId: string;
+  userId: string;
+  fullName: string;
+  status: string;
+  isOwner: boolean;
+  joinedAt: string | null;
+  roles: { id: string; name: string; code: string }[];
+};
+
+export async function listCompanyMembers(companyId: string): Promise<CompanyMember[]> {
+  const supabase = await createClient();
+
+  const { data: memberships, error: memErr } = await supabase
+    .from("memberships")
+    .select(
+      `
+      id,
+      user_id,
+      status,
+      is_owner,
+      joined_at,
+      membership_roles (
+        roles ( id, name, code )
+      )
+    `,
+    )
+    .eq("company_id", companyId)
+    .order("joined_at", { ascending: false });
+
+  if (memErr) throw memErr;
+
+  if (!memberships?.length) return [];
+
+  const userIds = memberships.map((m) => m.user_id);
+  const { data: profiles } = await supabase
+    .from("profiles")
+    .select("id, full_name")
+    .in("id", userIds);
+
+  const profileMap = new Map((profiles ?? []).map((p) => [p.id, p.full_name]));
+
+  return memberships.map((row) => ({
+    membershipId: row.id,
+    userId: row.user_id,
+    fullName: profileMap.get(row.user_id) ?? "—",
+    status: row.status,
+    isOwner: row.is_owner,
+    joinedAt: row.joined_at,
+    roles: (row.membership_roles ?? [])
+      .map((mr) => mr.roles)
+      .filter((r): r is { id: string; name: string; code: string } => r !== null),
+  }));
+}

--- a/src/modules/tenancy/queries/list-company-modules.ts
+++ b/src/modules/tenancy/queries/list-company-modules.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+import type { Tables } from "@/types/database.types";
+
+export type Module = Tables<"modules">;
+export type CompanyModuleStatus = Module & { enabled: boolean };
+
+export async function listCompanyModules(companyId: string): Promise<CompanyModuleStatus[]> {
+  const supabase = await createClient();
+
+  const [{ data: allModules, error: modErr }, { data: enabledModules, error: cmErr }] =
+    await Promise.all([
+      supabase.from("modules").select("*").eq("is_active", true).order("sort_order"),
+      supabase.from("company_modules").select("module_code").eq("company_id", companyId),
+    ]);
+
+  if (modErr) throw modErr;
+  if (cmErr) throw cmErr;
+
+  const enabledSet = new Set((enabledModules ?? []).map((r) => r.module_code));
+
+  return (allModules ?? []).map((m) => ({ ...m, enabled: enabledSet.has(m.code) }));
+}

--- a/src/modules/tenancy/queries/list-company-roles.ts
+++ b/src/modules/tenancy/queries/list-company-roles.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+
+export type CompanyRole = {
+  id: string;
+  code: string;
+  name: string;
+  isSystem: boolean;
+};
+
+export async function listCompanyRoles(companyId: string): Promise<CompanyRole[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("roles")
+    .select("id, code, name, is_system")
+    .eq("company_id", companyId)
+    .order("is_system", { ascending: false })
+    .order("name");
+
+  if (error) throw error;
+
+  return (data ?? []).map((r) => ({
+    id: r.id,
+    code: r.code,
+    name: r.name,
+    isSystem: r.is_system,
+  }));
+}

--- a/src/modules/tenancy/queries/list-company-roles.ts
+++ b/src/modules/tenancy/queries/list-company-roles.ts
@@ -6,6 +6,7 @@ export type CompanyRole = {
   id: string;
   code: string;
   name: string;
+  description: string | null;
   isSystem: boolean;
 };
 
@@ -14,7 +15,7 @@ export async function listCompanyRoles(companyId: string): Promise<CompanyRole[]
 
   const { data, error } = await supabase
     .from("roles")
-    .select("id, code, name, is_system")
+    .select("id, code, name, description, is_system")
     .eq("company_id", companyId)
     .order("is_system", { ascending: false })
     .order("name");
@@ -25,6 +26,7 @@ export async function listCompanyRoles(companyId: string): Promise<CompanyRole[]
     id: r.id,
     code: r.code,
     name: r.name,
+    description: r.description ?? null,
     isSystem: r.is_system,
   }));
 }

--- a/src/modules/tenancy/queries/list-role-permission-matrix.ts
+++ b/src/modules/tenancy/queries/list-role-permission-matrix.ts
@@ -1,0 +1,74 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+
+export type PermissionRow = {
+  code: string;
+  resource: string;
+  action: string;
+  description: string | null;
+  granted: boolean;
+};
+
+export type ModulePermissions = {
+  moduleCode: string;
+  moduleName: string;
+  permissions: PermissionRow[];
+};
+
+export async function listRolePermissionMatrix(
+  companyId: string,
+  roleId: string,
+): Promise<ModulePermissions[]> {
+  const supabase = await createClient();
+
+  const [{ data: enabledModules, error: modErr }, { data: grantedPerms, error: grantErr }] =
+    await Promise.all([
+      supabase
+        .from("company_modules")
+        .select("module_code, modules(name)")
+        .eq("company_id", companyId),
+      supabase.from("role_permissions").select("permission_code").eq("role_id", roleId),
+    ]);
+
+  if (modErr) throw modErr;
+  if (grantErr) throw grantErr;
+
+  if (!enabledModules || enabledModules.length === 0) return [];
+
+  const moduleCodes = enabledModules.map((m) => m.module_code);
+  const grantedSet = new Set((grantedPerms ?? []).map((p) => p.permission_code));
+
+  const { data: allPerms, error: permErr } = await supabase
+    .from("permissions")
+    .select("code, module_code, resource, action, description")
+    .in("module_code", moduleCodes)
+    .order("module_code")
+    .order("resource")
+    .order("action");
+
+  if (permErr) throw permErr;
+
+  const moduleMap = new Map<string, { moduleName: string; permissions: PermissionRow[] }>();
+
+  for (const em of enabledModules) {
+    const name = (em.modules as { name: string } | null)?.name ?? em.module_code;
+    moduleMap.set(em.module_code, { moduleName: name, permissions: [] });
+  }
+
+  for (const perm of allPerms ?? []) {
+    const entry = moduleMap.get(perm.module_code);
+    if (!entry) continue;
+    entry.permissions.push({
+      code: perm.code,
+      resource: perm.resource,
+      action: perm.action,
+      description: perm.description,
+      granted: grantedSet.has(perm.code),
+    });
+  }
+
+  return Array.from(moduleMap.entries())
+    .filter(([, v]) => v.permissions.length > 0)
+    .map(([moduleCode, { moduleName, permissions }]) => ({ moduleCode, moduleName, permissions }));
+}

--- a/src/modules/tenancy/schemas/create-role.ts
+++ b/src/modules/tenancy/schemas/create-role.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createRoleSchema = z.object({
+  name: z.string().min(2).max(50),
+  description: z.string().max(200).optional(),
+});
+
+export type CreateRoleInput = z.infer<typeof createRoleSchema>;

--- a/src/modules/tenancy/schemas/index.ts
+++ b/src/modules/tenancy/schemas/index.ts
@@ -6,3 +6,8 @@ export const switchActiveCompanySchema = z.object({
 });
 
 export type SwitchActiveCompanyInput = z.infer<typeof switchActiveCompanySchema>;
+
+export { createRoleSchema } from "./create-role";
+export type { CreateRoleInput } from "./create-role";
+export { updateRoleSchema } from "./update-role";
+export type { UpdateRoleInput } from "./update-role";

--- a/src/modules/tenancy/schemas/update-company-admin.ts
+++ b/src/modules/tenancy/schemas/update-company-admin.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const updateCompanyAdminSchema = z.object({
+  id: z.string().uuid("ID de empresa inválido"),
+  name: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
+  plan: z.enum(["starter", "pro", "enterprise"], {
+    errorMap: () => ({ message: "Plano inválido" }),
+  }),
+  document: z.string().optional(),
+  is_active: z
+    .string()
+    .optional()
+    .transform((v) => v === "on" || v === "true"),
+});
+
+export type UpdateCompanyAdminInput = z.infer<typeof updateCompanyAdminSchema>;

--- a/src/modules/tenancy/schemas/update-company.ts
+++ b/src/modules/tenancy/schemas/update-company.ts
@@ -1,16 +1,9 @@
 import { z } from "zod";
 
 export const updateCompanySchema = z.object({
-  id: z.string().uuid("ID de empresa inválido"),
   name: z.string().min(2, "Nome deve ter pelo menos 2 caracteres"),
-  plan: z.enum(["starter", "pro", "enterprise"], {
-    errorMap: () => ({ message: "Plano inválido" }),
-  }),
+  slug: z.string().optional(),
   document: z.string().optional(),
-  is_active: z
-    .string()
-    .optional()
-    .transform((v) => v === "on" || v === "true"),
 });
 
 export type UpdateCompanyInput = z.infer<typeof updateCompanySchema>;

--- a/src/modules/tenancy/schemas/update-role.ts
+++ b/src/modules/tenancy/schemas/update-role.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const updateRoleSchema = z.object({
+  roleId: z.string().uuid(),
+  name: z.string().min(2).max(50),
+  description: z.string().max(200).optional(),
+});
+
+export type UpdateRoleInput = z.infer<typeof updateRoleSchema>;

--- a/src/modules/tenancy/schemas/update-role.ts
+++ b/src/modules/tenancy/schemas/update-role.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 export const updateRoleSchema = z.object({
-  roleId: z.string().uuid(),
   name: z.string().min(2).max(50),
   description: z.string().max(200).optional(),
 });


### PR DESCRIPTION
## Summary

- Settings layout (`/[companySlug]/settings/`) com tabs Geral | Membros | Roles e indicador visual de tab ativa
- Gestão de membros: convite por e-mail, edição de roles, suspensão/remoção — gated por `core:member:invite` / `core:member:manage`
- CRUD de roles customizadas: criar, editar, excluir (roles `is_system` bloqueadas) — gated por `core:role:manage`
- Matriz de permissões por role: checkboxes agrupados por módulo habilitado, diff incremental, read-only para roles de sistema
- Testes unitários: 48 casos cobrindo todas as actions (invite, status, roles, permissions) — incluindo isolamento de módulos desabilitados e branches de convite pendente

## Arquitetura

- `companyId` e `roleId` sempre passados via `.bind()` (nunca do `FormData`) — sem escalada de privilégio por campo hidden
- `updateRolePermissionsAction` filtra permissões contra módulos habilitados antes do diff — injeção de perms de módulos off bloqueada
- `createServiceClient` extraído para `src/lib/supabase/service.ts` — reutilizável
- Roles `is_system=true`: UI read-only + guards na action

## Test Plan

- [ ] Criar empresa com módulos habilitados e navegar para `/[slug]/settings/`
- [ ] Tab ativa destaca corretamente em cada seção
- [ ] Convidar membro por e-mail → aparece com status "Convidado"
- [ ] Suspender / remover membro — feedback de erro se action falhar
- [ ] Criar role custom → aparece na lista sem badge "Sistema"
- [ ] Tentar editar role de sistema → formulário read-only
- [ ] Marcar/desmarcar permissões e salvar → recarrega matriz com estado correto
- [ ] Operator sem `core:role:manage` não acessa `/settings/roles/[id]`
- [ ] `npx vitest run` → 120 pass, 0 fail

## Checklist do roadmap

Fecha S7 do `ARCHITECTURE-MULTITENANT.md` (PRs #33–#35 + #35.5). Próximo: S8 — sprint de _contract_ (remover legado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)