### PR TITLE
test(tenancy): testes para updateRoleAction e updateMemberRolesAction

### DIFF
--- a/src/modules/tenancy/actions/__tests__/update-member-roles.test.ts
+++ b/src/modules/tenancy/actions/__tests__/update-member-roles.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/modules/audit", () => ({ audit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/modules/authz", () => ({
+  requirePermission: vi.fn().mockResolvedValue(undefined),
+  ForbiddenError: class ForbiddenError extends Error {
+    constructor(public permission: string) {
+      super(`forbidden:${permission}`);
+    }
+  },
+}));
+
+import { createClient } from "@/lib/supabase/server";
+import { requirePermission } from "@/modules/authz";
+import { updateMemberRolesAction } from "../update-member-roles";
+
+// -------------------------------------------------------------------
+// Sequência de produção (update-member-roles.ts):
+//   1. createClient() → auth.getUser()
+//   2. check: user autenticado
+//   3. requirePermission(companyId, "core:member:manage")
+//   4. memberships.select("id, user_id").eq("id").eq("company_id").maybeSingle()
+//   5. checks: fetchError, not found
+//   6. se roleIds.length > 0: roles.select("id").eq("company_id").in("id", roleIds)
+//      → valida que todos os roleIds existem
+//   7. rpc("set_member_roles", {p_company_id, p_membership_id, p_role_ids})
+//   8. audit()
+//   9. revalidatePath()
+// -------------------------------------------------------------------
+
+type MembershipData = { id: string; user_id: string } | null;
+
+type UpdateMemberRolesMockOptions = {
+  user?: { id: string } | null;
+  membershipData?: MembershipData;
+  membershipFetchError?: { message: string } | null;
+  validRoles?: Array<{ id: string }> | null;
+  rpcError?: { message: string } | null;
+};
+
+function makeSupabaseMock({
+  user = { id: "user-1" },
+  membershipData = { id: "membership-1", user_id: "user-2" },
+  membershipFetchError = null,
+  validRoles = null,
+  rpcError = null,
+}: UpdateMemberRolesMockOptions = {}) {
+  // auth.getUser()
+  const getUser = vi.fn().mockResolvedValue({ data: { user } });
+
+  // memberships: .select("id, user_id").eq("id").eq("company_id").maybeSingle()
+  const membershipsMaybeSingle = vi.fn().mockResolvedValue({
+    data: membershipFetchError ? null : membershipData,
+    error: membershipFetchError,
+  });
+  const membershipsEq2 = vi.fn().mockReturnValue({ maybeSingle: membershipsMaybeSingle });
+  const membershipsEq1 = vi.fn().mockReturnValue({ eq: membershipsEq2 });
+  const membershipsSelect = vi.fn().mockReturnValue({ eq: membershipsEq1 });
+
+  // roles: .select("id").eq("company_id").in("id", roleIds)
+  const rolesIn = vi.fn().mockResolvedValue({ data: validRoles, error: null });
+  const rolesEq = vi.fn().mockReturnValue({ in: rolesIn });
+  const rolesSelect = vi.fn().mockReturnValue({ eq: rolesEq });
+
+  // rpc("set_member_roles")
+  const rpc = vi.fn().mockResolvedValue({ data: null, error: rpcError });
+
+  const mockClient = {
+    auth: { getUser },
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "memberships") {
+        return { select: membershipsSelect };
+      }
+      if (table === "roles") {
+        return { select: rolesSelect };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    }),
+    rpc,
+    rolesIn,
+  };
+
+  return mockClient;
+}
+
+describe("updateMemberRolesAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retorna { ok: false } quando usuário não está autenticado", async () => {
+    const mock = makeSupabaseMock({ user: null });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await updateMemberRolesAction("company-1", "membership-1", ["role-1"]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("autenticado");
+    }
+  });
+
+  it("retorna { ok: false } quando core:member:manage é negado", async () => {
+    vi.mocked(requirePermission).mockRejectedValueOnce(new Error("forbidden:core:member:manage"));
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await updateMemberRolesAction("company-1", "membership-1", ["role-1"]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("permissão");
+    }
+  });
+
+  it("retorna { ok: false } quando membro não é encontrado", async () => {
+    const mock = makeSupabaseMock({ membershipData: null });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await updateMemberRolesAction("company-1", "membership-inexistente", []);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("encontrado");
+    }
+  });
+
+  it("retorna { ok: false } quando fetch de membership retorna erro do banco", async () => {
+    const mock = makeSupabaseMock({ membershipFetchError: { message: "Falha na consulta" } });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await updateMemberRolesAction("company-1", "membership-1", []);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Falha na consulta");
+    }
+  });
+
+  it("retorna { ok: false } quando uma ou mais roles são inválidas para a company", async () => {
+    // Solicita 2 roles mas banco retorna apenas 1 válida
+    const mock = makeSupabaseMock({
+      validRoles: [{ id: "role-1" }],
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await updateMemberRolesAction("company-1", "membership-1", [
+      "role-1",
+      "role-invalida",
+    ]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("inválidas");
+    }
+  });
+
+  it("retorna { ok: false } quando rpc set_member_roles retorna erro", async () => {
+    const mock = makeSupabaseMock({
+      validRoles: [{ id: "role-1" }],
+      rpcError: { message: "Erro no RPC" },
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await updateMemberRolesAction("company-1", "membership-1", ["role-1"]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Erro no RPC");
+    }
+  });
+
+  it("retorna { ok: true } no caminho feliz com roles válidas e chama rpc corretamente", async () => {
+    const mock = makeSupabaseMock({
+      validRoles: [{ id: "role-1" }, { id: "role-2" }],
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await updateMemberRolesAction("company-1", "membership-1", ["role-1", "role-2"]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message).toContain("atualizadas");
+    }
+    expect(mock.rpc).toHaveBeenCalledWith("set_member_roles", {
+      p_company_id: "company-1",
+      p_membership_id: "membership-1",
+      p_role_ids: ["role-1", "role-2"],
+    });
+  });
+
+  it("retorna { ok: true } e pula validação de roles quando lista está vazia", async () => {
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await updateMemberRolesAction("company-1", "membership-1", []);
+
+    expect(result.ok).toBe(true);
+    // Não deve consultar tabela de roles para lista vazia
+    expect(mock.rolesIn).not.toHaveBeenCalled();
+    // Deve chamar rpc com lista vazia
+    expect(mock.rpc).toHaveBeenCalledWith("set_member_roles", {
+      p_company_id: "company-1",
+      p_membership_id: "membership-1",
+      p_role_ids: [],
+    });
+  });
+});

--- a/src/modules/tenancy/actions/__tests__/update-role.test.ts
+++ b/src/modules/tenancy/actions/__tests__/update-role.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/modules/audit", () => ({ audit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/modules/authz", () => ({
+  requirePermission: vi.fn().mockResolvedValue(undefined),
+  ForbiddenError: class ForbiddenError extends Error {
+    constructor(public permission: string) {
+      super(`forbidden:${permission}`);
+    }
+  },
+}));
+
+import { createClient } from "@/lib/supabase/server";
+import { requirePermission } from "@/modules/authz";
+import { updateRoleAction } from "../update-role";
+
+// -------------------------------------------------------------------
+// Sequência de produção (update-role.ts):
+//   1. requirePermission(companyId, "core:role:manage")
+//   2. updateRoleSchema.safeParse(formData)
+//   3. createClient() → roles.select().eq().eq().maybeSingle()
+//   4. checks: fetchError, not found, is_system
+//   5. roles.update({name, description, updated_at}).eq("id")
+//   6. audit()
+//   7. revalidatePath()
+// -------------------------------------------------------------------
+
+type RoleData = {
+  id: string;
+  is_system: boolean;
+  company_id: string;
+} | null;
+
+type UpdateRoleMockOptions = {
+  roleData?: RoleData;
+  roleFetchError?: { message: string } | null;
+  updateError?: { message: string } | null;
+};
+
+function makeSupabaseMock({
+  roleData = { id: "role-1", is_system: false, company_id: "company-1" },
+  roleFetchError = null,
+  updateError = null,
+}: UpdateRoleMockOptions = {}) {
+  // roles select: .select().eq().eq().maybeSingle()
+  const rolesMaybeSingle = vi.fn().mockResolvedValue({
+    data: roleFetchError ? null : roleData,
+    error: roleFetchError,
+  });
+  const rolesEq2Select = vi.fn().mockReturnValue({ maybeSingle: rolesMaybeSingle });
+  const rolesEq1Select = vi.fn().mockReturnValue({ eq: rolesEq2Select });
+  const rolesSelectFetch = vi.fn().mockReturnValue({ eq: rolesEq1Select });
+
+  // roles update: .update({...}).eq("id")
+  const rolesUpdateEq = vi.fn().mockResolvedValue({ data: null, error: updateError });
+  const rolesUpdateFn = vi.fn().mockReturnValue({ eq: rolesUpdateEq });
+
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "roles") {
+        return {
+          select: rolesSelectFetch,
+          update: rolesUpdateFn,
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        update: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    }),
+    rolesUpdateFn,
+    rolesUpdateEq,
+  };
+
+  return mockClient;
+}
+
+function makeFormData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    fd.append(key, value);
+  }
+  return fd;
+}
+
+describe("updateRoleAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retorna { ok: false } quando core:role:manage é negado", async () => {
+    vi.mocked(requirePermission).mockRejectedValueOnce(new Error("forbidden:core:role:manage"));
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Gerente" });
+
+    const result = await updateRoleAction("company-1", "role-1", { ok: true }, fd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("permissão");
+    }
+  });
+
+  it("retorna { ok: false, fieldErrors } quando name está vazio", async () => {
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "" });
+
+    const result = await updateRoleAction("company-1", "role-1", { ok: true }, fd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.fieldErrors).toBeDefined();
+      expect(result.fieldErrors?.name).toBeDefined();
+    }
+  });
+
+  it("retorna { ok: false, fieldErrors } quando name é muito curto (< 2 caracteres)", async () => {
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "A" });
+
+    const result = await updateRoleAction("company-1", "role-1", { ok: true }, fd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.fieldErrors).toBeDefined();
+      expect(result.fieldErrors?.name).toBeDefined();
+    }
+  });
+
+  it("retorna { ok: false } quando role não é encontrada", async () => {
+    const mock = makeSupabaseMock({ roleData: null });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Gerente" });
+
+    const result = await updateRoleAction("company-1", "role-inexistente", { ok: true }, fd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("encontrada");
+    }
+  });
+
+  it("retorna { ok: false } quando role é is_system = true", async () => {
+    const mock = makeSupabaseMock({
+      roleData: { id: "role-sys", is_system: true, company_id: "company-1" },
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Admin" });
+
+    const result = await updateRoleAction("company-1", "role-sys", { ok: true }, fd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sistema");
+    }
+  });
+
+  it("retorna { ok: false } quando fetch de role retorna erro do banco", async () => {
+    const mock = makeSupabaseMock({ roleFetchError: { message: "Falha na consulta" } });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Gerente" });
+
+    const result = await updateRoleAction("company-1", "role-1", { ok: true }, fd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Falha na consulta");
+    }
+  });
+
+  it("retorna { ok: false, message } quando update falha com erro do banco", async () => {
+    const mock = makeSupabaseMock({ updateError: { message: "Erro ao atualizar role" } });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Gerente" });
+
+    const result = await updateRoleAction("company-1", "role-1", { ok: true }, fd);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe("Erro ao atualizar role");
+    }
+  });
+
+  it("retorna { ok: true } no caminho feliz e chama update com os dados corretos", async () => {
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Gerente de Vendas", description: "Gerencia vendas" });
+
+    const result = await updateRoleAction("company-1", "role-1", { ok: true }, fd);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message).toBe("Role atualizada");
+    }
+    expect(mock.rolesUpdateFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Gerente de Vendas",
+        description: "Gerencia vendas",
+      }),
+    );
+  });
+
+  it("aceita description opcional (undefined) e envia null ao banco", async () => {
+    const mock = makeSupabaseMock();
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData({ name: "Operador" });
+
+    const result = await updateRoleAction("company-1", "role-1", { ok: true }, fd);
+
+    expect(result.ok).toBe(true);
+    expect(mock.rolesUpdateFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Operador",
+        description: null,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Resumo

- Adiciona `update-role.test.ts` com **9 casos** cobrindo `updateRoleAction`: permissão negada, validações de `name` (vazio e curto), role não encontrada, `is_system`, erros de banco (fetch e update), caminho feliz, `description` opcional → `null`
- Adiciona `update-member-roles.test.ts` com **8 casos** cobrindo `updateMemberRolesAction`: não autenticado, permissão negada, membro não encontrado, erro de fetch, roles inválidas para a company, erro no RPC, caminho feliz, lista vazia pula validação e chama RPC com array vazio

## Cobertura de testes (actions de roles/permissions)

| Action | Antes | Depois |
|---|---|---|
| `create-role` | ✅ 7 testes | ✅ 7 testes |
| `delete-role` | ✅ 7 testes | ✅ 7 testes |
| `update-role-permissions` | ✅ 7 testes | ✅ 7 testes |
| `update-role` | ❌ sem testes | ✅ 9 testes |
| `update-member-roles` | ❌ sem testes | ✅ 8 testes |

## Verificação

- 161/161 testes passando (144 existentes + 17 novos)
- ESLint e Prettier aplicados via pre-commit hook