### PR TITLE
fix: implementa fluxo completo de redefinição de senha

### DIFF
--- a/src/app/(auth)/recover/reset/page.tsx
+++ b/src/app/(auth)/recover/reset/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { ResetPasswordForm } from "@/modules/auth";
+
+export const metadata = { title: "Redefinir senha — ERP" };
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/30 px-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">Redefinir senha</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Escolha uma nova senha para sua conta.
+          </p>
+        </div>
+
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+          <ResetPasswordForm />
+        </div>
+
+        <p className="text-center text-sm text-muted-foreground">
+          Lembrou a senha?{" "}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Entrar
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/auth/actions/recover-password.ts
+++ b/src/modules/auth/actions/recover-password.ts
@@ -16,7 +16,7 @@ export async function recoverPasswordAction(
 
   const supabase = await createClient();
   const { error } = await supabase.auth.resetPasswordForEmail(parsed.data.email, {
-    redirectTo: `${env.NEXT_PUBLIC_APP_URL}/recover/reset`,
+    redirectTo: `${env.NEXT_PUBLIC_APP_URL}/api/auth/callback?next=/recover/reset`,
   });
 
   if (error) {

--- a/src/modules/auth/actions/reset-password.ts
+++ b/src/modules/auth/actions/reset-password.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { resetPasswordSchema } from "../schemas";
+import type { ActionResult } from "@/lib/errors";
+
+export async function resetPasswordAction(
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  const parsed = resetPasswordSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.updateUser({ password: parsed.data.password });
+
+  if (error) {
+    return { ok: false, message: error.message };
+  }
+
+  return { ok: true, message: "Senha redefinida com sucesso! Faça login com a nova senha." };
+}

--- a/src/modules/auth/components/reset-password-form.tsx
+++ b/src/modules/auth/components/reset-password-form.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import { useFormStatus } from "react-dom";
+import { useActionState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { resetPasswordAction } from "../actions/reset-password";
+
+const initial = { ok: false } as const;
+
+export function ResetPasswordForm() {
+  const [state, formAction] = useActionState(resetPasswordAction, initial);
+
+  if (state.ok) {
+    return (
+      <div className="space-y-4">
+        <Alert>
+          <AlertDescription>{state.message}</AlertDescription>
+        </Alert>
+        <Button asChild className="w-full">
+          <Link href="/login">Ir para o login</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="password">Nova senha</Label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          required
+          autoComplete="new-password"
+          placeholder="Mínimo 8 caracteres"
+        />
+        {state.fieldErrors?.password && (
+          <p className="text-sm text-red-600">{state.fieldErrors.password[0]}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="confirmPassword">Confirmar senha</Label>
+        <Input
+          id="confirmPassword"
+          name="confirmPassword"
+          type="password"
+          required
+          autoComplete="new-password"
+          placeholder="Repita a senha"
+        />
+        {state.fieldErrors?.confirmPassword && (
+          <p className="text-sm text-red-600">{state.fieldErrors.confirmPassword[0]}</p>
+        )}
+      </div>
+
+      {state.message && !state.ok && (
+        <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{state.message}</p>
+      )}
+
+      <SubmitButton />
+    </form>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" className="w-full" disabled={pending}>
+      {pending ? "Salvando..." : "Redefinir senha"}
+    </Button>
+  );
+}

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -4,6 +4,7 @@ export { signInAction } from "./actions/sign-in";
 export { signUpAction } from "./actions/sign-up";
 export { signOutAction } from "./actions/sign-out";
 export { recoverPasswordAction } from "./actions/recover-password";
+export { resetPasswordAction } from "./actions/reset-password";
 export { signInGoogleAction } from "./actions/sign-in-google";
 
 export { getCurrentUser } from "./queries/get-current-user";
@@ -11,7 +12,8 @@ export { getCurrentUser } from "./queries/get-current-user";
 export { SignInForm } from "./components/sign-in-form";
 export { SignUpForm } from "./components/sign-up-form";
 export { RecoverForm } from "./components/recover-form";
+export { ResetPasswordForm } from "./components/reset-password-form";
 export { GoogleButton } from "./components/google-button";
 
-export type { SignInInput, SignUpInput, RecoverInput } from "./schemas";
+export type { SignInInput, SignUpInput, RecoverInput, ResetPasswordInput } from "./schemas";
 export type { CompanyMembership } from "./queries/get-current-user";

--- a/src/modules/auth/schemas/index.ts
+++ b/src/modules/auth/schemas/index.ts
@@ -21,6 +21,17 @@ export const recoverSchema = z.object({
   email: z.string().email("Email inválido"),
 });
 
+export const resetPasswordSchema = z
+  .object({
+    password: z.string().min(8, "Mínimo 8 caracteres"),
+    confirmPassword: z.string(),
+  })
+  .refine((d) => d.password === d.confirmPassword, {
+    path: ["confirmPassword"],
+    message: "As senhas não coincidem",
+  });
+
 export type SignInInput = z.infer<typeof signInSchema>;
 export type SignUpInput = z.infer<typeof signUpSchema>;
 export type RecoverInput = z.infer<typeof recoverSchema>;
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;


### PR DESCRIPTION
## Problema

A rota `/recover/reset` não existia. Após clicar no link do e-mail de recuperação, o usuário era redirecionado ao login sem conseguir definir uma nova senha.

## Causa raiz

1. `recoverPasswordAction` apontava `redirectTo` para `/recover/reset` diretamente — o Supabase envia o link com `?code=` que precisa ser trocado por sessão via `/api/auth/callback` antes
2. A página `/recover/reset` nunca foi criada

## Solução

**Fluxo correto:**
1. Usuário solicita recuperação → e-mail enviado com link para `/api/auth/callback?next=/recover/reset`
2. Callback troca o código PKCE → estabelece sessão → redireciona para `/recover/reset`
3. Usuário preenche nova senha + confirmação → `supabase.auth.updateUser({ password })`
4. Sucesso → botão "Ir para o login"

## Arquivos alterados

- `recover-password.ts` — `redirectTo` passa pelo callback agora
- `reset-password.ts` *(novo)* — Server Action que chama `updateUser`
- `reset-password-form.tsx` *(novo)* — Formulário com validação
- `/recover/reset/page.tsx` *(novo)* — Rota da página
- `schemas/index.ts` — Adiciona `resetPasswordSchema`
- `index.ts` — Exporta novos artefatos via barrel

**216/216 testes passando ✅**
