### PR TITLE
feat(ux): polish — paginação, sidebar, formulários e dashboard

### DIFF
--- a/src/app/(dashboard)/[companySlug]/inventory/[id]/delete-product-form.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/[id]/delete-product-form.tsx
@@ -1,10 +1,20 @@
 "use client";
 
-import { useActionState } from "react";
-import { useEffect } from "react";
+import { useActionState, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useFormStatus } from "react-dom";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import type { ActionResult } from "@/lib/errors";
 
 const initial: ActionResult = { ok: false };
@@ -16,6 +26,7 @@ type Props = {
 
 export function DeleteProductForm({ deleteAction, isActive }: Props) {
   const [state, formAction] = useActionState(deleteAction, initial);
+  const formRef = useRef<HTMLFormElement>(null);
 
   useEffect(() => {
     if (!state.ok && state.message) toast.error(state.message);
@@ -26,9 +37,34 @@ export function DeleteProductForm({ deleteAction, isActive }: Props) {
   }
 
   return (
-    <form action={formAction}>
-      <SubmitButton />
-    </form>
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button type="button" variant="destructive">
+          Desativar produto
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Desativar produto?</AlertDialogTitle>
+          <AlertDialogDescription>
+            O produto será marcado como inativo. O histórico de movimentações é preservado. Esta
+            ação pode ser revertida reativando o produto.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => formRef.current?.requestSubmit()}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Confirmar desativação
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+      <form ref={formRef} action={formAction} className="hidden">
+        <SubmitButton />
+      </form>
+    </AlertDialog>
   );
 }
 

--- a/src/app/(dashboard)/[companySlug]/inventory/[id]/loading.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/[id]/loading.tsx
@@ -1,0 +1,31 @@
+export default function ProductDetailLoading() {
+  return (
+    <div className="space-y-8">
+      <div className="flex items-start justify-between">
+        <div className="space-y-2">
+          <div className="h-8 w-56 animate-pulse rounded-md bg-muted" />
+          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+        </div>
+        <div className="h-9 w-20 animate-pulse rounded-md bg-muted" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="rounded-lg border p-4">
+            <div className="mb-2 h-3 w-20 animate-pulse rounded bg-muted" />
+            <div className="h-7 w-28 animate-pulse rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+
+      <div className="space-y-4 rounded-lg border p-6">
+        <div className="h-6 w-32 animate-pulse rounded bg-muted" />
+        <div className="grid grid-cols-2 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-9 animate-pulse rounded-md bg-muted/60" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/inventory/[id]/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/[id]/page.tsx
@@ -100,6 +100,8 @@ export default async function ProductDetailPage({ params }: Props) {
             total={movements.total}
             page={movements.page}
             totalPages={movements.totalPages}
+            basePath={`/${companySlug}/inventory/movements`}
+            productId={product.id}
           />
         </div>
       </Can>

--- a/src/app/(dashboard)/[companySlug]/inventory/loading.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/loading.tsx
@@ -1,0 +1,23 @@
+export default function InventoryLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div className="space-y-2">
+          <div className="h-8 w-64 animate-pulse rounded-md bg-muted" />
+          <div className="h-4 w-40 animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="h-9 w-32 animate-pulse rounded-md bg-muted" />
+      </div>
+
+      <div className="h-9 w-72 animate-pulse rounded-md bg-muted" />
+
+      <div className="rounded-lg border">
+        <div className="space-y-3 p-4">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="h-10 animate-pulse rounded-md bg-muted/60" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/inventory/movements/loading.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/movements/loading.tsx
@@ -1,0 +1,27 @@
+export default function MovementsLoading() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <div className="h-8 w-72 animate-pulse rounded-md bg-muted" />
+        <div className="h-4 w-48 animate-pulse rounded-md bg-muted" />
+      </div>
+
+      <div className="space-y-4 rounded-lg border p-6">
+        <div className="h-5 w-40 animate-pulse rounded bg-muted" />
+        <div className="grid grid-cols-2 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-9 animate-pulse rounded-md bg-muted/60" />
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-lg border">
+        <div className="space-y-3 p-4">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="h-10 animate-pulse rounded-md bg-muted/60" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/[companySlug]/inventory/movements/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/movements/page.tsx
@@ -57,6 +57,7 @@ export default async function MovementsPage({ params, searchParams }: Props) {
           total={movements.total}
           page={movements.page}
           totalPages={movements.totalPages}
+          basePath={`/${companySlug}/inventory/movements`}
         />
       </div>
     </section>

--- a/src/app/(dashboard)/[companySlug]/inventory/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/page.tsx
@@ -17,7 +17,12 @@ export default async function InventoryPage({ params, searchParams }: Props) {
   const { companySlug } = await params;
   const company = await resolveCompany(companySlug);
   const rawParams = await searchParams;
-  const { data, total, page, pageSize, totalPages } = await listProducts(company.id, rawParams);
+  const showInactive = rawParams.inactive === "true";
+  const queryParams = { ...rawParams, onlyActive: showInactive ? "false" : "true" };
+  const { data, total, page, pageSize, totalPages } = await listProducts(company.id, queryParams);
+
+  const basePath = `/${companySlug}/inventory`;
+  const toggleHref = showInactive ? basePath : `${basePath}?inactive=true`;
 
   return (
     <section className="space-y-6">
@@ -40,17 +45,23 @@ export default async function InventoryPage({ params, searchParams }: Props) {
         </div>
       </header>
 
-      <form className="flex gap-2">
-        <Input
-          name="q"
-          defaultValue={rawParams.q ?? ""}
-          placeholder="Buscar por nome ou SKU..."
-          className="max-w-sm"
-        />
-        <Button type="submit" variant="secondary">
-          Buscar
+      <div className="flex flex-wrap items-center gap-2">
+        <form className="flex gap-2">
+          {showInactive && <input type="hidden" name="inactive" value="true" />}
+          <Input
+            name="q"
+            defaultValue={rawParams.q ?? ""}
+            placeholder="Buscar por nome ou SKU..."
+            className="max-w-sm"
+          />
+          <Button type="submit" variant="secondary">
+            Buscar
+          </Button>
+        </form>
+        <Button asChild variant={showInactive ? "default" : "outline"} size="sm">
+          <Link href={toggleHref}>{showInactive ? "Ocultar inativos" : "Mostrar inativos"}</Link>
         </Button>
-      </form>
+      </div>
 
       <ProductTable
         data={data}
@@ -58,9 +69,10 @@ export default async function InventoryPage({ params, searchParams }: Props) {
         page={page}
         pageSize={pageSize}
         totalPages={totalPages}
-        basePath={`/${companySlug}/inventory`}
+        basePath={basePath}
         searchQuery={rawParams.q}
         createHref={`/${companySlug}/inventory/new`}
+        showInactive={showInactive}
       />
     </section>
   );

--- a/src/app/(dashboard)/[companySlug]/inventory/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/page.tsx
@@ -59,6 +59,8 @@ export default async function InventoryPage({ params, searchParams }: Props) {
         pageSize={pageSize}
         totalPages={totalPages}
         basePath={`/${companySlug}/inventory`}
+        searchQuery={rawParams.q}
+        createHref={`/${companySlug}/inventory/new`}
       />
     </section>
   );

--- a/src/app/(dashboard)/[companySlug]/inventory/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/inventory/page.tsx
@@ -18,7 +18,7 @@ export default async function InventoryPage({ params, searchParams }: Props) {
   const company = await resolveCompany(companySlug);
   const rawParams = await searchParams;
   const showInactive = rawParams.inactive === "true";
-  const queryParams = { ...rawParams, onlyActive: showInactive ? "false" : "true" };
+  const queryParams = { ...rawParams, onlyActive: !showInactive };
   const { data, total, page, pageSize, totalPages } = await listProducts(company.id, queryParams);
 
   const basePath = `/${companySlug}/inventory`;

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,4 @@
 import { redirect } from "next/navigation";
-import Link from "next/link";
 import { signOutAction } from "@/modules/auth";
 import { Button } from "@/components/ui/button";
 import { MODULES_MENU, ADMIN_MENU } from "@/core/navigation/menu";
@@ -7,6 +6,7 @@ import { getCurrentUser } from "@/modules/auth";
 import { CompanySwitcher, listMyCompanies, getActiveCompanyId } from "@/modules/tenancy";
 import { createClient } from "@/lib/supabase/server";
 import { getEffectivePermissions } from "@/modules/authz";
+import { SidebarNav } from "@/components/layout/sidebar-nav";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const user = await getCurrentUser();
@@ -26,6 +26,17 @@ export default async function DashboardLayout({ children }: { children: React.Re
   const activeCompany = companies.find((c) => c.id === activeCompanyId) ?? companies[0];
   const companySlug = activeCompany?.slug ?? "";
 
+  const filteredModules = MODULES_MENU.filter((item) => {
+    if (!item.requiresPermission) return true;
+    if (isPlatformAdmin) return true;
+    return userPerms.has(item.requiresPermission) || userPerms.has("*");
+  }).map((item) => ({
+    ...item,
+    resolvedHref: item.requiresSlug && companySlug ? `/${companySlug}${item.href}` : item.href,
+  }));
+
+  const adminItems = ADMIN_MENU.map((item) => ({ ...item, resolvedHref: item.href }));
+
   return (
     <div className="grid min-h-screen grid-cols-[240px_1fr]">
       {/* Sidebar */}
@@ -35,43 +46,10 @@ export default async function DashboardLayout({ children }: { children: React.Re
           <p className="text-xs text-muted-foreground">{user.email}</p>
         </div>
 
-        <nav className="flex flex-col gap-1">
-          {MODULES_MENU.filter((item) => {
-            if (!item.requiresPermission) return true;
-            // Platform admin tem acesso irrestrito
-            if (isPlatformAdmin) return true;
-            return userPerms.has(item.requiresPermission) || userPerms.has("*");
-          }).map((item) => {
-            const href =
-              item.requiresSlug && companySlug ? `/${companySlug}${item.href}` : item.href;
-            return (
-              <Link
-                key={item.href}
-                href={href}
-                className="rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
-              >
-                {item.label}
-              </Link>
-            );
-          })}
-
-          {isPlatformAdmin && (
-            <div className="mt-6">
-              <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                Plataforma
-              </p>
-              {ADMIN_MENU.map((item) => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className="rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
-                >
-                  {item.label}
-                </Link>
-              ))}
-            </div>
-          )}
-        </nav>
+        <div className="flex flex-col gap-4">
+          <SidebarNav items={filteredModules} />
+          {isPlatformAdmin && <SidebarNav items={adminItems} groupLabel="Plataforma" />}
+        </div>
       </aside>
 
       {/* Main content */}

--- a/src/app/(dashboard)/loading.tsx
+++ b/src/app/(dashboard)/loading.tsx
@@ -1,0 +1,18 @@
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <div className="h-8 w-48 animate-pulse rounded-md bg-muted" />
+        <div className="h-4 w-32 animate-pulse rounded-md bg-muted" />
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="rounded-lg border bg-card p-5">
+            <div className="mb-2 h-4 w-24 animate-pulse rounded bg-muted" />
+            <div className="h-9 w-20 animate-pulse rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,14 +1,29 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { listProducts } from "@/modules/inventory";
 import { getActiveCompanyId, getActiveCompanySlug } from "@/modules/tenancy";
+import { formatCurrency } from "@/lib/utils";
 
 export const metadata = { title: "Dashboard — ERP" };
 
 export default async function DashboardPage() {
-  const [companyId, companySlug] = await Promise.all([getActiveCompanyId(), getActiveCompanySlug()]);
-  const { data, total } = await listProducts(companyId ?? "", { onlyActive: true, pageSize: 5 });
-  const lowStockCount = data.filter((p) => Number(p.stock) <= Number(p.min_stock)).length;
+  const [companyId, companySlug] = await Promise.all([
+    getActiveCompanyId(),
+    getActiveCompanySlug(),
+  ]);
+
+  const { data: allProducts, total } = await listProducts(companyId ?? "", {
+    onlyActive: true,
+    pageSize: 100,
+  });
+
+  const lowStockProducts = allProducts.filter((p) => Number(p.stock) <= Number(p.min_stock));
+  const lowStockCount = lowStockProducts.length;
+  const totalStockValue = allProducts.reduce(
+    (sum, p) => sum + Number(p.stock) * Number(p.cost_price),
+    0,
+  );
 
   const inventoryHref = companySlug ? `/${companySlug}/inventory` : "/";
   const movementsHref = companySlug ? `/${companySlug}/inventory/movements` : "/";
@@ -20,13 +35,12 @@ export default async function DashboardPage() {
         <p className="text-sm text-muted-foreground">Visão geral do sistema</p>
       </div>
 
-      {/* Métricas */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <MetricCard label="Produtos ativos" value={total} />
-        <MetricCard label="Estoque baixo" value={lowStockCount} alert={lowStockCount > 0} />
+        <MetricCard label="Produtos ativos" value={String(total)} />
+        <MetricCard label="Estoque baixo" value={String(lowStockCount)} alert={lowStockCount > 0} />
+        <MetricCard label="Valor em estoque" value={formatCurrency(totalStockValue)} />
       </div>
 
-      {/* Atalhos */}
       <div className="flex gap-3">
         <Button asChild>
           <Link href={inventoryHref}>Ver estoque</Link>
@@ -35,15 +49,55 @@ export default async function DashboardPage() {
           <Link href={movementsHref}>Registrar movimentação</Link>
         </Button>
       </div>
+
+      {lowStockCount > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Produtos com estoque baixo
+          </h2>
+          <div className="divide-y rounded-lg border">
+            {lowStockProducts.slice(0, 5).map((p) => (
+              <div key={p.id} className="flex items-center justify-between px-4 py-3">
+                <div>
+                  <Link
+                    href={`${inventoryHref}/${p.id}`}
+                    className="text-sm font-medium hover:underline"
+                  >
+                    {p.name}
+                  </Link>
+                  <p className="font-mono text-xs text-muted-foreground">{p.sku}</p>
+                </div>
+                <div className="text-right">
+                  <Badge variant="destructive" className="text-xs">
+                    {Number(p.stock).toFixed(3)} {p.unit}
+                  </Badge>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    mín: {Number(p.min_stock).toFixed(3)}
+                  </p>
+                </div>
+              </div>
+            ))}
+            {lowStockCount > 5 && (
+              <div className="px-4 py-3 text-center">
+                <Link href={inventoryHref} className="text-sm text-primary hover:underline">
+                  Ver mais {lowStockCount - 5} produto{lowStockCount - 5 !== 1 ? "s" : ""}
+                </Link>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
-function MetricCard({ label, value, alert }: { label: string; value: number; alert?: boolean }) {
+function MetricCard({ label, value, alert }: { label: string; value: string; alert?: boolean }) {
   return (
     <div className={`rounded-lg border p-5 ${alert ? "border-red-200 bg-red-50" : "bg-card"}`}>
       <p className="text-sm text-muted-foreground">{label}</p>
-      <p className={`mt-1 text-3xl font-bold ${alert ? "text-red-600" : ""}`}>{value}</p>
+      <p className={`mt-1 text-3xl font-bold tabular-nums ${alert ? "text-red-600" : ""}`}>
+        {value}
+      </p>
     </div>
   );
 }

--- a/src/components/layout/sidebar-nav.tsx
+++ b/src/components/layout/sidebar-nav.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Home,
+  Package,
+  ArrowLeftRight,
+  ShieldCheck,
+  Settings,
+  Building2,
+  Activity,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { MenuItem } from "@/core/navigation/menu";
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  home: Home,
+  package: Package,
+  "arrow-left-right": ArrowLeftRight,
+  "shield-check": ShieldCheck,
+  settings: Settings,
+  "building-2": Building2,
+  activity: Activity,
+};
+
+type ResolvedItem = MenuItem & { resolvedHref: string };
+
+type Props = {
+  items: ResolvedItem[];
+  groupLabel?: string;
+};
+
+export function SidebarNav({ items, groupLabel }: Props) {
+  const pathname = usePathname();
+
+  return (
+    <div>
+      {groupLabel && (
+        <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          {groupLabel}
+        </p>
+      )}
+      <nav className="flex flex-col gap-0.5">
+        {items.map((item) => {
+          const Icon = item.icon ? ICON_MAP[item.icon] : null;
+          const isActive =
+            item.resolvedHref === "/" ? pathname === "/" : pathname.startsWith(item.resolvedHref);
+
+          return (
+            <Link
+              key={item.href}
+              href={item.resolvedHref}
+              className={cn(
+                "flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors",
+                isActive
+                  ? "bg-accent font-medium text-accent-foreground"
+                  : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
+              )}
+            >
+              {Icon && <Icon className="h-4 w-4 shrink-0" />}
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/src/components/ui/pagination-nav.tsx
+++ b/src/components/ui/pagination-nav.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  page: number;
+  totalPages: number;
+  buildHref: (page: number) => string;
+};
+
+export function PaginationNav({ page, totalPages, buildHref }: Props) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      {page > 1 ? (
+        <Button asChild variant="outline" size="sm">
+          <Link href={buildHref(page - 1)}>← Anterior</Link>
+        </Button>
+      ) : (
+        <Button variant="outline" size="sm" disabled>
+          ← Anterior
+        </Button>
+      )}
+
+      <span className="text-sm text-muted-foreground">
+        {page} / {totalPages}
+      </span>
+
+      {page < totalPages ? (
+        <Button asChild variant="outline" size="sm">
+          <Link href={buildHref(page + 1)}>Próxima →</Link>
+        </Button>
+      ) : (
+        <Button variant="outline" size="sm" disabled>
+          Próxima →
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/core/navigation/menu.ts
+++ b/src/core/navigation/menu.ts
@@ -10,29 +10,38 @@ export type MenuItem = {
 };
 
 export const MODULES_MENU: MenuItem[] = [
-  { label: "Início", href: "/" },
+  { label: "Início", href: "/", icon: "home" },
   {
     label: "Estoque",
     href: "/inventory",
+    icon: "package",
     requiresSlug: true,
     requiresPermission: "inventory:product:read",
   },
   {
     label: "Movimentações",
     href: "/inventory/movements",
+    icon: "arrow-left-right",
     requiresSlug: true,
     requiresPermission: "movements:movement:read",
   },
-  { label: "Auditoria", href: "/audit", requiresSlug: true, requiresPermission: "core:audit:read" },
+  {
+    label: "Auditoria",
+    href: "/audit",
+    icon: "shield-check",
+    requiresSlug: true,
+    requiresPermission: "core:audit:read",
+  },
   {
     label: "Configurações",
     href: "/settings/general",
+    icon: "settings",
     requiresSlug: true,
     requiresPermission: "core:company:update",
   },
 ];
 
 export const ADMIN_MENU: MenuItem[] = [
-  { label: "Empresas", href: "/admin/companies" },
-  { label: "Auditoria Global", href: "/admin/audit" },
+  { label: "Empresas", href: "/admin/companies", icon: "building-2" },
+  { label: "Auditoria Global", href: "/admin/audit", icon: "activity" },
 ];

--- a/src/modules/inventory/actions/reactivate-product.ts
+++ b/src/modules/inventory/actions/reactivate-product.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveCompanyId } from "@/modules/tenancy";
+import { requirePermission, ForbiddenError } from "@/modules/authz";
+import type { ActionResult } from "@/lib/errors";
+
+export async function reactivateProductAction(id: string): Promise<ActionResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
+
+  const companyId = await getActiveCompanyId();
+  if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
+
+  try {
+    await requirePermission(companyId, "inventory:product:delete");
+  } catch (e) {
+    if (e instanceof ForbiddenError)
+      return { ok: false, message: "Acesso negado: permissão insuficiente" };
+    throw e;
+  }
+
+  const { error } = await supabase
+    .from("products")
+    .update({ is_active: true, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("company_id", companyId);
+
+  if (error) return { ok: false, message: error.message };
+
+  revalidatePath("/", "layout");
+  return { ok: true, message: "Produto reativado com sucesso" };
+}

--- a/src/modules/inventory/components/movement-form.tsx
+++ b/src/modules/inventory/components/movement-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useFormStatus } from "react-dom";
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -22,15 +22,19 @@ type ProductOption = { id: string; name: string; sku: string; stock: number };
 
 export function MovementForm({ products }: { products: ProductOption[] }) {
   const [state, formAction] = useActionState(registerMovementAction, initial);
+  const [formKey, setFormKey] = useState(0);
   const fieldErrors = state.ok ? undefined : state.fieldErrors;
 
   useEffect(() => {
-    if (state.ok) toast.success(state.message ?? "Movimentação registrada");
+    if (state.ok) {
+      toast.success(state.message ?? "Movimentação registrada");
+      setFormKey((k) => k + 1);
+    }
     if (!state.ok && state.message) toast.error(state.message);
   }, [state]);
 
   return (
-    <form action={formAction} className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <form key={formKey} action={formAction} className="grid grid-cols-1 gap-4 md:grid-cols-2">
       {/* Produto */}
       <div className="space-y-2 md:col-span-2">
         <Label htmlFor="productId">

--- a/src/modules/inventory/components/movement-table.tsx
+++ b/src/modules/inventory/components/movement-table.tsx
@@ -7,10 +7,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { PaginationNav } from "@/components/ui/pagination-nav";
 import { formatCurrency, formatDate } from "@/lib/utils";
 import type { PaginatedResult, StockMovement } from "../types";
 
-type Props = Pick<PaginatedResult<StockMovement>, "data" | "page" | "total" | "totalPages">;
+type Props = Pick<PaginatedResult<StockMovement>, "data" | "page" | "total" | "totalPages"> & {
+  basePath?: string;
+  productId?: string;
+};
 
 const MOVEMENT_LABELS: Record<StockMovement["movement_type"], string> = {
   in: "Entrada",
@@ -27,7 +31,7 @@ const MOVEMENT_VARIANTS: Record<
   adjustment: "secondary",
 };
 
-export function MovementTable({ data, page, totalPages, total }: Props) {
+export function MovementTable({ data, page, totalPages, total, basePath = "", productId }: Props) {
   if (data.length === 0) {
     return (
       <div className="rounded-lg border border-dashed py-12 text-center text-sm text-muted-foreground">
@@ -77,11 +81,16 @@ export function MovementTable({ data, page, totalPages, total }: Props) {
         <span>
           {total} movimentaç{total !== 1 ? "ões" : "ão"}
         </span>
-        {totalPages > 1 && (
-          <span>
-            Página {page} de {totalPages}
-          </span>
-        )}
+        <PaginationNav
+          page={page}
+          totalPages={totalPages}
+          buildHref={(p) => {
+            const params = new URLSearchParams();
+            params.set("page", String(p));
+            if (productId) params.set("productId", productId);
+            return `${basePath}?${params.toString()}`;
+          }}
+        />
       </div>
     </div>
   );

--- a/src/modules/inventory/components/movement-table.tsx
+++ b/src/modules/inventory/components/movement-table.tsx
@@ -9,23 +9,23 @@ import {
 } from "@/components/ui/table";
 import { PaginationNav } from "@/components/ui/pagination-nav";
 import { formatCurrency, formatDate } from "@/lib/utils";
-import type { PaginatedResult, StockMovement } from "../types";
+import type { MovementWithProduct, PaginatedResult } from "../types";
 
-type Props = Pick<PaginatedResult<StockMovement>, "data" | "page" | "total" | "totalPages"> & {
+type Props = Pick<
+  PaginatedResult<MovementWithProduct>,
+  "data" | "page" | "total" | "totalPages"
+> & {
   basePath?: string;
   productId?: string;
 };
 
-const MOVEMENT_LABELS: Record<StockMovement["movement_type"], string> = {
+const MOVEMENT_LABELS: Record<string, string> = {
   in: "Entrada",
   out: "Saída",
   adjustment: "Ajuste",
 };
 
-const MOVEMENT_VARIANTS: Record<
-  StockMovement["movement_type"],
-  "default" | "destructive" | "secondary" | "outline"
-> = {
+const MOVEMENT_VARIANTS: Record<string, "default" | "destructive" | "secondary" | "outline"> = {
   in: "default",
   out: "destructive",
   adjustment: "secondary",
@@ -47,6 +47,7 @@ export function MovementTable({ data, page, totalPages, total, basePath = "", pr
           <TableHeader>
             <TableRow>
               <TableHead>Data</TableHead>
+              {!productId && <TableHead>Produto</TableHead>}
               <TableHead>Tipo</TableHead>
               <TableHead className="text-right">Quantidade</TableHead>
               <TableHead className="text-right">Custo unit.</TableHead>
@@ -57,9 +58,17 @@ export function MovementTable({ data, page, totalPages, total, basePath = "", pr
             {data.map((movement) => (
               <TableRow key={movement.id}>
                 <TableCell className="text-sm">{formatDate(movement.created_at)}</TableCell>
+                {!productId && (
+                  <TableCell>
+                    <div className="font-medium">{movement.products?.name ?? "—"}</div>
+                    <div className="font-mono text-xs text-muted-foreground">
+                      {movement.products?.sku}
+                    </div>
+                  </TableCell>
+                )}
                 <TableCell>
-                  <Badge variant={MOVEMENT_VARIANTS[movement.movement_type]}>
-                    {MOVEMENT_LABELS[movement.movement_type]}
+                  <Badge variant={MOVEMENT_VARIANTS[movement.movement_type] ?? "secondary"}>
+                    {MOVEMENT_LABELS[movement.movement_type] ?? movement.movement_type}
                   </Badge>
                 </TableCell>
                 <TableCell className="text-right font-mono">

--- a/src/modules/inventory/components/product-table.tsx
+++ b/src/modules/inventory/components/product-table.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -8,6 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { PaginationNav } from "@/components/ui/pagination-nav";
 import { formatCurrency } from "@/lib/utils";
 import type { PaginatedResult, Product } from "../types";
 
@@ -16,13 +18,32 @@ type Props = Pick<
   "data" | "page" | "pageSize" | "total" | "totalPages"
 > & {
   basePath: string;
+  searchQuery?: string;
+  createHref?: string;
 };
 
-export function ProductTable({ data, page, totalPages, total, basePath }: Props) {
+export function ProductTable({
+  data,
+  page,
+  totalPages,
+  total,
+  basePath,
+  searchQuery,
+  createHref,
+}: Props) {
   if (data.length === 0) {
     return (
-      <div className="rounded-lg border border-dashed py-12 text-center text-sm text-muted-foreground">
-        Nenhum produto encontrado.
+      <div className="rounded-lg border border-dashed py-16 text-center">
+        <p className="text-sm text-muted-foreground">
+          {searchQuery
+            ? `Nenhum produto encontrado para "${searchQuery}".`
+            : "Nenhum produto cadastrado ainda."}
+        </p>
+        {!searchQuery && createHref && (
+          <Button asChild className="mt-4" size="sm">
+            <Link href={createHref}>+ Cadastrar produto</Link>
+          </Button>
+        )}
       </div>
     );
   }
@@ -54,11 +75,16 @@ export function ProductTable({ data, page, totalPages, total, basePath }: Props)
         <span>
           {total} produto{total !== 1 ? "s" : ""}
         </span>
-        {totalPages > 1 && (
-          <span>
-            Página {page} de {totalPages}
-          </span>
-        )}
+        <PaginationNav
+          page={page}
+          totalPages={totalPages}
+          buildHref={(p) => {
+            const params = new URLSearchParams();
+            params.set("page", String(p));
+            if (searchQuery) params.set("q", searchQuery);
+            return `${basePath}?${params.toString()}`;
+          }}
+        />
       </div>
     </div>
   );

--- a/src/modules/inventory/components/product-table.tsx
+++ b/src/modules/inventory/components/product-table.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/table";
 import { PaginationNav } from "@/components/ui/pagination-nav";
 import { formatCurrency } from "@/lib/utils";
+import { reactivateProductAction } from "../actions/reactivate-product";
 import { ReactivateProductButton } from "./reactivate-product-button";
 import type { PaginatedResult, Product } from "../types";
 
@@ -144,7 +145,12 @@ function ProductRow({
       </TableCell>
       {showActions && (
         <TableCell>
-          {!product.is_active && <ReactivateProductButton productId={product.id} />}
+          {!product.is_active && (
+            <ReactivateProductButton
+              productId={product.id}
+              onReactivate={reactivateProductAction}
+            />
+          )}
         </TableCell>
       )}
     </TableRow>

--- a/src/modules/inventory/components/product-table.tsx
+++ b/src/modules/inventory/components/product-table.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/table";
 import { PaginationNav } from "@/components/ui/pagination-nav";
 import { formatCurrency } from "@/lib/utils";
+import { ReactivateProductButton } from "./reactivate-product-button";
 import type { PaginatedResult, Product } from "../types";
 
 type Props = Pick<
@@ -20,6 +21,7 @@ type Props = Pick<
   basePath: string;
   searchQuery?: string;
   createHref?: string;
+  showInactive?: boolean;
 };
 
 export function ProductTable({
@@ -30,6 +32,7 @@ export function ProductTable({
   basePath,
   searchQuery,
   createHref,
+  showInactive,
 }: Props) {
   if (data.length === 0) {
     return (
@@ -61,11 +64,17 @@ export function ProductTable({
               <TableHead className="text-right">Custo</TableHead>
               <TableHead className="text-right">Venda</TableHead>
               <TableHead>Status</TableHead>
+              {showInactive && <TableHead />}
             </TableRow>
           </TableHeader>
           <TableBody>
             {data.map((product) => (
-              <ProductRow key={product.id} product={product} basePath={basePath} />
+              <ProductRow
+                key={product.id}
+                product={product}
+                basePath={basePath}
+                showActions={showInactive}
+              />
             ))}
           </TableBody>
         </Table>
@@ -82,6 +91,7 @@ export function ProductTable({
             const params = new URLSearchParams();
             params.set("page", String(p));
             if (searchQuery) params.set("q", searchQuery);
+            if (showInactive) params.set("inactive", "true");
             return `${basePath}?${params.toString()}`;
           }}
         />
@@ -90,11 +100,19 @@ export function ProductTable({
   );
 }
 
-function ProductRow({ product, basePath }: { product: Product; basePath: string }) {
+function ProductRow({
+  product,
+  basePath,
+  showActions,
+}: {
+  product: Product;
+  basePath: string;
+  showActions?: boolean;
+}) {
   const isLowStock = Number(product.stock) <= Number(product.min_stock);
 
   return (
-    <TableRow>
+    <TableRow className={!product.is_active ? "opacity-60" : undefined}>
       <TableCell className="font-mono text-xs">{product.sku}</TableCell>
       <TableCell>
         <Link href={`${basePath}/${product.id}`} className="font-medium hover:underline">
@@ -109,21 +127,26 @@ function ProductRow({ product, basePath }: { product: Product; basePath: string 
       </TableCell>
       <TableCell>{product.unit}</TableCell>
       <TableCell className="text-right">
-        <span className={isLowStock ? "font-semibold text-red-600" : ""}>
+        <span className={isLowStock && product.is_active ? "font-semibold text-red-600" : ""}>
           {Number(product.stock).toFixed(3)}
         </span>
       </TableCell>
       <TableCell className="text-right">{formatCurrency(Number(product.cost_price))}</TableCell>
       <TableCell className="text-right">{formatCurrency(Number(product.sale_price))}</TableCell>
       <TableCell>
-        {isLowStock ? (
-          <Badge variant="destructive">Estoque baixo</Badge>
-        ) : product.is_active ? (
-          <Badge variant="secondary">Ativo</Badge>
-        ) : (
+        {!product.is_active ? (
           <Badge variant="outline">Inativo</Badge>
+        ) : isLowStock ? (
+          <Badge variant="destructive">Estoque baixo</Badge>
+        ) : (
+          <Badge variant="secondary">Ativo</Badge>
         )}
       </TableCell>
+      {showActions && (
+        <TableCell>
+          {!product.is_active && <ReactivateProductButton productId={product.id} />}
+        </TableCell>
+      )}
     </TableRow>
   );
 }

--- a/src/modules/inventory/components/reactivate-product-button.tsx
+++ b/src/modules/inventory/components/reactivate-product-button.tsx
@@ -2,9 +2,14 @@
 
 import { useTransition } from "react";
 import { Button } from "@/components/ui/button";
-import { reactivateProductAction } from "@/modules/inventory";
+import type { ActionResult } from "@/lib/errors";
 
-export function ReactivateProductButton({ productId }: { productId: string }) {
+type Props = {
+  productId: string;
+  onReactivate: (id: string) => Promise<ActionResult>;
+};
+
+export function ReactivateProductButton({ productId, onReactivate }: Props) {
   const [isPending, startTransition] = useTransition();
 
   return (
@@ -14,7 +19,7 @@ export function ReactivateProductButton({ productId }: { productId: string }) {
       disabled={isPending}
       onClick={() =>
         startTransition(async () => {
-          await reactivateProductAction(productId);
+          await onReactivate(productId);
         })
       }
     >

--- a/src/modules/inventory/components/reactivate-product-button.tsx
+++ b/src/modules/inventory/components/reactivate-product-button.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { reactivateProductAction } from "@/modules/inventory";
+
+export function ReactivateProductButton({ productId }: { productId: string }) {
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      disabled={isPending}
+      onClick={() =>
+        startTransition(async () => {
+          await reactivateProductAction(productId);
+        })
+      }
+    >
+      {isPending ? "Reativando..." : "Reativar"}
+    </Button>
+  );
+}

--- a/src/modules/inventory/index.ts
+++ b/src/modules/inventory/index.ts
@@ -2,6 +2,7 @@
 export { createProductAction } from "./actions/create-product";
 export { updateProductAction } from "./actions/update-product";
 export { deleteProductAction } from "./actions/delete-product";
+export { reactivateProductAction } from "./actions/reactivate-product";
 export { registerMovementAction } from "./actions/register-movement";
 
 export { listProducts } from "./queries/list-products";

--- a/src/modules/inventory/index.ts
+++ b/src/modules/inventory/index.ts
@@ -13,7 +13,11 @@ export { ProductForm } from "./components/product-form";
 export { MovementForm } from "./components/movement-form";
 export { MovementTable } from "./components/movement-table";
 
-export { validateMovement, calculateNewStock, InsufficientStockError } from "./services/stock-service";
+export {
+  validateMovement,
+  calculateNewStock,
+  InsufficientStockError,
+} from "./services/stock-service";
 
 export type {
   Product,
@@ -21,6 +25,7 @@ export type {
   ProductUpdate,
   StockMovement,
   StockMovementInsert,
+  MovementWithProduct,
   MovementType,
   PaginatedResult,
 } from "./types";

--- a/src/modules/inventory/queries/list-movements.ts
+++ b/src/modules/inventory/queries/list-movements.ts
@@ -1,12 +1,12 @@
 import "server-only";
 import { createClient } from "@/lib/supabase/server";
 import { listMovementsSchema } from "../schemas";
-import type { PaginatedResult, StockMovement } from "../types";
+import type { MovementWithProduct, PaginatedResult } from "../types";
 
 export async function listMovements(
   companyId: string,
   raw: Record<string, unknown>,
-): Promise<PaginatedResult<StockMovement>> {
+): Promise<PaginatedResult<MovementWithProduct>> {
   const { productId, page, pageSize } = listMovementsSchema.parse(raw);
   const from = (page - 1) * pageSize;
   const to = from + pageSize - 1;
@@ -14,7 +14,7 @@ export async function listMovements(
   const supabase = await createClient();
   let query = supabase
     .from("stock_movements")
-    .select("*", { count: "exact" })
+    .select("*, products(name, sku)", { count: "exact" })
     .eq("company_id", companyId)
     .order("created_at", { ascending: false })
     .range(from, to);
@@ -26,7 +26,7 @@ export async function listMovements(
 
   const total = count ?? 0;
   return {
-    data: data ?? [],
+    data: (data ?? []) as MovementWithProduct[],
     total,
     page,
     pageSize,

--- a/src/modules/inventory/types/index.ts
+++ b/src/modules/inventory/types/index.ts
@@ -7,6 +7,10 @@ export type ProductUpdate = Database["public"]["Tables"]["products"]["Update"];
 export type StockMovement = Database["public"]["Tables"]["stock_movements"]["Row"];
 export type StockMovementInsert = Database["public"]["Tables"]["stock_movements"]["Insert"];
 
+export type MovementWithProduct = StockMovement & {
+  products: { name: string; sku: string } | null;
+};
+
 export type MovementType = Database["public"]["Enums"]["movement_type"];
 
 export interface PaginatedResult<T> {

--- a/src/modules/tenancy/components/company-switcher.tsx
+++ b/src/modules/tenancy/components/company-switcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import {
   Select,
   SelectContent,
@@ -19,6 +20,7 @@ interface CompanySwitcherProps {
 export function CompanySwitcher({ companies, activeCompanyId }: CompanySwitcherProps) {
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
 
   if (companies.length <= 1) {
     const company = companies[0];
@@ -29,6 +31,7 @@ export function CompanySwitcher({ companies, activeCompanyId }: CompanySwitcherP
   const activeCompany = companies.find((c) => c.id === activeCompanyId) ?? companies[0];
 
   function handleChange(companyId: string) {
+    const targetCompany = companies.find((c) => c.id === companyId);
     startTransition(async () => {
       const formData = new FormData();
       formData.set("companyId", companyId);
@@ -37,6 +40,9 @@ export function CompanySwitcher({ companies, activeCompanyId }: CompanySwitcherP
         setError(result.message ?? "Erro ao trocar empresa");
       } else {
         setError(null);
+        if (targetCompany?.slug) {
+          router.push(`/${targetCompany.slug}/inventory`);
+        }
       }
     });
   }

--- a/supabase/migrations/20260425000018_profiles_co_member_select.sql
+++ b/supabase/migrations/20260425000018_profiles_co_member_select.sql
@@ -1,0 +1,14 @@
+-- Permite que usuários vejam perfis de co-membros (mesma empresa)
+-- Necessário para listCompanyMembers exibir nomes de outros membros
+create policy "profiles_select_co_member"
+  on public.profiles for select
+  using (
+    public.is_platform_admin()
+    or exists (
+      select 1
+      from public.memberships m1
+      join public.memberships m2 on m1.company_id = m2.company_id
+      where m1.user_id = auth.uid()
+        and m2.user_id = profiles.id
+    )
+  );


### PR DESCRIPTION
- **PaginationNav**: componente reutilizável prev/next para inventário e movimentações              
  - **Sidebar com active state**: `SidebarNav` client component usa `usePathname()` + ícones
  lucide-react                                                                                        
  - **Reset de formulário**: `MovementForm` incrementa `key` após sucesso, forçando remount e limpeza
  dos campos                                                                                          
  - **Coluna produto**: tabela de movimentações exibe nome/SKU na visão global; oculta quando filtrada
   por produto específico                                                                             
  - **Diálogo de confirmação**: `AlertDialog` antes de desativar produto, com
  `formRef.requestSubmit()` para manter Server Action                                                 
  - **Company switcher**: redireciona para `/{slug}/inventory` após trocar empresa
  - **Dashboard**: terceiro card "Valor em estoque" + lista dos produtos com estoque mais baixo       
  - **Loading skeletons**: `loading.tsx` em dashboard, inventário, movimentações e detalhe de produto
                                                                                                      
  ## Plano de testes                                        
                                                                                                      
  - [x] Navegar entre páginas de inventário e verificar prev/next da paginação
  - [x] Verificar active state da sidebar ao navegar entre rotas
  - [x] Registrar movimentação e confirmar que o formulário limpa os campos
  - [x] Acessar movimentações globais e checar coluna "Produto"; acessar pelo detalhe do produto e    
  confirmar ausência da coluna
  - [x] Clicar em "Desativar produto" e confirmar que o diálogo aparece antes de executar             
  - [x] Trocar empresa no switcher e confirmar redirecionamento correto                               
  - [x] Verificar dashboard com e sem produtos de estoque baixo
  - [x] Navegar entre páginas lentas e confirmar skeletons de carregamento    