### PR TITLE
fix(kb): F1 pendências — upsertCategoryAction, slug opcional e doc atualizada

### DIFF
--- a/docs/KNOWLEDGE-BASE-ARCHITECTURE.md
+++ b/docs/KNOWLEDGE-BASE-ARCHITECTURE.md
@@ -1,0 +1,638 @@
+# Base de Conhecimento do ERP — Arquitetura
+
+> **Status:** F3 em revisão (PR #24) · F2 em revisão (PR #23) · F1 concluído · 2026-04-29 · F0 concluído e em main · 2026-04-26
+> **Autor:** Plano gerado por Claude a pedido de Yuri
+> **Escopo:** Módulo `knowledge-base` para o ERP, com manual do usuário, documentação técnica, vídeos animados (Remotion), edição híbrida (MDX + UI) e camada de IA.
+
+---
+
+## 1. Objetivo
+
+Criar dentro do próprio ERP uma base de conhecimento que cumpra três papéis:
+
+1. **Manual do Usuário** — como operar o sistema (cadastros, fluxos, regras de negócio, exemplos visuais e vídeos curtos).
+2. **Documentação Técnica** — modelo de dados, RLS, eventos de gatilho, contratos das Server Actions, ADRs, para devs e analistas.
+3. **Apoio contínuo** — busca semântica, copiloto de IA para responder dúvidas e ajudar a redigir/atualizar conteúdo.
+
+Princípios não-negociáveis (decorrentes do `CLAUDE.md`):
+
+- Tudo em **português (pt-BR)**.
+- Encaixar no padrão **`src/modules/<domain>/`** com barrel `index.ts` único.
+- Toda Server Action retorna **`ActionResult`**.
+- **RLS é a camada autoritativa** de permissão; checagem em TS é defesa em profundidade.
+- Atualizar `MODULES_MENU` em `src/core/navigation/menu.ts` (não o layout).
+- Não mexer em `products.stock` direto — manter a regra de que triggers do banco são fonte de verdade. Aqui não há essa preocupação porque o módulo é só leitura/escrita de conteúdo, mas a filosofia se aplica: **regras de negócio do conteúdo (slug único, versionamento, soft delete) ficam no banco**.
+
+---
+
+## 2. Decisões técnicas (resumo)
+
+| Camada                          | Escolha                                                                                                    | Por quê                                                                                                        |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Conteúdo "código" (devs)        | **MDX** + frontmatter, lido em build via `@next/mdx` ou `next-mdx-remote/rsc`                              | Versionado em Git, revisão por PR, type-safe via `zod` no frontmatter, render via React Server Components.     |
+| Conteúdo "operacional" (admins) | **Tabela `kb_articles` no Supabase** + editor **Tiptap** (com extensão Markdown)                           | Edição em tempo real pelos admins, RLS por empresa, histórico de revisões nativo.                              |
+| Diagramas de fluxo              | **Mermaid** (texto → SVG via `mermaid` lib client-side) e **React Flow** quando precisar de interatividade | Mermaid é trivial em MDX; React Flow para fluxogramas clicáveis (ex.: clicar no nó "Aprovação" abre o artigo). |
+| Vídeos animados                 | **Remotion** (`@remotion/player` + `@remotion/renderer`)                                                   | Pedido explícito. Permite as 3 modalidades: pré-renderizado, player embutido, animação com dados reais.        |
+| Busca                           | **Postgres FTS** (tsvector) + **pgvector** para busca semântica                                            | FTS resolve 80% dos casos; pgvector entra para "perguntas em linguagem natural".                               |
+| IA                              | **Vercel AI SDK** (`ai` + `@ai-sdk/openai` ou `@ai-sdk/anthropic`)                                         | Integra direto com Server Actions e Streaming UI. Trocável de provider.                                        |
+| Storage de mídia                | **Supabase Storage** bucket `knowledge-base`                                                               | Já temos Supabase; políticas de bucket espelham a RLS.                                                         |
+
+---
+
+## 3. Topologia de rotas
+
+Aproveita os route groups existentes (`(auth)`, `(dashboard)`).
+
+```
+src/app/
+├── (dashboard)/
+│   └── [companySlug]/
+│       ├── manual/                       ← Manual do Usuário (operacional)
+│       │   ├── page.tsx                  ← Home: categorias + busca + destaques
+│       │   ├── categoria/[slug]/page.tsx
+│       │   ├── artigo/[slug]/page.tsx
+│       │   ├── editor/                   ← Restrito a quem tem perm "kb:article:write"
+│       │   │   ├── page.tsx              ← Lista de artigos editáveis
+│       │   │   └── [id]/page.tsx         ← Editor Tiptap + IA copilot
+│       │   └── busca/page.tsx            ← FTS + semântica
+│       └── docs/                         ← Documentação Técnica (somente leitura, gerada de MDX)
+│           ├── page.tsx                  ← Sumário
+│           ├── arquitetura/[...slug]/page.tsx
+│           ├── modulos/[modulo]/page.tsx
+│           ├── tabelas/[tabela]/page.tsx ← Renderiza spec de tabela + RLS + diagrama
+│           └── adrs/[id]/page.tsx
+│
+└── api/
+    └── kb/
+        ├── search/route.ts               ← POST { q } → resultados FTS + semânticos
+        ├── chat/route.ts                 ← POST stream chat com RAG
+        └── remotion/render/route.ts      ← POST inicia render de vídeo (server action também serve)
+```
+
+**Permissões novas (a inserir via migration `seed_core_permissions`):**
+
+| Permission           | Para quê                                    |
+| -------------------- | ------------------------------------------- |
+| `kb:article:read`    | Ver artigos do manual                       |
+| `kb:article:write`   | Criar/editar artigos via UI                 |
+| `kb:article:publish` | Publicar/despublicar (gate de revisão)      |
+| `kb:doc:read`        | Ver a doc técnica (geralmente só dev/admin) |
+| `kb:ai:use`          | Usar copiloto de IA (controla custo)        |
+
+---
+
+## 4. Estrutura do módulo `knowledge-base`
+
+Segue 1:1 o padrão de `src/modules/inventory/`.
+
+```
+src/modules/knowledge-base/
+├── actions/
+│   ├── create-article.ts            ← "use server", retorna ActionResult
+│   ├── update-article.ts
+│   ├── publish-article.ts
+│   ├── delete-article.ts
+│   ├── upsert-category.ts
+│   ├── trigger-video-render.ts      ← Dispara job Remotion (pré-renderizado)
+│   ├── ai-draft-article.ts          ← Gera rascunho com IA
+│   └── ai-suggest-edit.ts           ← Sugere edição inline
+├── queries/
+│   ├── list-articles.ts             ← server-only
+│   ├── get-article-by-slug.ts
+│   ├── list-categories.ts
+│   ├── search-articles.ts           ← FTS
+│   ├── semantic-search.ts           ← pgvector
+│   └── list-doc-pages.ts            ← Lê MDX do filesystem
+├── components/
+│   ├── article-card.tsx
+│   ├── article-list.tsx
+│   ├── article-viewer.tsx           ← Renderiza HTML do Tiptap + componentes embutidos
+│   ├── article-editor.tsx           ← Editor Tiptap + toolbar + IA panel
+│   ├── category-tree.tsx
+│   ├── search-bar.tsx               ← Cliente, com debounce
+│   ├── kb-chat-widget.tsx           ← Floating chat (RAG)
+│   ├── mermaid-diagram.tsx          ← Render lazy de diagramas
+│   ├── flow-diagram.tsx             ← React Flow
+│   ├── remotion-player.tsx          ← Wrapper do <Player /> com fallback
+│   └── doc-renderer.tsx             ← Renderiza MDX com remarks/rehypes
+├── services/
+│   ├── slug-service.ts              ← Geração e validação de slug
+│   ├── markdown-service.ts          ← Sanitização e transform Tiptap ↔ MD ↔ HTML
+│   ├── embedding-service.ts         ← Chunking + chamada ao provider de embeddings
+│   ├── rag-service.ts               ← Monta contexto para chat
+│   └── permission-helpers.ts        ← Pequenos helpers de checagem (sempre via authz)
+├── schemas/
+│   ├── article.ts                   ← Zod: CreateArticleInput, UpdateArticleInput
+│   ├── category.ts
+│   └── search.ts
+├── types/
+│   └── index.ts                     ← Tipos derivados de Database
+└── index.ts                         ← Barrel — única API pública
+```
+
+### Composições Remotion (fora do módulo)
+
+```
+src/remotion/
+├── Root.tsx                         ← registra todas as composições
+├── compositions/
+│   ├── stock-movement-flow.tsx      ← Anima entrada/saída de estoque
+│   ├── auth-flow.tsx                ← Anima login/registro/RBAC
+│   ├── permission-cascade.tsx       ← Mostra como RLS + has_permission decidem acesso
+│   └── module-tour.tsx              ← Tour pelo dashboard
+├── primitives/                      ← Componentes Remotion reutilizáveis (Card, Pill, ArrowFlow…)
+└── tokens.ts                        ← Cores/spacing alinhados ao Tailwind
+```
+
+> A pasta `src/remotion/` fica fora do `modules/` porque é consumida tanto pelo player no front quanto pelo bin de render no servidor. O `remotion-player.tsx` (no módulo) referencia `src/remotion` como dependência, igual a Storybook referencia componentes.
+
+---
+
+## 5. Schema do Supabase
+
+Migrations aplicadas em produção:
+
+| Arquivo                             | Conteúdo                                                                                                              |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `20260425000019_knowledge_base.sql` | Tabelas `kb_categories`, `kb_articles`, `kb_article_revisions`, `kb_article_chunks`, `kb_videos` + trigger de revisão |
+| `20260425000020_kb_rls.sql`         | RLS em todas as 5 tabelas KB                                                                                          |
+| `20260425000021_kb_permissions.sql` | Módulo `knowledge-base`, 5 permissões, atribuição automática a `owner`/`manager`/`operator`                           |
+
+Schema das tabelas (migração real `20260425000019_knowledge_base.sql`):
+
+```sql
+-- ============================================================
+-- 18 — KNOWLEDGE BASE
+-- Manual operacional editável + busca FTS/semântica + vídeos
+-- ============================================================
+
+create extension if not exists vector;
+create extension if not exists pg_trgm;
+
+-- 1) Categorias (árvore simples, parent_id opcional)
+create table public.kb_categories (
+  id          uuid primary key default gen_random_uuid(),
+  company_id  uuid not null references public.companies(id) on delete cascade,
+  parent_id   uuid references public.kb_categories(id) on delete set null,
+  slug        text not null,
+  title       text not null,
+  audience    text not null check (audience in ('user','dev','both')) default 'user',
+  position    int  not null default 0,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now(),
+  unique (company_id, slug)
+);
+
+-- 2) Artigos (conteúdo Tiptap salvo como JSON + markdown derivado)
+create table public.kb_articles (
+  id            uuid primary key default gen_random_uuid(),
+  company_id    uuid not null references public.companies(id) on delete cascade,
+  category_id   uuid references public.kb_categories(id) on delete set null,
+  slug          text not null,
+  title         text not null,
+  summary       text,
+  content_json  jsonb not null,              -- estado nativo do Tiptap
+  content_md    text  not null,              -- markdown gerado (para FTS e diff)
+  status        text  not null check (status in ('draft','published','archived')) default 'draft',
+  audience      text  not null check (audience in ('user','dev','both')) default 'user',
+  related_module text,                       -- ex.: 'inventory'
+  related_table  text,                       -- ex.: 'stock_movements' (link cruzado para doc técnica)
+  video_id      uuid references public.kb_videos(id) on delete set null,
+  search_vector tsvector
+    generated always as (
+      setweight(to_tsvector('portuguese', coalesce(title, '')), 'A') ||
+      setweight(to_tsvector('portuguese', coalesce(summary, '')), 'B') ||
+      setweight(to_tsvector('portuguese', coalesce(content_md, '')), 'C')
+    ) stored,
+  created_by    uuid references auth.users(id),
+  updated_by    uuid references auth.users(id),
+  published_at  timestamptz,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  unique (company_id, slug)
+);
+create index kb_articles_search_idx on public.kb_articles using gin (search_vector);
+create index kb_articles_company_status_idx on public.kb_articles (company_id, status);
+
+-- 3) Histórico de revisões (snapshot a cada save)
+create table public.kb_article_revisions (
+  id            uuid primary key default gen_random_uuid(),
+  article_id    uuid not null references public.kb_articles(id) on delete cascade,
+  content_json  jsonb not null,
+  content_md    text  not null,
+  edited_by     uuid references auth.users(id),
+  edited_at     timestamptz not null default now()
+);
+
+-- 4) Embeddings para busca semântica e RAG
+create table public.kb_article_chunks (
+  id          uuid primary key default gen_random_uuid(),
+  article_id  uuid not null references public.kb_articles(id) on delete cascade,
+  company_id  uuid not null references public.companies(id) on delete cascade,
+  chunk_index int  not null,
+  content     text not null,
+  embedding   vector(1536) not null,         -- ajustar dim conforme provider
+  created_at  timestamptz not null default now(),
+  unique (article_id, chunk_index)
+);
+create index kb_chunks_embedding_idx
+  on public.kb_article_chunks
+  using ivfflat (embedding vector_cosine_ops) with (lists = 100);
+
+-- 5) Vídeos Remotion (registro + URL no Storage)
+create table public.kb_videos (
+  id            uuid primary key default gen_random_uuid(),
+  company_id    uuid not null references public.companies(id) on delete cascade,
+  composition   text not null,               -- nome da composição em src/remotion
+  title         text not null,
+  description   text,
+  status        text not null check (status in ('queued','rendering','ready','failed')) default 'queued',
+  storage_path  text,                        -- ex.: kb-videos/<id>.mp4
+  duration_s    numeric,
+  thumbnail_path text,
+  input_props   jsonb,                       -- props passadas pra composição
+  created_by    uuid references auth.users(id),
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+);
+
+-- 6) Trigger: ao salvar artigo, copia snapshot pra revisões e zera embeddings
+create or replace function public.kb_after_article_update()
+returns trigger language plpgsql as $$
+begin
+  if (tg_op = 'UPDATE' and (old.content_json is distinct from new.content_json)) then
+    insert into public.kb_article_revisions (article_id, content_json, content_md, edited_by)
+    values (old.id, old.content_json, old.content_md, new.updated_by);
+    delete from public.kb_article_chunks where article_id = new.id;
+  end if;
+  new.updated_at := now();
+  return new;
+end$$;
+
+create trigger trg_kb_after_article_update
+before update on public.kb_articles
+for each row execute function public.kb_after_article_update();
+```
+
+### RLS (`20260425000020_kb_rls.sql`)
+
+Padrão idêntico ao `20260423000016_movements_rls.sql`:
+
+```sql
+alter table public.kb_categories       enable row level security;
+alter table public.kb_articles         enable row level security;
+alter table public.kb_article_revisions enable row level security;
+alter table public.kb_article_chunks    enable row level security;
+alter table public.kb_videos            enable row level security;
+
+-- LEITURA
+create policy "kb_articles_select"
+  on public.kb_articles for select
+  using (
+    company_id in (select user_company_ids())
+    and (status = 'published' or has_permission(company_id, 'kb:article:write'))
+  );
+
+-- ESCRITA
+create policy "kb_articles_insert"
+  on public.kb_articles for insert
+  with check (has_permission(company_id, 'kb:article:write'));
+
+create policy "kb_articles_update"
+  on public.kb_articles for update
+  using (has_permission(company_id, 'kb:article:write'))
+  with check (
+    company_id = (select company_id from public.kb_articles where id = kb_articles.id)
+    -- regra extra: só quem tem 'kb:article:publish' pode mudar status para 'published'
+  );
+
+-- (idem para revisions/chunks/videos/categories — sempre filtrando por company_id e perms)
+```
+
+As 5 permissões e a atribuição por role ficam em `20260425000021_kb_permissions.sql` (não no seed original).
+
+---
+
+## 6. Como o Remotion entra (3 modalidades)
+
+Você marcou as três. Cada uma resolve um caso diferente; combinadas dão a experiência completa.
+
+### 6.1 Vídeos pré-renderizados (assets prontos no Storage)
+
+**Quando usar:** explicações longas, onboarding, conteúdo que muda raramente. Render pesado uma vez, servido como MP4 leve.
+
+**Como:**
+
+1. Composição em `src/remotion/compositions/auth-flow.tsx` (componente React).
+2. Server Action `triggerVideoRenderAction` insere linha em `kb_videos` com `status='queued'`.
+3. Job (Edge Function do Supabase ou rota Next + `@remotion/renderer`) lê fila, chama `renderMedia`, sobe MP4 para `Supabase Storage`, atualiza `status='ready'`, `storage_path` e `duration_s`.
+4. UI mostra `<video src={signedUrl} controls />`.
+
+> **Trade-off:** render pesa CPU. Se hospedagem é Vercel, melhor usar **Lambda render** (`@remotion/lambda`) ou um worker dedicado fora da serverless. Documentar em ADR.
+
+### 6.2 Player Remotion embutido (interativo, sem MP4)
+
+**Quando usar:** dicas curtas dentro de um artigo ("clique aqui para ver a animação"), sem custo de render, controles totais (play/pause/scrub).
+
+**Como:**
+
+```tsx
+// components/remotion-player.tsx
+"use client";
+import { Player } from "@remotion/player";
+import { StockMovementFlow } from "@/remotion/compositions/stock-movement-flow";
+
+export function StockMovementPlayer({ inputProps }) {
+  return (
+    <Player
+      component={StockMovementFlow}
+      durationInFrames={180}
+      compositionWidth={1280}
+      compositionHeight={720}
+      fps={30}
+      inputProps={inputProps}
+      controls
+      style={{ width: "100%", borderRadius: "0.5rem" }}
+    />
+  );
+}
+```
+
+Esse componente é exposto pelo barrel e fica disponível em **artigos do Tiptap** via uma extensão custom `RemotionEmbed` que armazena `{ composition, props }` no JSON e, na renderização, monta o `<RemotionPlayer />` correspondente.
+
+### 6.3 Animações com dados reais (storytelling do banco)
+
+**Quando usar:** "mostrar o último movimento de estoque registrado" como animação, ou onboarding personalizado ("você cadastrou 12 produtos").
+
+**Como:**
+
+1. Server Component busca dados (`getProduct`, `listMovements` do módulo inventory — via barrel, claro).
+2. Passa via `inputProps` para a composição:
+
+   ```tsx
+   const movement = await getMovement(id);
+   return <StockMovementPlayer inputProps={{ movement, product }} />;
+   ```
+
+3. A composição usa `useCurrentFrame()` e `interpolate()` para animar o número saindo/entrando.
+4. Bonus: se o usuário quiser baixar como MP4, o mesmo `inputProps` é serializado e mandado pra fila de render (modalidade 1).
+
+> **Importante:** dados reais nunca são embutidos em MP4 público. Render só roda autenticado e o Storage usa **signed URLs** com TTL curto.
+
+---
+
+## 7. Camada de IA (assistente híbrido)
+
+Você pediu "Híbrido + IA". A IA atua em três pontos, todos opcionais e gateados por `kb:ai:use`:
+
+### 7.1 Busca semântica (SearchBar e `/manual/busca`)
+
+- Indexação: ao publicar um artigo, `embedding-service.chunkAndEmbed(article)` divide o `content_md` em chunks (~500 tokens), gera embeddings via Vercel AI SDK (`embed`), grava em `kb_article_chunks`.
+- Query: usuário digita → server action `semanticSearch(q)` faz embedding da query, roda `select ... order by embedding <=> :q_emb limit 10`, mistura resultados com FTS (rank-fusion simples) e devolve top 10.
+
+### 7.2 RAG Chat (widget flutuante "Pergunte ao manual")
+
+- Componente `kb-chat-widget.tsx` (cliente) usa `useChat` do `ai/react`.
+- Endpoint `app/api/kb/chat/route.ts` recebe a pergunta, chama `rag-service.buildContext(question, companyId)` (faz semantic search nos chunks **filtrando por company_id via RLS**), monta prompt:
+
+  ```
+  Você é o assistente do ERP da empresa X. Responda APENAS com base nos
+  trechos abaixo. Se não souber, diga que não encontrou no manual e
+  sugira 2 buscas relacionadas. Sempre cite o título do artigo entre [].
+  ```
+
+- Stream de volta com `streamText`. UI mostra com citações clicáveis para os artigos-fonte.
+
+### 7.3 Copiloto no editor (geração assistida)
+
+Dentro do editor Tiptap, três ações:
+
+| Ação                                | Server Action                                                 | Comportamento                                                                                                              |
+| ----------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **"Gerar rascunho"**                | `aiDraftArticle({ title, audience, related_module })`         | Lê schema/migrations relacionadas (via filesystem do projeto, em build-time fica num índice estático), gera 3 seções base. |
+| **"Reescrever para usuário final"** | `aiSuggestEdit({ articleId, mode: 'simplify' })`              | Faz pass de simplificação no trecho selecionado.                                                                           |
+| **"Documentar tabela"**             | `aiDraftArticle({ kind: 'table', table: 'stock_movements' })` | Lê definição da tabela + policies RLS + triggers e gera documentação técnica em MDX-pronto.                                |
+
+> **Provider:** começar com `@ai-sdk/anthropic` (Claude) por afinidade. Trocar é reescrever 1 import. Chave em `src/core/config/env.ts` com Zod (`ANTHROPIC_API_KEY`).
+
+---
+
+## 8. Conteúdo "código" (MDX para devs)
+
+Para a Documentação Técnica (`/docs/...`), preferimos MDX no repositório:
+
+```
+src/content/docs/
+├── arquitetura/
+│   ├── visao-geral.mdx
+│   ├── multitenant.mdx
+│   └── rls-rbac.mdx
+├── modulos/
+│   ├── inventory.mdx
+│   ├── auth.mdx
+│   └── knowledge-base.mdx
+├── tabelas/
+│   ├── products.mdx
+│   ├── stock_movements.mdx
+│   └── kb_articles.mdx
+└── adrs/
+    ├── 0001-modular-boundaries.mdx
+    └── 0002-remotion-rendering.mdx
+```
+
+Cada `.mdx` tem frontmatter validado por Zod (`title`, `audience`, `related_module`, `tags`). A página renderiza com:
+
+- `next-mdx-remote/rsc` (avoid client bundle).
+- Plugins: `remark-gfm`, `rehype-slug`, `rehype-autolink-headings`, `rehype-pretty-code`.
+- Componentes injetados: `<Mermaid />`, `<RemotionPlayer />`, `<TableSpec />`, `<RlsBlock />`, `<Callout />`.
+
+A vantagem dupla: o **mesmo conteúdo MDX entra na busca semântica**, porque um job no build (`scripts/index-docs.ts`) percorre os arquivos, faz chunking e popula `kb_article_chunks` com `article_id = null` + `source = 'mdx'` (campo extra).
+
+---
+
+## 9. Fluxos principais
+
+### 9.1 Admin cria/edita artigo (UI)
+
+```
+Admin → /manual/editor/[id]
+   → ArticleEditor (Tiptap)
+   → Botão "Salvar"
+   → updateArticleAction(formData)        # 'use server'
+       → schema.safeParse                   # zod
+       → requirePermission('kb:article:write')
+       → supabase.from('kb_articles').update({ content_json, content_md })
+       → trigger trg_kb_after_article_update grava revisão
+       → revalidatePath(`/${slug}/manual/artigo/${slug}`)
+   → Toast (sonner): "Artigo salvo"
+```
+
+### 9.2 Dev escreve doc técnica
+
+```
+Dev → cria src/content/docs/tabelas/nova-tabela.mdx
+   → PR → merge → CI roda `scripts/index-docs.ts` no postbuild
+   → Embeddings novos vão pra kb_article_chunks
+   → /docs/tabelas/nova-tabela é estático (build-time)
+```
+
+### 9.3 Usuário busca
+
+```
+Usuário digita "como dar baixa em estoque"
+   → SearchBar (cliente) → POST /api/kb/search
+   → Mistura FTS + semantic search
+   → Lista de hits com snippet destacado
+   → Clica → /manual/artigo/[slug]
+```
+
+### 9.4 Render de vídeo personalizado
+
+```
+Usuário (perm kb:article:write) clica "Gerar vídeo deste fluxo"
+   → triggerVideoRenderAction({ composition, inputProps })
+   → insert kb_videos status='queued'
+   → Worker (Supabase Edge Function ou rota /api/kb/remotion/render)
+       → bundle Remotion (cache de bundle entre runs)
+       → renderMedia → MP4 temp
+       → upload pro bucket knowledge-base/videos
+       → update kb_videos status='ready'
+   → UI faz polling (ou Realtime) → exibe player
+```
+
+---
+
+## 10. Plano faseado
+
+| Fase                                                                                                           | Entrega                                                                                                                                                                                                                                                            | Critério de pronto                                                                                                                                                   |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **F0 — Fundação** ✅ **CONCLUÍDO** (PR #18 · 2026-04-26)                                                       | Migrations 19, 20 e 21, 5 perms semeadas, item no `MODULES_MENU`, módulo `knowledge-base/` com barrel vazio, rota `/manual` placeholder.                                                                                                                           | `db:types` regenerado, `lint` e `typecheck` limpos, rota carrega gated por `requirePermission`. CI: `supabase start --ignore-health-check` (edge runtime não usado). |
+| **F1 — Manual editável (CRUD)** ✅ **CONCLUÍDO** (branch `feat/knowledge-base-f1` · 2026-04-29)                | Tiptap instalado, actions CRUD completas, queries, schemas, slug-service, componentes (editor, viewer, list, category-tree, publish-form), rotas `/manual` completas.                                                                                              | Admin cria artigo, publica; usuário sem `kb:article:write` vê só publicados. Build limpo, hydration fix aplicado.                                                    |
+| **F2 — Doc técnica MDX** 🔍 **EM REVISÃO** ([PR #23](https://github.com/triade-devs/erp/pull/23) · 2026-04-30) | Pipeline `next-mdx-remote/rsc`, layout `/docs`, plugins (gfm, slug, pretty-code), componentes `<Mermaid />`, `<TableSpec />`, `<Callout />`, `<RlsBlock />`, `<DocRenderer />`. Item "Documentação" no `MODULES_MENU` gated por `kb:doc:read`. 3 páginas MDX seed. | 3 páginas MDX renderizam, build limpo, typecheck limpo.                                                                                                              |
+| **F3 — Remotion** 🔍 **EM REVISÃO** ([PR #24](https://github.com/triade-devs/erp/pull/24) · 2026-04-30)        | `src/remotion/` com tokens, primitivos (`Card`, `Pill`, `ArrowFlow`) e 2 composições (`StockMovementFlow`, `AuthFlow`). `<RemotionPlayer />` client component no barrel. Extensão Tiptap `RemotionEmbedExtension`. `transpilePackages` configurado.                | Build limpo, typecheck limpo. Player toca props mockadas.                                                                                                            |
+| **F4 — Busca + IA**                                                                                            | FTS, pgvector, `embedding-service`, `/api/kb/search`, widget de chat RAG, copiloto no editor.                                                                                                                                                                      | Busca textual e semântica retornam resultados pertinentes em <500ms p95, chat cita fontes, copiloto gera rascunho coerente.                                          |
+| **F5 — Render de vídeos**                                                                                      | Worker de render (decisão: Edge Function vs Lambda Remotion), upload pro Storage, polling/Realtime na UI.                                                                                                                                                          | Job dispara, MP4 chega ao bucket, link assinado abre, falhas marcam `status='failed'` com `error_message`.                                                           |
+
+> Cada fase entra como PR independente, com migration própria quando aplicável, seguindo o ritmo do `docs/PLAN.md`.
+
+---
+
+## 11. Dependências a instalar
+
+```bash
+# Editor + MDX
+npm i @tiptap/react @tiptap/starter-kit @tiptap/extension-link @tiptap/extension-image \
+      tiptap-markdown next-mdx-remote remark-gfm rehype-slug rehype-autolink-headings \
+      rehype-pretty-code shiki
+
+# Diagramas
+npm i mermaid @xyflow/react
+
+# Remotion
+npm i remotion @remotion/player @remotion/renderer @remotion/bundler
+# (opcional render serverless) @remotion/lambda
+
+# IA
+npm i ai @ai-sdk/anthropic
+# (opcional) @ai-sdk/openai
+
+# Busca / utils
+npm i fuse.js  # fallback client-side de busca para casos offline
+```
+
+E o seguinte schema env (em `src/core/config/env.ts`):
+
+```ts
+ANTHROPIC_API_KEY: z.string().min(1),
+KB_EMBEDDINGS_PROVIDER: z.enum(["anthropic","openai"]).default("anthropic"),
+KB_VIDEO_RENDER_MODE: z.enum(["inline","lambda","worker"]).default("inline"),
+```
+
+---
+
+## 12. Riscos e trade-offs
+
+| Risco                                              | Mitigação                                                                                                                                                                         |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Render Remotion pesado em Vercel serverless        | Começar com player embutido (sem render). Render só na F5, e nessa fase decidir entre Lambda Remotion ou um worker dedicado (Render.com/Railway). Documentar em ADR.              |
+| pgvector em Supabase free tier tem limite de RAM   | Usar índice `ivfflat` com `lists` adequado; manter chunks pequenos; só indexar artigos publicados.                                                                                |
+| Conteúdo desatualizado (drift entre código e docs) | F2 inclui um lint custom em CI: para cada `kb_articles.related_table`, checar se a tabela ainda existe nas migrations. Falha se órfão.                                            |
+| Custo de IA descontrolado                          | Permissão `kb:ai:use` por role. Rate-limit por usuário/empresa em `app/api/kb/chat/route.ts`. Logging de tokens em `audit_log`.                                                   |
+| Tiptap JSON virar formato refém                    | `content_md` é fonte secundária e é o que vai pra busca/RAG. Sempre mantemos os dois.                                                                                             |
+| RLS na busca semântica                             | A query `semantic_search` roda **com o cliente do usuário** (não service role), então o `vector <=>` já é pré-filtrado pela policy `kb_chunks_select`. Garantir testes para isso. |
+
+---
+
+## 13. Definition of Done (módulo)
+
+### F0 — concluído ✅
+
+- [x] Migrations 19, 20 e 21 aplicadas em produção; `db:types` regenerado com tabelas KB.
+- [x] 5 permissões semeadas e atribuídas: `owner` recebe todas; `manager` todas; `operator` `read` + `ai:use`. Roles customizadas (ex.: `docs`) precisam de atribuição manual via Configurações → Roles.
+- [x] `src/modules/knowledge-base/index.ts` exporta barrel vazio; `types/index.ts` com tipos derivados de `Database`. ESLint limpo.
+- [x] Item `"Manual"` em `MODULES_MENU` com `requiresPermission: "kb:article:read"` e `icon: "book-open"`.
+- [x] Layout do dashboard não foi tocado.
+- [x] Página `/manual` gated por `requirePermission(company.id, "kb:article:read")` com mensagem de acesso negado em pt-BR.
+- [x] Strings e comentários em pt-BR.
+- [x] CI corrigido: `supabase start --ignore-health-check` (edge runtime retornava 502 no GitHub Actions).
+
+### F1 — concluído ✅
+
+- [x] Tiptap instalado: `@tiptap/react`, `@tiptap/starter-kit`, `tiptap-markdown`.
+- [x] Server Actions com `ActionResult`: `createArticleAction`, `updateArticleAction`, `deleteArticleAction`, `publishArticleAction`.
+- [x] Queries server-only: `listArticles`, `getArticleBySlug`, `listCategories`.
+- [x] Schemas Zod: `createArticleSchema`, `updateArticleSchema`, `categorySchema`.
+- [x] Service: `slug-service.ts` (geração e unicidade de slug).
+- [x] Componentes: `ArticleEditor` (Tiptap), `ArticleViewer`, `ArticleList`, `CategoryTree`, `PublishForm`.
+- [x] Rotas: `/manual`, `/manual/artigo/[slug]`, `/manual/editor`, `/manual/editor/[id]`.
+- [x] Barrel `index.ts` exporta tudo acima.
+- [x] Fix hydration: `immediatelyRender: false` no `useEditor`.
+- [x] Sem `dangerouslySetInnerHTML` — viewer renderiza `content_md` como texto.
+- [x] Checagem de permissão sem duplicação na rota de artigo.
+
+- [x] `upsertCategoryAction` — cria e edita categorias, slug auto-gerado do título, exportado no barrel.
+- [x] Filtro por categoria via `?category=slug` no `/manual` — rota `categoria/[slug]` não necessária (CategoryTree já faz link com query param).
+
+### F2 — em revisão 🔍 ([PR #23](https://github.com/triade-devs/erp/pull/23))
+
+- [x] Pacotes instalados: `next-mdx-remote`, `remark-gfm`, `rehype-slug`, `rehype-autolink-headings`, `rehype-pretty-code`, `shiki`, `gray-matter`, `mermaid`.
+- [x] Schema Zod `docPageFrontmatterSchema` (`title`, `audience`, `related_module`, `tags`) em `schemas/doc-page.ts`.
+- [x] Query `listDocPages` — lê MDX do filesystem, valida frontmatter.
+- [x] Componentes: `Callout`, `TableSpec`, `RlsBlock`, `MermaidDiagram` (client, lazy), `DocRenderer` (RSC, next-mdx-remote/rsc).
+- [x] Rotas: `/docs` (sumário), `/docs/arquitetura/[...slug]`, `/docs/modulos/[modulo]`, `/docs/tabelas/[tabela]` — todas via layout gated por `kb:doc:read`.
+- [x] Item "Documentação" no `MODULES_MENU` com `requiresPermission: "kb:doc:read"`.
+- [x] 3 páginas seed: `arquitetura/visao-geral.mdx`, `modulos/inventory.mdx`, `tabelas/products.mdx`.
+
+### F3 — em revisão 🔍 ([PR #24](https://github.com/triade-devs/erp/pull/24))
+
+- [x] Pacotes instalados: `remotion`, `@remotion/player`. `transpilePackages` em `next.config.mjs`.
+- [x] `src/remotion/tokens.ts` — paleta alinhada ao Tailwind/shadcn.
+- [x] `src/remotion/primitives/` — `Card`, `Pill`, `ArrowFlow` com animações via `useCurrentFrame`/`interpolate`.
+- [x] `src/remotion/Root.tsx` — registra `StockMovementFlow` e `AuthFlow`.
+- [x] `src/remotion/compositions/stock-movement-flow.tsx` — anima entrada/saída de estoque (180 frames, 30fps).
+- [x] `src/remotion/compositions/auth-flow.tsx` — anima login → sessão → role → permissão (180 frames, 30fps).
+- [x] `RemotionPlayer` — wrapper `"use client"` do `<Player />`, exportado no barrel.
+- [x] `RemotionEmbedExtension` — extensão Tiptap `atom` que armazena `{ composition, props }` como JSON no editor.
+
+### Pendente (F4+)
+
+- [ ] `busca/page.tsx` (FTS + semântica — F4).
+- [ ] README atualizado com seção "Base de Conhecimento".
+- [ ] RLS validada com 2 empresas distintas (teste formal).
+
+---
+
+## 14. Próximos passos
+
+**F3 concluído.** Próxima fase: **F4 — Busca + IA**.
+
+Escopo de F4:
+
+- FTS via `search_vector` (já gerado como coluna `tsvector stored` em `kb_articles`)
+- pgvector: `embedding-service.ts` — chunking + embed via Vercel AI SDK, grava em `kb_article_chunks`
+- Rota `POST /api/kb/search` — mistura FTS + semantic search (rank-fusion)
+- `busca/page.tsx` com `SearchBar` debounced
+- Widget `kb-chat-widget.tsx` — `useChat` do `ai/react`, endpoint `POST /api/kb/chat` com RAG
+- Copiloto no editor: `aiDraftArticle`, `aiSuggestEdit` (Server Actions gated por `kb:ai:use`)
+- Env vars a adicionar em `src/core/config/env.ts`: `ANTHROPIC_API_KEY`, `KB_EMBEDDINGS_PROVIDER`
+- Critério: busca textual e semântica retornam resultados em <500ms p95; chat cita fontes; copiloto gera rascunho coerente.

--- a/docs/superpowers/plans/2026-04-29-stock-review.md
+++ b/docs/superpowers/plans/2026-04-29-stock-review.md
@@ -1,0 +1,718 @@
+# Revisão Completa das Funções de Estoque — Plano de Execução
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auditar todas as camadas do módulo `inventory` nos 4 eixos (bugs, gaps, segurança, testes) e produzir um relatório de achados priorizados em `docs/superpowers/reports/stock-review-report.md`.
+
+**Architecture:** Revisão sequencial por camada (migrations → schemas → services → actions → queries → components → tests). Cada layer é auditado individualmente; os achados são agregados no relatório final com severidade e correção sugerida. Nenhuma correção é aplicada durante a revisão.
+
+**Tech Stack:** TypeScript · Next.js 15 Server Actions · Supabase (PostgreSQL + RLS + Triggers) · Zod · Vitest
+
+---
+
+## Mapa de arquivos auditados
+
+| Camada        | Arquivos                                                                                                                                                                                                                                                                                              |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Migrations/DB | `supabase/migrations/20260420000002_products.sql` `20260420000003_stock_movements.sql` `20260423000011_products_company_nullable.sql` `20260423000013_sku_unique_per_company.sql` `20260423000014_products_company_not_null.sql` `20260423000015_products_rls.sql` `20260423000016_movements_rls.sql` |
+| Schemas       | `src/modules/inventory/schemas/index.ts`                                                                                                                                                                                                                                                              |
+| Services      | `src/modules/inventory/services/stock-service.ts`                                                                                                                                                                                                                                                     |
+| Actions       | `src/modules/inventory/actions/create-product.ts` `update-product.ts` `delete-product.ts` `reactivate-product.ts` `register-movement.ts`                                                                                                                                                              |
+| Queries       | `src/modules/inventory/queries/get-product.ts` `list-products.ts` `list-movements.ts`                                                                                                                                                                                                                 |
+| Components    | `src/modules/inventory/components/product-form.tsx` `product-table.tsx` `movement-form.tsx` `movement-table.tsx` `reactivate-product-button.tsx`                                                                                                                                                      |
+| Testes        | `src/modules/inventory/actions/__tests__/inventory-actions.test.ts`                                                                                                                                                                                                                                   |
+
+**Relatório de saída:** `docs/superpowers/reports/stock-review-report.md`
+
+---
+
+## Task 1: Criar esqueleto do relatório
+
+**Files:**
+
+- Create: `docs/superpowers/reports/stock-review-report.md`
+
+- [ ] **Step 1: Criar o arquivo de relatório com a estrutura base**
+
+```bash
+mkdir -p docs/superpowers/reports
+```
+
+Criar `docs/superpowers/reports/stock-review-report.md` com o conteúdo abaixo (exatamente):
+
+```markdown
+# Relatório de Revisão — Módulo Inventory (Estoque)
+
+**Data:** 2026-04-29
+**Escopo:** `src/modules/inventory/` + migrations relacionadas
+**Metodologia:** Auditoria sequencial por camada (migrations → schemas → services → actions → queries → components → testes)
+
+## Legenda de Severidade
+
+| Símbolo | Nível     | Critério                                           |
+| ------- | --------- | -------------------------------------------------- |
+| 🔴      | **Alta**  | Bug ativo, falha de segurança, ou dado corrompível |
+| 🟡      | **Média** | Comportamento inesperado, gap funcional relevante  |
+| 🟢      | **Baixa** | Cobertura de testes ausente, melhoria de qualidade |
+
+## Legenda de Eixos
+
+- **BUG** — comportamento incorreto ou inconsistente
+- **GAP** — funcionalidade ausente ou incompleta
+- **SEC** — segurança, RLS, permissões, isolamento multi-tenant
+- **TEST** — lacuna de cobertura de testes
+
+---
+
+## Camada 1: Migrations / Banco de Dados
+
+_(a preencher na Task 2)_
+
+## Camada 2: Schemas Zod
+
+_(a preencher na Task 3)_
+
+## Camada 3: Services
+
+_(a preencher na Task 4)_
+
+## Camada 4: Actions
+
+_(a preencher na Task 5)_
+
+## Camada 5: Queries
+
+_(a preencher na Task 6)_
+
+## Camada 6: UI Components
+
+_(a preencher na Task 7)_
+
+## Camada 7: Testes Existentes
+
+_(a preencher na Task 8)_
+
+---
+
+## Sumário dos Achados
+
+_(a preencher na Task 9)_
+
+## Próximos Passos — Plano de Correções Priorizadas
+
+_(a preencher na Task 9)_
+```
+
+- [ ] **Step 2: Commit do esqueleto**
+
+```bash
+git add docs/superpowers/reports/stock-review-report.md
+git commit -m "docs(review): esqueleto do relatório de revisão do módulo inventory
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 2: Auditar Camada 1 — Migrations / Banco de Dados
+
+**Files:**
+
+- Read: `supabase/migrations/20260420000002_products.sql`
+- Read: `supabase/migrations/20260420000003_stock_movements.sql`
+- Read: `supabase/migrations/20260423000011_products_company_nullable.sql`
+- Read: `supabase/migrations/20260423000013_sku_unique_per_company.sql`
+- Read: `supabase/migrations/20260423000014_products_company_not_null.sql`
+- Read: `supabase/migrations/20260423000015_products_rls.sql`
+- Read: `supabase/migrations/20260423000016_movements_rls.sql`
+- Modify: `docs/superpowers/reports/stock-review-report.md`
+
+- [ ] **Step 1: Ler todas as migrations relevantes**
+
+```bash
+cat supabase/migrations/20260420000002_products.sql
+cat supabase/migrations/20260420000003_stock_movements.sql
+cat supabase/migrations/20260423000011_products_company_nullable.sql
+cat supabase/migrations/20260423000013_sku_unique_per_company.sql
+cat supabase/migrations/20260423000014_products_company_not_null.sql
+cat supabase/migrations/20260423000015_products_rls.sql
+cat supabase/migrations/20260423000016_movements_rls.sql
+```
+
+- [ ] **Step 2: Preencher a seção "Camada 1" do relatório**
+
+Substituir `_(a preencher na Task 2)_` por:
+
+```markdown
+### Achados
+
+**[DB-01] 🟢 TEST — Índice GIN não utilizado pela query**
+
+- **Arquivo**: `supabase/migrations/20260420000002_products.sql:22-24`
+- **Detalhe**: A migration cria `idx_products_name` usando `GIN(to_tsvector('portuguese', name))` para full-text search. Porém, `listProducts` usa `name.ilike.%${q}%` que não aproveita esse índice — faz seq scan.
+- **Correção sugerida**: Substituir `ilike` por busca full-text (`@@to_tsquery`) ou remover o índice GIN (que não está sendo usado) e criar `CREATE INDEX idx_products_name_ilike ON products USING gin(name gin_trgm_ops)` com a extensão `pg_trgm`.
+
+**[DB-02] 🟢 TEST — Sem índice em `products.is_active`**
+
+- **Arquivo**: `supabase/migrations/20260420000002_products.sql`
+- **Detalhe**: `listProducts` filtra frequentemente por `is_active = true` (padrão), mas não há índice nessa coluna.
+- **Correção sugerida**: `CREATE INDEX idx_products_is_active ON public.products(is_active) WHERE is_active = false;` (índice parcial para inativos, mais seletivo).
+
+**[DB-03] 🟢 GAP — Policy `products_delete` nunca é ativada**
+
+- **Arquivo**: `supabase/migrations/20260423000015_products_rls.sql:26-27`
+- **Detalhe**: A policy cobre `DELETE` físico, mas o código nunca deleta produtos — usa soft-delete via `UPDATE is_active = false`. Essa policy não oferece proteção real e cria falsa impressão de segurança. O soft-delete passa pela policy `products_update`.
+- **Correção sugerida**: Documentar o soft-delete como design intencional no comentário da migration. A policy `products_delete` pode ser mantida como defesa de profundidade caso alguém adicione DELETE direto no futuro.
+
+### Verificações OK
+
+- ✅ `company_id` adicionado nas migrations 11/14 (nullable → NOT NULL) — campo existe na tabela quando `registerMovementAction` o insere.
+- ✅ Trigger `apply_stock_movement`: lógica correta para `in` (soma), `out` (subtrai + check negativo), `adjustment` (valor absoluto).
+- ✅ Constraint `products_sku_per_company` (migration 13): SKU único por empresa, não global.
+- ✅ RLS em ambas as tabelas (`products` e `stock_movements`) com isolamento por `company_id`.
+- ✅ FK `product_id → products(id) ON DELETE RESTRICT` impede exclusão física de produto com histórico.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/reports/stock-review-report.md
+git commit -m "docs(review): achados da camada migrations/DB
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 3: Auditar Camada 2 — Schemas Zod
+
+**Files:**
+
+- Read: `src/modules/inventory/schemas/index.ts`
+- Modify: `docs/superpowers/reports/stock-review-report.md`
+
+- [ ] **Step 1: Ler o arquivo de schemas**
+
+```bash
+cat src/modules/inventory/schemas/index.ts
+```
+
+- [ ] **Step 2: Preencher a seção "Camada 2" do relatório**
+
+Substituir `_(a preencher na Task 3)_` por:
+
+```markdown
+### Achados
+
+**[SCH-01] 🟡 GAP — `movementSchema` bloqueia zeragem de estoque via ajuste**
+
+- **Arquivo**: `src/modules/inventory/schemas/index.ts:24-28`
+- **Detalhe**: `quantity: z.coerce.number().positive("Deve ser maior que zero")` — `positive()` exige `> 0`. Para o tipo `adjustment` (que define o saldo absoluto), pode ser necessário ajustar estoque para 0 (ex: inventário zerado, perda total). O schema bloqueia esse caso.
+- **Correção sugerida**: Para `adjustment`, aceitar `quantity >= 0`. Isso requer validação contextual (refinamento Zod ou validação na action baseada no tipo).
+
+### Verificações OK
+
+- ✅ `productSchema`: todos os campos validados com limites razoáveis (SKU alfanumérico, nome 2-120 chars, unidades enum).
+- ✅ `movementSchema`: `productId` validado como UUID; tipo restrito a `["in", "out", "adjustment"]`.
+- ✅ `listProductsSchema` e `listMovementsSchema`: limites de página (`min: 1`, `max: 100`) e defaults seguros.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/reports/stock-review-report.md
+git commit -m "docs(review): achados da camada schemas Zod
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 4: Auditar Camada 3 — Services
+
+**Files:**
+
+- Read: `src/modules/inventory/services/stock-service.ts`
+- Modify: `docs/superpowers/reports/stock-review-report.md`
+
+- [ ] **Step 1: Ler o arquivo de services**
+
+```bash
+cat src/modules/inventory/services/stock-service.ts
+```
+
+- [ ] **Step 2: Preencher a seção "Camada 3" do relatório**
+
+Substituir `_(a preencher na Task 4)_` por:
+
+```markdown
+### Achados
+
+**[SVC-01] 🟢 TEST — `validateMovement` e `calculateNewStock` sem cobertura de testes**
+
+- **Arquivo**: `src/modules/inventory/services/stock-service.ts`
+- **Detalhe**: Nenhum teste unitário para essas duas funções. `validateMovement` tem branch para `type === "out"`, mas nenhuma cobertura do happy path, do erro lançado, nem do comportamento para `in` e `adjustment`. `calculateNewStock` não é testado em nenhum caso.
+- **Correção sugerida**: Criar `src/modules/inventory/services/__tests__/stock-service.test.ts` com casos: (a) `validateMovement` tipo `out` com estoque suficiente — sem erro; (b) `validateMovement` tipo `out` com estoque insuficiente — lança `InsufficientStockError`; (c) `validateMovement` tipos `in`/`adjustment` — sempre passa; (d) `calculateNewStock` para os 3 tipos.
+
+**[SVC-02] 🟢 GAP — `calculateNewStock` pode retornar negativo sem aviso**
+
+- **Arquivo**: `src/modules/inventory/services/stock-service.ts:23-36`
+- **Detalhe**: Se chamado para tipo `out` sem chamar `validateMovement` antes (e.g. diretamente na UI para preview), `calculateNewStock` retorna valor negativo silenciosamente. Não é um bug crítico (é usado só para preview), mas pode exibir saldo negativo na UI.
+- **Correção sugerida**: Documentar explicitamente que o retorno pode ser negativo e que a validação é responsabilidade do chamador.
+
+### Verificações OK
+
+- ✅ `validateMovement` cobre corretamente o único caso de pré-validação necessário (`out` > stock).
+- ✅ `InsufficientStockError` extends `Error` corretamente, com `name` explícito.
+- ✅ `calculateNewStock` cobre os 3 tipos de movimento com lógica correta.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/reports/stock-review-report.md
+git commit -m "docs(review): achados da camada services
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 5: Auditar Camada 4 — Actions
+
+**Files:**
+
+- Read: `src/modules/inventory/actions/create-product.ts`
+- Read: `src/modules/inventory/actions/update-product.ts`
+- Read: `src/modules/inventory/actions/delete-product.ts`
+- Read: `src/modules/inventory/actions/reactivate-product.ts`
+- Read: `src/modules/inventory/actions/register-movement.ts`
+- Modify: `docs/superpowers/reports/stock-review-report.md`
+
+- [ ] **Step 1: Ler todas as actions**
+
+```bash
+cat src/modules/inventory/actions/create-product.ts
+cat src/modules/inventory/actions/update-product.ts
+cat src/modules/inventory/actions/delete-product.ts
+cat src/modules/inventory/actions/reactivate-product.ts
+cat src/modules/inventory/actions/register-movement.ts
+```
+
+- [ ] **Step 2: Preencher a seção "Camada 4" do relatório**
+
+Substituir `_(a preencher na Task 5)_` por:
+
+```markdown
+### Achados
+
+**[ACT-01] 🔴 BUG — `reactivateProductAction` usa permissão de delete**
+
+- **Arquivo**: `src/modules/inventory/actions/reactivate-product.ts:22`
+- **Detalhe**: `await requirePermission(companyId, "inventory:product:delete")` — usa a mesma permissão do soft-delete. Reativar e desativar são operações distintas. Um operador sem permissão de delete não consegue reativar produtos. Semanticamente errado e viola o princípio de menor privilégio.
+- **Correção sugerida**: Usar `"inventory:product:update"` (reativar é uma atualização de `is_active`) ou criar permissão dedicada `"inventory:product:reactivate"` e registrá-la em `20260420000007_seed_core_permissions.sql`.
+
+**[ACT-02] 🔴 BUG — `updateProductAction` reseta `is_active` para `true` ao editar produto inativo**
+
+- **Arquivo**: `src/modules/inventory/actions/update-product.ts:47` + `src/modules/inventory/schemas/index.ts:17`
+- **Detalhe**: O `productSchema` tem `isActive: z.coerce.boolean().default(true)`. O `ProductForm` não renderiza input para `isActive`, então `FormData` nunca contém esse campo. `z.coerce.boolean().default(true)` com campo ausente retorna `true`. Logo, `updateProductAction` sempre faz `is_active = true`, reativando silenciosamente qualquer produto inativo que seja editado.
+- **Correção sugerida**: Em `updateProductAction`, não sobrescrever `is_active` se o campo não estiver presente no FormData. Opção mais limpa: criar `updateProductSchema` separado que omite `isActive` (ou o torna explicitamente opcional sem default).
+
+**[ACT-03] 🟡 GAP — `updateProductAction` retorna `ok: true` quando produto não existe**
+
+- **Arquivo**: `src/modules/inventory/actions/update-product.ts:37-58`
+- **Detalhe**: O `.update().eq("id", id).eq("company_id", companyId)` pode afetar 0 rows (produto não encontrado ou de outra empresa) sem erro — o Supabase retorna `{ error: null, count: 0 }`. A action retorna `{ ok: true, message: "Produto atualizado com sucesso" }` mesmo sem nada ter sido atualizado.
+- **Correção sugerida**: Verificar `count === 0` após o update e retornar `{ ok: false, message: "Produto não encontrado" }`.
+
+**[ACT-04] 🟡 GAP — `deleteProductAction` retorna silenciosamente quando produto não existe**
+
+- **Arquivo**: `src/modules/inventory/actions/delete-product.ts:34-42`
+- **Detalhe**: Mesmo problema do ACT-03: soft-delete de produto inexistente/de outra empresa não gera erro, mas o `redirect()` ainda redireciona o usuário normalmente.
+- **Correção sugerida**: Verificar `count === 0` e retornar erro antes de chamar `redirect()`.
+
+**[ACT-05] 🔵 SEC — Detecção de erro do trigger via string matching frágil**
+
+- **Arquivo**: `src/modules/inventory/actions/register-movement.ts:66`
+- **Detalhe**: `if (error.message.includes("Estoque insuficiente"))` — se a mensagem do trigger mudar na migration (ex: tradução, refatoração), essa condição deixa de funcionar silenciosamente, expondo a mensagem técnica do Postgres ao usuário.
+- **Correção sugerida**: Usar código de erro Postgres. Erros levantados por `RAISE EXCEPTION` ficam em `error.code === "P0001"` (raise_exception). Checar `error.code === "P0001"` em vez da mensagem de texto.
+
+**[ACT-06] 🟢 TEST — `reactivateProductAction` sem nenhum teste**
+
+- **Arquivo**: `src/modules/inventory/actions/__tests__/inventory-actions.test.ts`
+- **Detalhe**: Única action sem cobertura alguma — nem de permissão, nem de happy path.
+- **Correção sugerida**: Adicionar suite de testes cobrindo: (a) bloqueio sem empresa ativa; (b) bloqueio por ForbiddenError; (c) happy path com reativação bem-sucedida.
+
+**[ACT-07] 🟢 TEST — Ausência de happy-path tests para todas as actions**
+
+- **Arquivo**: `src/modules/inventory/actions/__tests__/inventory-actions.test.ts`
+- **Detalhe**: A suite cobre apenas isolamento de permissão (ForbiddenError + empresa). Não há teste que verifique o caminho feliz: create retorna `ok: true`, insert é chamado com os dados corretos, `revalidatePath` é chamado após sucesso.
+- **Correção sugerida**: Adicionar pelo menos um happy-path test por action.
+
+### Verificações OK
+
+- ✅ Todas as actions verificam autenticação (`getUser`) e empresa ativa antes de continuar.
+- ✅ Todas as actions chamam `requirePermission` antes de operar no banco.
+- ✅ `createProductAction` e `updateProductAction` tratam `23505` (SKU duplicado).
+- ✅ `registerMovementAction` faz pré-validação de saldo + captura erro do trigger.
+- ✅ Soft-delete em `deleteProductAction` preserva histórico de movimentações (não viola FK).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/reports/stock-review-report.md
+git commit -m "docs(review): achados da camada actions
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 6: Auditar Camada 5 — Queries
+
+**Files:**
+
+- Read: `src/modules/inventory/queries/get-product.ts`
+- Read: `src/modules/inventory/queries/list-products.ts`
+- Read: `src/modules/inventory/queries/list-movements.ts`
+- Modify: `docs/superpowers/reports/stock-review-report.md`
+
+- [ ] **Step 1: Ler todas as queries**
+
+```bash
+cat src/modules/inventory/queries/get-product.ts
+cat src/modules/inventory/queries/list-products.ts
+cat src/modules/inventory/queries/list-movements.ts
+```
+
+- [ ] **Step 2: Preencher a seção "Camada 5" do relatório**
+
+Substituir `_(a preencher na Task 6)_` por:
+
+```markdown
+### Achados
+
+**[QRY-01] 🟡 GAP — `getProduct` mascara todos os erros como `null`**
+
+- **Arquivo**: `src/modules/inventory/queries/get-product.ts:12-13`
+- **Detalhe**: `if (error) return null` — retorna `null` tanto para "produto não encontrado" (PostgREST code `PGRST116`) quanto para falhas de rede, timeout ou erro de RLS. O caller não consegue distinguir "produto não existe" de "erro de sistema". Uma página de detalhe de produto pode renderizar "não encontrado" mesmo quando o problema é uma falha de conexão.
+- **Correção sugerida**: Verificar `error.code === "PGRST116"` para "not found" e relançar (`throw error`) para os demais.
+
+**[QRY-02] 🟡 GAP — `listMovements` sem filtros por data, tipo ou responsável**
+
+- **Arquivo**: `src/modules/inventory/queries/list-movements.ts`
+- **Detalhe**: Suporta apenas filtro por `productId`. Casos de uso comuns — "movimentações de entrada hoje", "ajustes feitos pelo usuário X", "saídas do último mês" — não são suportados.
+- **Correção sugerida**: Adicionar ao `listMovementsSchema` campos opcionais `movementType`, `startDate`, `endDate`, `performedBy` e construir a query dinamicamente.
+
+**[QRY-03] 🟢 TEST — Nenhum teste para as queries**
+
+- **Arquivo**: `src/modules/inventory/queries/`
+- **Detalhe**: `getProduct`, `listProducts` e `listMovements` não têm nenhum teste. Como são server-only, precisariam de mock do Supabase client (mesmo padrão das actions) ou de testes de integração.
+- **Correção sugerida**: Criar `src/modules/inventory/queries/__tests__/` com testes para: (a) `getProduct` produto encontrado; (b) `getProduct` não encontrado; (c) `listProducts` paginação correta; (d) `listMovements` filtro por `productId`.
+
+### Verificações OK
+
+- ✅ Todas as queries começam com `import "server-only"`.
+- ✅ `listProducts` e `listMovements` recebem `companyId` explicitamente e isolam por empresa.
+- ✅ Paginação implementada corretamente com `range(from, to)` e `count: "exact"`.
+- ✅ `listProducts` suporta busca por `name` e `sku` simultaneamente com `ilike`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/reports/stock-review-report.md
+git commit -m "docs(review): achados da camada queries
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 7: Auditar Camada 6 — UI Components
+
+**Files:**
+
+- Read: `src/modules/inventory/components/product-form.tsx`
+- Read: `src/modules/inventory/components/product-table.tsx`
+- Read: `src/modules/inventory/components/movement-form.tsx`
+- Read: `src/modules/inventory/components/movement-table.tsx`
+- Read: `src/modules/inventory/components/reactivate-product-button.tsx`
+- Modify: `docs/superpowers/reports/stock-review-report.md`
+
+- [ ] **Step 1: Ler todos os componentes**
+
+```bash
+cat src/modules/inventory/components/product-form.tsx
+cat src/modules/inventory/components/product-table.tsx
+cat src/modules/inventory/components/movement-form.tsx
+cat src/modules/inventory/components/movement-table.tsx
+cat src/modules/inventory/components/reactivate-product-button.tsx
+```
+
+- [ ] **Step 2: Preencher a seção "Camada 6" do relatório**
+
+Substituir `_(a preencher na Task 7)_` por:
+
+```markdown
+### Achados
+
+**[UI-01] 🔴 BUG — `ReactivateProductButton` ignora resultado da action (sem feedback de erro)**
+
+- **Arquivo**: `src/modules/inventory/components/reactivate-product-button.tsx:20-24`
+- **Detalhe**: O callback `onClick` chama `await onReactivate(productId)` mas nunca usa o `ActionResult` retornado. Se a reativação falhar (erro de rede, permissão negada), o usuário não recebe nenhum feedback — o botão simplesmente volta ao estado normal, sem mensagem de erro.
+- **Correção sugerida**: Verificar `result.ok` e usar `toast.error(result.message)` em caso de falha (mesmo padrão do `MovementForm` e `ProductForm`).
+
+**[UI-02] 🟡 GAP — Saldo do produto no `MovementForm` fica desatualizado após registrar movimentação**
+
+- **Arquivo**: `src/modules/inventory/components/movement-form.tsx:48-55`
+- **Detalhe**: A lista de produtos com seus saldos é renderizada server-side no carregamento da página. Após registrar uma movimentação (que reseta o form via `formKey`), o saldo exibido no dropdown continua sendo o do carregamento original — não reflete a movimentação recém-registrada.
+- **Correção sugerida**: `revalidatePath` no server action já invalida o cache, mas o `MovementForm` recebe `products` como prop estática. Para atualizar o saldo, a lista de produtos deve ser refetched — o mais simples é fazer o form estar numa Server Component que re-renderiza, ou usar router refresh client-side após sucesso.
+
+**[UI-03] 🟡 GAP — `MovementTable` não exibe quem realizou a movimentação**
+
+- **Arquivo**: `src/modules/inventory/components/movement-table.tsx`
+- **Detalhe**: A coluna `performed_by` (UUID do usuário) existe na tabela `stock_movements` mas não é exibida na tabela. Para auditoria e rastreabilidade em um ERP, saber quem fez cada movimentação é essencial.
+- **Correção sugerida**: Adicionar join com `profiles(name)` na query `listMovements` e exibir o nome do usuário na tabela.
+
+**[UI-04] 🟡 GAP — `ProductForm` não permite editar o status `is_active` do produto**
+
+- **Arquivo**: `src/modules/inventory/components/product-form.tsx`
+- **Detalhe**: O form de edição não renderiza nenhum input para `isActive`. O usuário não consegue desativar um produto pelo form de edição — só pelo botão de delete (soft-delete). Embora o design atual seja intencional, não está documentado e pode causar confusão.
+- **Correção sugerida**: Documentar o design intencional ou adicionar um campo `isActive` explícito no form de edição para tornar o comportamento transparente.
+
+### Verificações OK
+
+- ✅ `MovementForm` e `ProductForm` usam `useActionState` (API correta do React 19 / Next.js 15).
+- ✅ `MovementForm` reseta o form após sucesso via `formKey` + `useState`.
+- ✅ Feedback visual com `toast.success/error` no `MovementForm` e `ProductForm`.
+- ✅ `aria-invalid` nos inputs com erro para acessibilidade.
+- ✅ `ProductTable`: badge de estoque baixo quando `stock <= min_stock`.
+- ✅ `MovementTable`: tipos de movimento com badges coloridos (entrada/saída/ajuste).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/reports/stock-review-report.md
+git commit -m "docs(review): achados da camada UI components
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 8: Auditar Camada 7 — Testes Existentes
+
+**Files:**
+
+- Read: `src/modules/inventory/actions/__tests__/inventory-actions.test.ts`
+- Modify: `docs/superpowers/reports/stock-review-report.md`
+
+- [ ] **Step 1: Ler o arquivo de testes e verificar cobertura**
+
+```bash
+cat src/modules/inventory/actions/__tests__/inventory-actions.test.ts
+```
+
+Também executar os testes para confirmar que passam:
+
+```bash
+npx vitest run src/modules/inventory/actions/__tests__/inventory-actions.test.ts
+```
+
+Saída esperada: todos os testes passam (12 testes em 4 suites).
+
+- [ ] **Step 2: Preencher a seção "Camada 7" do relatório**
+
+Substituir `_(a preencher na Task 8)_` por:
+
+```markdown
+### Cobertura Atual
+
+| Suite                                            | Testes | Cobertura                                                |
+| ------------------------------------------------ | ------ | -------------------------------------------------------- |
+| `createProductAction — isolamento por empresa`   | 4      | Permissão negada, empresa nula, empresa B≠A, Zod invalid |
+| `updateProductAction — controle de permissão`    | 2      | Permissão negada, permissão correta                      |
+| `deleteProductAction — controle de permissão`    | 2      | Permissão negada, permissão correta                      |
+| `registerMovementAction — controle de permissão` | 3      | Permissão negada, permissão correta, empresa nula        |
+| `reactivateProductAction`                        | **0**  | **Sem cobertura**                                        |
+
+### Achados
+
+**[TST-01] 🟢 TEST — `reactivateProductAction` sem nenhum teste (listado também em ACT-06)**
+
+- **Arquivo**: `src/modules/inventory/actions/__tests__/inventory-actions.test.ts`
+- **Detalhe**: Única action completamente fora da suite.
+- **Correção sugerida**: Ver ACT-06.
+
+**[TST-02] 🟢 TEST — Ausência de happy-path tests para todas as actions**
+
+- **Arquivo**: `src/modules/inventory/actions/__tests__/inventory-actions.test.ts`
+- **Detalhe**: Nenhum teste verifica: (a) insert/update/delete é chamado com os dados corretos; (b) `revalidatePath` é chamado após sucesso; (c) a action retorna `{ ok: true }` com a mensagem correta.
+- **Correção sugerida**: Ver ACT-07.
+
+**[TST-03] 🟢 TEST — Caminho de erro do trigger não testado**
+
+- **Arquivo**: `src/modules/inventory/actions/__tests__/inventory-actions.test.ts`
+- **Detalhe**: Não há teste que simule o insert retornando `{ error: { message: "Estoque insuficiente..." } }` para verificar se a action retorna a mensagem correta de erro ao usuário.
+- **Correção sugerida**: Adicionar caso de teste em `registerMovementAction` com `insertError = { message: "Estoque insuficiente para o produto X" }` e verificar que `result.message` contém o texto esperado.
+
+**[TST-04] 🟢 TEST — `out` com estoque insuficiente (pré-check UX) não testado**
+
+- **Arquivo**: `src/modules/inventory/actions/__tests__/inventory-actions.test.ts`
+- **Detalhe**: `registerMovementAction` com `type: "out"` e `quantity > stockValue` deve retornar `{ ok: false }` antes de chamar insert. Não há teste para esse cenário.
+- **Correção sugerida**: Adicionar caso com `type: "out", quantity: "150"` e `stockValue: 100` e verificar que `result.ok === false` e `insert` não foi chamado.
+
+**[TST-05] 🟢 TEST — Nenhum teste unitário para `stock-service.ts`**
+
+- **Arquivo**: `src/modules/inventory/services/` — sem diretório `__tests__/`
+- **Detalhe**: Ver SVC-01.
+
+### Verificações OK
+
+- ✅ Mocks bem estruturados com `vi.mock` e cleanup via `beforeEach(() => vi.clearAllMocks())`.
+- ✅ `ForbiddenError` mockada corretamente como classe com propriedade `permission`.
+- ✅ `makeSupabaseMock` é extensível e cobre os cenários de permissão testados.
+- ✅ Constantes de UUID (`COMPANY_A`, `COMPANY_B`, `PRODUCT_UUID`) evitam magic strings.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/reports/stock-review-report.md
+git commit -m "docs(review): achados da camada testes existentes
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 9: Consolidar relatório e escrever Próximos Passos
+
+**Files:**
+
+- Modify: `docs/superpowers/reports/stock-review-report.md`
+
+- [ ] **Step 1: Substituir a seção "Sumário dos Achados"**
+
+Substituir `_(a preencher na Task 9)_` (na seção Sumário) por:
+
+```markdown
+| ID     | Eixo | Severidade | Descrição breve                                                                |
+| ------ | ---- | ---------- | ------------------------------------------------------------------------------ |
+| ACT-01 | BUG  | 🔴 Alta    | `reactivateProductAction` usa permissão `delete` em vez de `update`            |
+| ACT-02 | BUG  | 🔴 Alta    | `updateProductAction` reseta `is_active` para `true` ao editar produto inativo |
+| UI-01  | BUG  | 🔴 Alta    | `ReactivateProductButton` ignora resultado da action — sem feedback de erro    |
+| ACT-05 | SEC  | 🔵 Alta    | Detecção de erro do trigger por `string.includes()` frágil — usar `error.code` |
+| ACT-03 | GAP  | 🟡 Média   | `updateProductAction` retorna `ok: true` quando produto não existe (0 rows)    |
+| ACT-04 | GAP  | 🟡 Média   | `deleteProductAction` retorna `ok: true` quando produto não existe (0 rows)    |
+| SCH-01 | GAP  | 🟡 Média   | `movementSchema` bloqueia zeragem de estoque via ajuste (`quantity = 0`)       |
+| QRY-01 | GAP  | 🟡 Média   | `getProduct` mascara todos os erros como `null` — não distingue "not found"    |
+| QRY-02 | GAP  | 🟡 Média   | `listMovements` sem filtros por data, tipo ou responsável                      |
+| UI-02  | GAP  | 🟡 Média   | Saldo no dropdown do `MovementForm` desatualizado após registrar movimentação  |
+| UI-03  | GAP  | 🟡 Média   | `MovementTable` não exibe quem realizou a movimentação (`performed_by`)        |
+| UI-04  | GAP  | 🟡 Média   | `ProductForm` não permite editar `is_active` — comportamento não documentado   |
+| SVC-01 | TEST | 🟢 Baixa   | `validateMovement` e `calculateNewStock` sem cobertura de testes               |
+| SVC-02 | GAP  | 🟢 Baixa   | `calculateNewStock` pode retornar valor negativo sem aviso                     |
+| ACT-06 | TEST | 🟢 Baixa   | `reactivateProductAction` sem nenhum teste                                     |
+| ACT-07 | TEST | 🟢 Baixa   | Ausência de happy-path tests para todas as actions                             |
+| TST-03 | TEST | 🟢 Baixa   | Propagação de erro do trigger não testada                                      |
+| TST-04 | TEST | 🟢 Baixa   | Saída com estoque insuficiente (pré-check) não testada                         |
+| QRY-03 | TEST | 🟢 Baixa   | Nenhum teste para as queries                                                   |
+| DB-01  | TEST | 🟢 Baixa   | Índice GIN de full-text não utilizado pela query (`ilike`)                     |
+| DB-02  | TEST | 🟢 Baixa   | Sem índice em `products.is_active`                                             |
+| DB-03  | GAP  | 🟢 Baixa   | Policy `products_delete` nunca ativada (soft-delete via update)                |
+
+**Total: 3 bugs 🔴 · 8 gaps 🟡 · 11 melhorias 🟢**
+```
+
+- [ ] **Step 2: Substituir a seção "Próximos Passos"**
+
+Substituir `_(a preencher na Task 9)_` (na seção Próximos Passos) por:
+
+```markdown
+Ordenado por impacto e risco. Cada item é uma task atômica independente.
+
+### 🔴 Prioridade 1 — Bugs ativos (corrigir antes de qualquer nova feature)
+
+1. **[ACT-01]** Corrigir permissão em `reactivateProductAction`: trocar `inventory:product:delete` por `inventory:product:update` em `src/modules/inventory/actions/reactivate-product.ts:22`.
+
+2. **[ACT-02]** Corrigir reset silencioso de `is_active` no update: criar `updateProductSchema` sem o campo `isActive`, ou remover `isActive` do payload de update em `update-product.ts:40-47`.
+
+3. **[UI-01]** Corrigir `ReactivateProductButton` para tratar o `ActionResult`: verificar `result.ok` e exibir `toast.error(result.message)` em caso de falha.
+
+4. **[ACT-05]** Substituir string matching frágil em `register-movement.ts:66` por `error.code === "P0001"`.
+
+### 🟡 Prioridade 2 — Gaps funcionais relevantes
+
+5. **[ACT-03]** Verificar `count === 0` em `updateProductAction` e retornar `{ ok: false, message: "Produto não encontrado" }`.
+
+6. **[ACT-04]** Verificar `count === 0` em `deleteProductAction` antes de chamar `redirect()`.
+
+7. **[QRY-01]** Distinguir "not found" de erro de sistema em `getProduct`: checar `error.code === "PGRST116"` antes de retornar `null`.
+
+8. **[SCH-01]** Permitir `quantity = 0` para `adjustment` em `movementSchema` (validação contextual por tipo).
+
+9. **[UI-02]** Resolver saldo desatualizado no `MovementForm` — usar `router.refresh()` client-side após sucesso ou garantir que a Server Component pai re-renderize.
+
+10. **[QRY-02]** Adicionar filtros `movementType`, `startDate`, `endDate`, `performedBy` em `listMovements` e `listMovementsSchema`.
+
+11. **[UI-03]** Exibir nome do responsável em `MovementTable` — adicionar join `profiles(name)` em `listMovements`.
+
+### 🟢 Prioridade 3 — Cobertura de testes e qualidade
+
+12. **[SVC-01/TST-04/TST-03]** Criar `src/modules/inventory/services/__tests__/stock-service.test.ts` com casos unitários para `validateMovement` e `calculateNewStock`.
+
+13. **[ACT-06/ACT-07]** Expandir `inventory-actions.test.ts`: adicionar suite para `reactivateProductAction` e happy-path tests para todas as 5 actions.
+
+14. **[QRY-03]** Criar `src/modules/inventory/queries/__tests__/` com testes mockados para as 3 queries.
+
+15. **[DB-01]** Avaliar adoção de `pg_trgm` + índice GIN trigram em vez do índice GIN full-text (ou remover o índice não utilizado).
+
+16. **[DB-02]** Adicionar `CREATE INDEX idx_products_is_active ON products(is_active) WHERE is_active = false`.
+
+17. **[DB-03/UI-04]** Documentar o design de soft-delete e o comportamento de `is_active` no `ProductForm`.
+```
+
+- [ ] **Step 3: Commit final**
+
+```bash
+git add docs/superpowers/reports/stock-review-report.md
+git commit -m "docs(review): relatório completo de revisão do módulo inventory
+
+22 achados: 3 bugs críticos, 8 gaps funcionais, 11 melhorias de qualidade/testes
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 10: Verificação final
+
+- [ ] **Step 1: Confirmar que o relatório está completo**
+
+```bash
+cat docs/superpowers/reports/stock-review-report.md | grep "a preencher"
+```
+
+Saída esperada: nenhuma linha (todos os placeholders substituídos).
+
+- [ ] **Step 2: Verificar histórico de commits**
+
+```bash
+git --no-pager log --oneline -10
+```
+
+Saída esperada: 9 commits de review (esqueleto + 7 camadas + consolidação).
+
+- [ ] **Step 3: Reportar ao usuário**
+
+O relatório está em `docs/superpowers/reports/stock-review-report.md` com:
+
+- 22 achados documentados
+- 3 bugs 🔴 (reativação com permissão errada, reset silencioso de is_active, botão sem feedback)
+- 8 gaps 🟡 (rows afetados não verificados, zeragem bloqueada, queries sem filtros, etc.)
+- 11 melhorias 🟢 (cobertura de testes, índices, documentação)
+
+Perguntar ao usuário se deseja iniciar um plano de correções (`writing-plans`) para as prioridades 1 e 2.

--- a/docs/superpowers/specs/2026-04-29-stock-review-design.md
+++ b/docs/superpowers/specs/2026-04-29-stock-review-design.md
@@ -1,0 +1,83 @@
+# Revisão Completa das Funções de Estoque — Design
+
+## Problema
+
+O módulo `inventory` cobre gestão de produtos e movimentações de estoque num ERP multi-tenant. Precisa de uma revisão sistemática para identificar bugs, gaps funcionais, falhas de segurança e lacunas de cobertura de testes antes de avançar para novas funcionalidades.
+
+## Abordagem
+
+Revisão sequencial por camada (de baixo para cima), auditando cada camada em 4 eixos. Entregável: relatório de achados priorizados + plano de correções.
+
+---
+
+## Escopo
+
+### Arquivos revisados
+
+| Camada               | Arquivos                                                                                  |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| 1. Migrations/DB     | `supabase/migrations/*_stock*`, `*_movements*`, migrations de produtos e RLS relacionados |
+| 2. Schemas Zod       | `src/modules/inventory/schemas/index.ts`                                                  |
+| 3. Services          | `src/modules/inventory/services/stock-service.ts`                                         |
+| 4. Actions           | `src/modules/inventory/actions/*.ts` (5 actions)                                          |
+| 5. Queries           | `src/modules/inventory/queries/*.ts` (3 queries)                                          |
+| 6. UI Components     | `src/modules/inventory/components/*.tsx`                                                  |
+| 7. Testes existentes | `src/modules/inventory/actions/__tests__/*.test.ts`                                       |
+
+### Fora de escopo
+
+- Aplicar correções (vai para plano de implementação separado)
+- Módulos sem relação direta com estoque (billing, auth flow, etc.)
+- Redesign de arquitetura
+
+---
+
+## 4 Eixos de Auditoria (por camada)
+
+- 🔴 **Bugs** — comportamento incorreto ou inconsistente
+- 🟡 **Gaps funcionais** — funcionalidade ausente ou incompleta
+- 🔵 **Segurança/Multi-tenant** — RLS, permissões, isolamento
+- 🟢 **Cobertura de testes** — o que falta testar
+
+---
+
+## Processo de Execução
+
+1. Para cada camada, auditar todos os arquivos relevantes nos 4 eixos.
+2. Classificar achados por severidade:
+   - 🔴 **Alta** — bug ativo, falha de segurança, ou dado corrompível
+   - 🟡 **Média** — comportamento inesperado, gap funcional relevante
+   - 🟢 **Baixa** — melhoria de qualidade, test coverage, refatoração
+3. Consolidar achados em `docs/superpowers/reports/stock-review-report.md`.
+4. Gerar plano de correções ordenado por prioridade com tasks atômicas.
+5. Nenhuma correção é aplicada durante a revisão.
+
+---
+
+## Candidatos a Achados (identificados durante exploração)
+
+Estes pontos devem ser verificados formalmente na revisão:
+
+1. `reactivateProductAction` usa permissão `inventory:product:delete` em vez de uma permissão dedicada de reativação.
+2. `updateProductAction` e `deleteProductAction` não verificam `count` de rows afetados (0 rows = silencioso).
+3. A migration `20260420000003_stock_movements.sql` não define coluna `company_id`, mas `registerMovementAction` insere esse campo — verificar se outra migration o adiciona.
+4. Zero testes unitários para `validateMovement()` e `calculateNewStock()`.
+5. Ausência de happy-path tests para todas as actions.
+6. `reactivateProductAction` sem nenhum teste.
+7. `movementSchema` bloqueia `quantity = 0` para `adjustment` — pode bloquear zeragem legítima de estoque.
+
+---
+
+## Entregáveis
+
+1. **`docs/superpowers/reports/stock-review-report.md`** — relatório de achados com severidade, localização (arquivo:linha) e correção sugerida para cada item.
+2. **Plano de implementação** (via `writing-plans`) — tasks atômicas de correção ordenadas por prioridade, prontas para execução.
+
+---
+
+## Critérios de Conclusão
+
+- Todos os 7 layers auditados nos 4 eixos
+- Cada achado tem: arquivo, linha (quando aplicável), descrição, severidade, correção sugerida
+- Relatório tem seção "Próximos Passos" ordenada por prioridade
+- Plano de correções tem tasks independentes e atômicas

--- a/src/modules/knowledge-base/actions/upsert-category.ts
+++ b/src/modules/knowledge-base/actions/upsert-category.ts
@@ -1,0 +1,80 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveCompanyId } from "@/modules/tenancy";
+import { requirePermission, ForbiddenError } from "@/modules/authz";
+import type { ActionResult } from "@/lib/errors";
+import { categorySchema } from "../schemas/category";
+import { generateSlug, ensureUniqueSlug } from "../services/slug-service";
+
+export async function upsertCategoryAction(
+  id: string | null,
+  _prev: ActionResult,
+  formData: FormData,
+): Promise<ActionResult> {
+  const parsed = categorySchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  const companyId = await getActiveCompanyId();
+  if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
+
+  try {
+    await requirePermission(companyId, "kb:article:write");
+  } catch (e) {
+    if (e instanceof ForbiddenError)
+      return { ok: false, message: "Acesso negado: permissão insuficiente" };
+    throw e;
+  }
+
+  const supabase = await createClient();
+
+  // Resolve slug: use provided or auto-generate from title
+  let slug = parsed.data.slug ?? "";
+  if (!slug) {
+    const baseSlug = generateSlug(parsed.data.title);
+    const query = supabase.from("kb_categories").select("slug").eq("company_id", companyId);
+    // Exclude current record on updates to allow keeping same slug
+    const { data: existingRows, error: slugFetchError } = id
+      ? await query.neq("id", id)
+      : await query;
+    if (slugFetchError) return { ok: false, message: slugFetchError.message };
+    const existing = (existingRows ?? []).map((r) => r.slug);
+    slug = ensureUniqueSlug(baseSlug, existing);
+  }
+
+  if (id) {
+    // Update
+    const { error } = await supabase
+      .from("kb_categories")
+      .update({
+        title: parsed.data.title,
+        slug,
+        parent_id: parsed.data.parent_id ?? null,
+        audience: parsed.data.audience,
+        position: parsed.data.position,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", id)
+      .eq("company_id", companyId);
+
+    if (error) return { ok: false, message: error.message };
+  } else {
+    // Insert
+    const { error } = await supabase.from("kb_categories").insert({
+      company_id: companyId,
+      title: parsed.data.title,
+      slug,
+      parent_id: parsed.data.parent_id ?? null,
+      audience: parsed.data.audience,
+      position: parsed.data.position,
+    });
+
+    if (error) return { ok: false, message: error.message };
+  }
+
+  revalidatePath("/", "layout");
+  return { ok: true, message: id ? "Categoria atualizada" : "Categoria criada" };
+}

--- a/src/modules/knowledge-base/index.ts
+++ b/src/modules/knowledge-base/index.ts
@@ -5,6 +5,7 @@ export { createArticleAction } from "./actions/create-article";
 export { updateArticleAction } from "./actions/update-article";
 export { deleteArticleAction } from "./actions/delete-article";
 export { publishArticleAction } from "./actions/publish-article";
+export { upsertCategoryAction } from "./actions/upsert-category";
 
 // Queries
 export { listArticles } from "./queries/list-articles";

--- a/src/modules/knowledge-base/schemas/category.ts
+++ b/src/modules/knowledge-base/schemas/category.ts
@@ -4,9 +4,9 @@ export const categorySchema = z.object({
   title: z.string().min(2, "Mínimo 2 caracteres").max(100, "Máximo 100 caracteres"),
   slug: z
     .string()
-    .min(1, "Slug obrigatório")
     .max(80, "Máximo 80 caracteres")
-    .regex(/^[a-z0-9-]+$/, "Slug deve conter apenas letras minúsculas, números e hífens"),
+    .regex(/^[a-z0-9-]*$/, "Slug deve conter apenas letras minúsculas, números e hífens")
+    .optional(),
   parent_id: z.string().uuid("Categoria pai inválida").optional(),
   audience: z.enum(["user", "dev", "both"]).default("user"),
   position: z.number().default(0),


### PR DESCRIPTION
## Summary

Arquivos do F1 que ficaram sem commit na `main` após a branch `feat/knowledge-base-f1` ser concluída.

- `upsert-category.ts`: action `upsertCategoryAction` — cria ou atualiza categoria com slug auto-gerado a partir do título
- `schemas/category.ts`: campo `slug` agora opcional (gerado automaticamente se omitido, com regex permissiva `[a-z0-9-]*`)
- `index.ts`: exporta `upsertCategoryAction` no barrel público
- `docs/KNOWLEDGE-BASE-ARCHITECTURE.md`: histórico atualizado com status de F2 (PR #23) e F3 (PR #24)

## Relacionado

- Histórico completo: issue #26
- F2: PR #23
- F3: PR #24

## Test Plan

- [ ] `npm run typecheck` limpo
- [ ] `npm run lint` limpo
- [ ] Admin consegue criar categoria sem informar slug (gerado do título)
- [ ] Admin consegue criar categoria com slug explícito

🤖 Generated with [Claude Code](https://claude.com/claude-code)