### PR TITLE
fix: suporta convite para usuários que já têm conta no Supabase

### DIFF
--- a/src/modules/tenancy/actions/__tests__/invite-member.test.ts
+++ b/src/modules/tenancy/actions/__tests__/invite-member.test.ts
@@ -118,10 +118,19 @@ function makeAnonMock({
   return mockClient;
 }
 
+type ServiceMockOptions = {
+  inviteError?: { message: string } | null;
+  invitedUserId?: string;
+  rpcExistingUserId?: string | null;
+  rpcError?: { message: string } | null;
+};
+
 function makeServiceMock({
   inviteError = null,
   invitedUserId = "invited-user-id",
-}: { inviteError?: { message: string } | null; invitedUserId?: string } = {}) {
+  rpcExistingUserId = "existing-user-id",
+  rpcError = null,
+}: ServiceMockOptions = {}) {
   const inviteUserByEmail = vi
     .fn()
     .mockResolvedValue(
@@ -130,12 +139,15 @@ function makeServiceMock({
         : { data: { user: { id: invitedUserId } }, error: null },
     );
 
+  const rpc = vi
+    .fn()
+    .mockResolvedValue(
+      rpcError ? { data: null, error: rpcError } : { data: rpcExistingUserId, error: null },
+    );
+
   return {
-    auth: {
-      admin: {
-        inviteUserByEmail,
-      },
-    },
+    auth: { admin: { inviteUserByEmail } },
+    rpc,
   };
 }
 
@@ -300,6 +312,72 @@ describe("inviteMemberAction", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.message).toContain("autenticad");
+    }
+  });
+
+  it("retorna { ok: true } quando usuário já existe no Supabase Auth (email já registrado)", async () => {
+    // Arrange
+    const anonMock = makeAnonMock({ existingMembership: null, membershipId: "mem-existing" });
+    const serviceMock = makeServiceMock({
+      inviteError: { message: "A user with this email address has already been registered" },
+      rpcExistingUserId: "existing-auth-user-id",
+    });
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+    vi.mocked(createServiceClient).mockReturnValue(serviceMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "existing@empresa.com", ["role-1"]);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.message).toContain("existing@empresa.com");
+      expect(result.message).not.toContain("Convite");
+    }
+    expect(anonMock.membershipsInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "active" }),
+    );
+  });
+
+  it("retorna { ok: false } quando RPC falha ao buscar usuário existente", async () => {
+    // Arrange
+    const anonMock = makeAnonMock();
+    const serviceMock = makeServiceMock({
+      inviteError: { message: "A user with this email address has already been registered" },
+      rpcError: { message: "função não encontrada" },
+    });
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+    vi.mocked(createServiceClient).mockReturnValue(serviceMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "existing@empresa.com", []);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("localizar");
+    }
+  });
+
+  it("retorna { ok: false } quando usuário existente já é membro desta empresa", async () => {
+    // Arrange
+    const anonMock = makeAnonMock({
+      existingMembership: { id: "mem-1", status: "active" },
+    });
+    const serviceMock = makeServiceMock({
+      inviteError: { message: "A user with this email address has already been registered" },
+      rpcExistingUserId: "existing-auth-user-id",
+    });
+    vi.mocked(createClient).mockResolvedValue(anonMock as never);
+    vi.mocked(createServiceClient).mockReturnValue(serviceMock as never);
+
+    // Act
+    const result = await inviteMemberAction("company-1", "existing@empresa.com", []);
+
+    // Assert
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("membro");
     }
   });
 });

--- a/src/modules/tenancy/actions/invite-member.ts
+++ b/src/modules/tenancy/actions/invite-member.ts
@@ -32,14 +32,31 @@ export async function inviteMemberAction(
 
   const adminClient = createServiceClient();
 
-  const { data: invitedUser, error: inviteError } = await adminClient.auth.admin.inviteUserByEmail(
+  const { data: inviteData, error: inviteError } = await adminClient.auth.admin.inviteUserByEmail(
     email,
     { redirectTo: `${env.NEXT_PUBLIC_APP_URL}/accept-invite` },
   );
 
-  if (inviteError) return { ok: false, message: inviteError.message };
+  let invitedUserId: string;
+  let isExistingAuthUser = false;
 
-  const invitedUserId = invitedUser.user.id;
+  if (inviteError) {
+    if (!inviteError.message.includes("already been registered")) {
+      return { ok: false, message: inviteError.message };
+    }
+    // Usuário já tem conta no Supabase — busca o ID via RPC segura
+    const { data: existingUserId, error: lookupError } = await adminClient.rpc(
+      "get_user_id_by_email",
+      { p_email: email },
+    );
+    if (lookupError || !existingUserId) {
+      return { ok: false, message: "Não foi possível localizar o usuário existente" };
+    }
+    invitedUserId = existingUserId as string;
+    isExistingAuthUser = true;
+  } else {
+    invitedUserId = inviteData.user.id;
+  }
 
   const { data: existingMembership } = await supabase
     .from("memberships")
@@ -60,9 +77,10 @@ export async function inviteMemberAction(
     .insert({
       company_id: companyId,
       user_id: invitedUserId,
-      status: "invited",
+      status: isExistingAuthUser ? "active" : "invited",
       invited_by: user.id,
       invited_at: new Date().toISOString(),
+      ...(isExistingAuthUser ? { joined_at: new Date().toISOString() } : {}),
     })
     .select("id")
     .single();
@@ -90,5 +108,8 @@ export async function inviteMemberAction(
   });
 
   revalidatePath(`/[companySlug]/settings/members`, "page");
-  return { ok: true, message: `Convite enviado para ${email}` };
+  const message = isExistingAuthUser
+    ? `${email} adicionado como membro`
+    : `Convite enviado para ${email}`;
+  return { ok: true, message };
 }

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -797,6 +797,7 @@ export type Database = {
         Args: { p_company: string };
         Returns: undefined;
       };
+      get_user_id_by_email: { Args: { p_email: string }; Returns: string };
       has_permission: {
         Args: { p_company: string; p_permission: string };
         Returns: boolean;

--- a/supabase/migrations/20260429000023_get_user_id_by_email.sql
+++ b/supabase/migrations/20260429000023_get_user_id_by_email.sql
@@ -1,0 +1,23 @@
+-- RPC SECURITY DEFINER: retorna o UUID de um usuário existente em auth.users pelo email.
+-- Necessário para o fluxo de convite quando o usuário já tem conta no Supabase
+-- (auth.admin.inviteUserByEmail falha para usuários existentes).
+-- Restrito ao service_role — nunca exposto ao cliente público.
+create or replace function public.get_user_id_by_email(p_email text)
+returns uuid
+language plpgsql
+security definer
+set search_path = auth, public
+as $$
+declare
+  v_user_id uuid;
+begin
+  select id into v_user_id
+  from auth.users
+  where email = lower(trim(p_email))
+  limit 1;
+
+  return v_user_id;
+end $$;
+
+revoke all on function public.get_user_id_by_email(text) from public, anon, authenticated;
+grant execute on function public.get_user_id_by_email(text) to service_role;


### PR DESCRIPTION
## Problema

`auth.admin.inviteUserByEmail()` falha com _"A user with this email address has already been registered"_ quando o e-mail já existe em `auth.users` (ex.: usuário de outra empresa no mesmo projeto Supabase).

## Solução

**Usuário novo (sem conta):** `inviteUserByEmail` → membership `invited` → "Convite enviado para email"

**Usuário existente (já tem conta):**
1. `inviteUserByEmail` retorna `already been registered`
2. RPC `get_user_id_by_email` busca o UUID em `auth.users` (SECURITY DEFINER, restrita ao `service_role`)
3. Membership criada com `status: 'active'` + `joined_at` (não precisa aceitar)
4. Retorna "email adicionado como membro"

## Mudanças

- `supabase/migrations/20260429000023_get_user_id_by_email.sql` — nova RPC segura
- `invite-member.ts` — trata o caso de usuário existente
- `invite-member.test.ts` — 3 novos casos de teste (8 → 11 testes)

**219/219 testes passando ✅**
