### PR TITLE
fix: skill audit adjustments — RLS, forms, KB actions, queries

### DIFF
--- a/.claude/skills/erp-infra-modules/SKILL.md
+++ b/.claude/skills/erp-infra-modules/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: erp-infra-modules
+description: Use when creating or modifying the auth, authz, audit, or tenancy modules — adding queries, actions, services, components, or hooks to any of these infrastructure modules.
+---
+
+# ERP Infrastructure Modules
+
+## Overview
+
+Infrastructure modules (`auth`, `authz`, `audit`, `tenancy`) are framework-level — they own the cross-cutting concerns that feature modules depend on. They are **exempt** from the full structure checklist in `erp-module-conventions`, but each has its own rules.
+
+## Global Rules — all 4 modules
+
+**Always applies:**
+
+- `index.ts` barrel is mandatory — ESLint blocks deep imports
+- `import "server-only"` at the top of every query file
+- Types derived from `Database["public"]["Tables"]["x"]["Row"]` — no hand-written interfaces duplicating DB columns
+- `services/` files are pure — no Supabase client, no `next/headers`, no `getActiveCompanyId()`
+
+**Does NOT apply to infra modules:**
+
+- Full folder structure (missing `services/`, `types/`, `schemas/` is fine)
+- `requirePermission()` in actions — infra modules manage their own authorization
+- Migration checklist from `erp-module-conventions` (`company_modules`, `role_permissions`)
+- Mandatory `revalidatePath` — not always applicable
+
+---
+
+## `auth` — Identidade
+
+**Purpose:** Who is the user? Login, logout, signup, OAuth, password reset.
+
+**Structure:**
+
+```
+auth/
+├── actions/     ← Server Actions for auth flows
+├── components/  ← Forms (SignInForm, SignUpForm, etc.)
+├── queries/     ← getCurrentUser, listResetRequests
+├── schemas/     ← Zod schemas for auth inputs
+├── client.ts    ← Client-side context if needed
+└── index.ts
+```
+
+**Rules:**
+
+- Actions do **NOT** call `requirePermission` — they ARE the authentication layer
+- Actions call Supabase Auth directly (`supabase.auth.signInWithPassword`, etc.)
+- `getCurrentUser()` is the only source of truth for the current user in Server Components — it returns user + company memberships
+- No `services/` — auth logic lives directly in actions and queries
+
+**How to extend:**
+
+- New auth flow → new file in `actions/` + schema in `schemas/` + component in `components/`
+- New user data query → new file in `queries/` with `import "server-only"`
+- Export everything through `index.ts`
+
+---
+
+## `authz` — Autorização
+
+**Purpose:** Can this user do this? Permission checks for Server Actions and UI gating.
+
+**Structure:**
+
+```
+authz/
+├── services/    ← Pure permission logic (requirePermission, hasPermission)
+├── components/  ← <Can> and PermissionsProvider
+├── hooks/       ← usePermissions (client-side)
+├── client.ts    ← Client-side permission context
+└── index.ts
+```
+
+**Rules:**
+
+- `services/` may use Supabase — permission lookups require DB queries (`memberships`, `roles`, `role_permissions`)
+- `services/` does NOT use `next/headers`, cookies, or `getActiveCompanyId()` — the user is resolved via `supabase.auth.getUser()` internally
+- `requirePermission(companyId, permissionCode)` throws `ForbiddenError` if denied
+- `hasPermission(companyId, permissionCode)` returns boolean for UI branching
+- Platform admins receive `Set(["*"])` in TypeScript — this bypasses TS checks but **not** Postgres RLS
+
+**How to extend:**
+
+- New permission utility → add to `services/authz-service.ts`
+- New UI gate → add component to `components/` wrapping `usePermissions`
+- Do NOT add cookie/header access to services — keep identity resolution via Supabase Auth only
+
+---
+
+## `audit` — Rastreabilidade
+
+**Purpose:** What was done, by whom, when? Immutable log of actions across the system.
+
+**Structure:**
+
+```
+audit/
+├── services/    ← audit() — called by other modules' actions
+├── queries/     ← listAuditLogs, listAuditLogsGlobal
+├── components/  ← AuditLogTable
+└── index.ts
+```
+
+**Rules:**
+
+- `audit()` is called **from other modules' actions** — never from components or pages directly
+- `audit()` is fire-and-forget — it logs errors to console but never throws, never fails the calling action
+- No actions of its own — `audit` does not expose Server Actions
+
+**Correct usage from another module's action:**
+
+```ts
+// ✅ After a successful DB write, at the end of the action:
+await audit({
+  companyId,
+  action: "product:created",
+  resourceType: "product",
+  resourceId: product.id,
+  status: "success",
+});
+// audit() swallows errors internally — action proceeds regardless
+```
+
+**How to extend:**
+
+- New event type → add the string literal to the `action` field in the call — no schema change needed
+- New audit query (e.g., filter by event type) → new file in `queries/` with `import "server-only"`
+- Never add components that call `audit()` directly
+
+---
+
+## `tenancy` — Multi-tenancy
+
+**Purpose:** Company membership, roles, permissions, module toggles, invitations.
+
+**Structure:**
+
+```
+tenancy/
+├── actions/     ← Company, member, role, invitation, module management
+├── queries/     ← resolveCompany, listMyCompanies, getActiveCompanySlug, etc.
+├── services/    ← getActiveCompanyId (reads active company from cookies)
+├── components/  ← CompanySwitcher, forms, tables
+├── schemas/     ← Zod schemas for all tenancy inputs
+├── client.ts    ← Client-side company context
+├── constants.ts ← Shared constants (e.g., cookie names)
+└── index.ts
+```
+
+**Rules:**
+
+- `getActiveCompanyId()` lives in `services/active-company.ts` — reads the active company from cookies. It is the canonical way to get `companyId` in Server Actions.
+- `resolveCompany(companySlug)` lives in `queries/` — used in page Server Components to resolve slug → company row + membership check.
+- Admin-only actions (e.g., `createModuleAction`, `bulkToggleModuleForCompaniesAction`) must check `is_platform_admin` or `requirePermission` with a tenancy-specific permission code.
+- `switchActiveCompanyAction` writes a cookie — it does not need `revalidatePath` (the redirect handles navigation).
+
+**How to extend:**
+
+- New company setting → `updateCompanySettingsAction` + schema field + migration
+- New role capability → new file in `actions/` + export from `index.ts`
+- New query → `queries/` with `import "server-only"` + export from `index.ts`
+
+---
+
+## Red Flags
+
+| Thought                                                        | Reality                                                                                                             |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| "I'll add `requirePermission` to this `auth` action"           | `auth` actions are the authentication layer — no permission checks here                                             |
+| "I'll call `audit()` from a component"                         | `audit()` goes in Server Actions only, after successful DB writes                                                   |
+| "I'll add cookie/header access to `authz/services/`"           | `authz` services resolve identity via `supabase.auth.getUser()` only — no `next/headers`, no `getActiveCompanyId()` |
+| "I'll skip the barrel since `tenancy/index.ts` is already big" | Barrel is mandatory — ESLint blocks deep imports regardless of size                                                 |
+| "I need a new infra module"                                    | Stop and discuss — creating a new infrastructure module is a significant architectural decision                     |

--- a/.claude/skills/erp-module-conventions/SKILL.md
+++ b/.claude/skills/erp-module-conventions/SKILL.md
@@ -9,6 +9,12 @@ description: Use when creating or modifying modules in the triade-devs/erp proje
 
 Every module lives in `src/modules/<domain>/` and MUST follow this structure and checklist without exception.
 
+## Infrastructure vs. Feature Modules
+
+**Feature modules** (inventory, knowledge-base, anestesia, …) must follow the full structure below.
+
+**Infrastructure modules** (`auth`, `authz`, `audit`, `tenancy`) are framework-level — they may omit folders that don't apply (e.g., `auth` has no `services/`, `authz` exposes only hooks and components). Do NOT enforce full structure on them.
+
 ## Required Structure
 
 ```

--- a/docs/superpowers/specs/2026-05-19-erp-infra-modules-skill-design.md
+++ b/docs/superpowers/specs/2026-05-19-erp-infra-modules-skill-design.md
@@ -1,0 +1,193 @@
+# Design: erp-infra-modules Skill
+
+**Date:** 2026-05-19  
+**Status:** Approved  
+**Scope:** Create `.claude/skills/erp-infra-modules/SKILL.md`
+
+---
+
+## Problem
+
+The `erp-module-conventions` skill covers feature modules (inventory, knowledge-base, etc.) with a full structure checklist. Infrastructure modules (`auth`, `authz`, `audit`, `tenancy`) are exempt from that checklist but have no documented patterns of their own. This creates two risks:
+
+1. **Wrong rules applied** — someone extends `auth` and adds `requirePermission` because that's what conventions say; or adds a full migration with `role_permissions` to a module that doesn't need one.
+2. **No guidance on how to extend** — someone adding a new query to `tenancy` or a new event type to `audit` has no reference for the correct pattern.
+
+---
+
+## Approach
+
+Single skill file `erp-infra-modules/SKILL.md` with:
+
+- **Auto-invoke trigger** covering all 4 modules
+- **Global section** — what applies to all infra modules and what doesn't
+- **Per-module sections** — structure, rules, and how-to-extend for each module
+
+---
+
+## Skill Structure
+
+### Trigger (description field)
+
+```
+Use when creating or modifying the auth, authz, audit, or tenancy modules —
+adding queries, actions, services, components, or hooks to any of these
+infrastructure modules.
+```
+
+### Section 1: Global Rules
+
+**Applies to all infra modules:**
+
+- Barrel (`index.ts`) is mandatory — deep imports are blocked by ESLint
+- `import "server-only"` at top of every query file
+- Types derived from `Database` (not hand-written interfaces)
+- No Supabase client in `services/` files — pure logic only
+
+**Does NOT apply to infra modules:**
+
+- Full folder structure (missing `services/`, `types/`, `schemas/` is fine)
+- `requirePermission()` in actions — infra modules manage auth/tenancy themselves
+- Migration checklist from `erp-module-conventions` (company_modules, role_permissions)
+- `revalidatePath` requirement — not always relevant
+
+### Section 2: `auth`
+
+**Purpose:** Identity — who is the user? Login, logout, signup, OAuth, password reset.
+
+**Structure allowed:**
+
+```
+auth/
+├── actions/     ← Server Actions for auth flows
+├── components/  ← Forms (SignInForm, SignUpForm, etc.)
+├── queries/     ← getCurrentUser, listResetRequests
+├── schemas/     ← Zod schemas for auth inputs
+├── client.ts    ← Client-side context/hooks if needed
+└── index.ts
+```
+
+**Key rules:**
+
+- Actions do NOT call `requirePermission` — they ARE the authentication layer
+- Actions call Supabase Auth directly (`supabase.auth.signInWithPassword`, etc.)
+- `getCurrentUser()` returns the user + their company memberships — it is the only source of truth for the current user in Server Components
+- No `services/` folder — auth logic lives directly in actions and queries
+
+**How to extend:**
+
+- New auth flow → new file in `actions/` + schema in `schemas/` + component in `components/`
+- New user data query → new file in `queries/` with `import "server-only"` at top
+- Export everything through `index.ts`
+
+### Section 3: `authz`
+
+**Purpose:** Authorization — can this user do this action? Permission checks for Server Actions and UI.
+
+**Structure allowed:**
+
+```
+authz/
+├── services/    ← Pure permission logic (requirePermission, hasPermission)
+├── components/  ← <Can> provider and gate component
+├── hooks/       ← usePermissions (client-side)
+├── client.ts    ← Client-side permission context
+└── index.ts
+```
+
+**Key rules:**
+
+- `services/` is pure — NO Supabase client, NO `next/headers`, NO cookies
+- Permission data flows in as a parameter or comes from the session object passed in
+- `requirePermission(companyId, permissionCode)` — throws `ForbiddenError` if denied
+- `hasPermission(companyId, permissionCode)` — returns boolean for UI branching
+- Platform admins receive `Set(["*"])` — this bypasses TS checks but NOT Postgres RLS
+
+**How to extend:**
+
+- New permission utility → add to `services/authz-service.ts` as a pure function
+- New UI gate → add component to `components/` wrapping `usePermissions`
+- Do NOT add Supabase calls here — permission data is fetched elsewhere and passed in
+
+### Section 4: `audit`
+
+**Purpose:** Traceability — what was done, by whom, when?
+
+**Structure allowed:**
+
+```
+audit/
+├── services/    ← audit() function — called by other modules' actions
+├── queries/     ← listAuditLogs, listAuditLogsGlobal
+├── components/  ← AuditLogTable
+└── index.ts
+```
+
+**Key rules:**
+
+- `audit()` is called FROM other modules' actions — NEVER from components or pages directly
+- `audit()` is fire-and-forget — errors inside it must NOT propagate to the calling action
+- No actions of its own — audit does not expose Server Actions
+
+**How to extend:**
+
+- New event type → add the string literal to the audit event type union in `services/audit-service.ts`
+- New audit query (e.g., filter by event type) → new file in `queries/` with `import "server-only"`
+- Never add components that call `audit()` directly
+
+**Correct usage from another module's action:**
+
+```ts
+// ✅ Inside an action after a successful DB write:
+await audit({ companyId, userId, event: "product:created", resourceId: product.id });
+// audit errors are swallowed internally — action proceeds regardless
+```
+
+### Section 5: `tenancy`
+
+**Purpose:** Multi-tenancy — company membership, roles, permissions, module toggles, invitations.
+
+**Structure allowed:**
+
+```
+tenancy/
+├── actions/     ← Company, member, role, invitation, module management
+├── queries/     ← resolveCompany, listMyCompanies, getActiveCompanySlug, etc.
+├── services/    ← getActiveCompanyId (reads active company from cookies)
+├── components/  ← CompanySwitcher, forms, tables
+├── schemas/     ← Zod schemas for all tenancy inputs
+├── client.ts    ← Client-side company context
+├── constants.ts ← Shared constants (e.g., cookie names)
+└── index.ts
+```
+
+**Key rules:**
+
+- `getActiveCompanyId()` lives in `services/active-company.ts` — it reads the active company from cookies. It is the canonical way to get `companyId` in Server Actions.
+- `resolveCompany(companySlug)` lives in `queries/` — used in page Server Components to resolve slug → company row + membership check.
+- Admin-only actions (e.g., `createModuleAction`, `bulkToggleModuleForCompaniesAction`) check `is_platform_admin` or `requirePermission` with a tenancy-specific permission. Do not skip this check.
+- `switchActiveCompanyAction` writes a cookie — it does NOT need `revalidatePath` (the redirect handles it).
+
+**How to extend:**
+
+- New company setting → add field to `updateCompanySettingsAction` + schema + migration
+- New role capability → new action in `actions/` + add to barrel
+- New query → `queries/` with `import "server-only"` + export from `index.ts`
+
+---
+
+## Red Flags
+
+| Thought                                                    | Reality                                                                                |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| "I'll add `requirePermission` to this `auth` action"       | `auth` actions are the auth layer — no permission checks here                          |
+| "I'll call `audit()` from a component"                     | `audit()` goes in Server Actions only, after DB writes                                 |
+| "I'll add Supabase to `authz/services/`"                   | `authz` services are pure — pass data in, don't fetch it                               |
+| "I'll skip the barrel in `tenancy` since it's already big" | Barrel is mandatory — ESLint blocks deep imports                                       |
+| "I need a new infra module"                                | Stop and discuss — creating a new infra module is a significant architectural decision |
+
+---
+
+## Files Changed
+
+- `.claude/skills/erp-infra-modules/SKILL.md` ← new file

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { listProducts } from "@/modules/inventory";
+import { getInventoryStats } from "@/modules/inventory";
 import { getActiveCompanyId, getActiveCompanySlug } from "@/modules/tenancy";
 import { formatCurrency } from "@/lib/utils";
 
@@ -13,16 +13,8 @@ export default async function DashboardPage() {
     getActiveCompanySlug(),
   ]);
 
-  const { data: allProducts, total } = await listProducts(companyId ?? "", {
-    onlyActive: true,
-    pageSize: 9999,
-  });
-
-  const lowStockProducts = allProducts.filter((p) => Number(p.stock) <= Number(p.min_stock));
-  const lowStockCount = lowStockProducts.length;
-  const totalStockValue = allProducts.reduce(
-    (sum, p) => sum + Number(p.stock) * Number(p.cost_price),
-    0,
+  const { totalActive, lowStockCount, totalStockValue, lowStockProducts } = await getInventoryStats(
+    companyId ?? "",
   );
 
   const inventoryHref = companySlug ? `/${companySlug}/inventory` : "/";
@@ -36,7 +28,7 @@ export default async function DashboardPage() {
       </div>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <MetricCard label="Produtos ativos" value={String(total)} />
+        <MetricCard label="Produtos ativos" value={String(totalActive)} />
         <MetricCard label="Estoque baixo" value={String(lowStockCount)} alert={lowStockCount > 0} />
         <MetricCard label="Valor em estoque" value={formatCurrency(totalStockValue)} />
       </div>

--- a/src/modules/audit/queries/list-audit-logs-global.ts
+++ b/src/modules/audit/queries/list-audit-logs-global.ts
@@ -25,6 +25,6 @@ export async function listAuditLogsGlobal(filters: GlobalAuditFilters = {}): Pro
   if (filters.status) query = query.eq("status", filters.status);
 
   const { data, error } = await query;
-  if (error) throw error;
+  if (error) throw new Error(error.message);
   return data ?? [];
 }

--- a/src/modules/audit/queries/list-audit-logs.ts
+++ b/src/modules/audit/queries/list-audit-logs.ts
@@ -13,6 +13,6 @@ export async function listAuditLogs(companyId: string): Promise<AuditLog[]> {
     .order("created_at", { ascending: false })
     .limit(200);
 
-  if (error) throw error;
+  if (error) throw new Error(error.message);
   return data ?? [];
 }

--- a/src/modules/inventory/components/movement-form.tsx
+++ b/src/modules/inventory/components/movement-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { useActionState, useEffect, useRef, useState } from "react";
 import { useFormStatus } from "react-dom";
-import { useActionState, useEffect, useState } from "react";
 import { Check, ChevronsUpDown } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -36,21 +36,37 @@ export function MovementForm({ products }: { products: ProductOption[] }) {
   const [formKey, setFormKey] = useState(0);
   const [open, setOpen] = useState(false);
   const [selectedId, setSelectedId] = useState<string>("");
+  const formRef = useRef<HTMLFormElement>(null);
+  const hasMountedRef = useRef(false);
   const fieldErrors = state.ok ? undefined : state.fieldErrors;
 
   const selected = products.find((p) => p.id === selectedId);
 
   useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
     if (state.ok) {
+      formRef.current?.reset();
       toast.success(state.message ?? "Movimentação registrada");
       setFormKey((k) => k + 1);
       setSelectedId("");
+      setOpen(false);
+      return;
     }
-    if (!state.ok && state.message) toast.error(state.message);
+
+    if (state.message) toast.error(state.message);
   }, [state]);
 
   return (
-    <form key={formKey} action={formAction} className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <form
+      key={formKey}
+      ref={formRef}
+      action={formAction}
+      className="grid grid-cols-1 gap-4 md:grid-cols-2"
+    >
       {/* Produto */}
       <div className="space-y-2 md:col-span-2">
         <Label>

--- a/src/modules/inventory/components/product-form.tsx
+++ b/src/modules/inventory/components/product-form.tsx
@@ -42,7 +42,9 @@ export function ProductForm({ product, updateAction }: Props) {
     }
 
     if (state.ok) {
-      formRef.current?.reset();
+      if (!product) {
+        formRef.current?.reset();
+      }
       toast.success(state.message ?? "Salvo com sucesso.");
       return;
     }

--- a/src/modules/inventory/components/product-form.tsx
+++ b/src/modules/inventory/components/product-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { useActionState, useEffect, useRef } from "react";
 import { useFormStatus } from "react-dom";
-import { useActionState, useEffect } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -31,15 +31,27 @@ type Props = {
 export function ProductForm({ product, updateAction }: Props) {
   const action = updateAction ?? createProductAction;
   const [state, formAction] = useActionState(action, initial);
+  const formRef = useRef<HTMLFormElement>(null);
+  const hasMountedRef = useRef(false);
   const fieldErrors = state.ok ? undefined : state.fieldErrors;
 
   useEffect(() => {
-    if (state.ok) toast.success(state.message ?? "Salvo com sucesso");
-    if (!state.ok && state.message) toast.error(state.message);
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
+    if (state.ok) {
+      formRef.current?.reset();
+      toast.success(state.message ?? "Salvo com sucesso.");
+      return;
+    }
+
+    if (state.message) toast.error(state.message);
   }, [state]);
 
   return (
-    <form action={formAction} className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <form ref={formRef} action={formAction} className="grid grid-cols-1 gap-4 md:grid-cols-2">
       <Field
         label="SKU"
         name="sku"

--- a/src/modules/inventory/index.ts
+++ b/src/modules/inventory/index.ts
@@ -8,6 +8,8 @@ export { registerMovementAction } from "./actions/register-movement";
 export { listProducts } from "./queries/list-products";
 export { getProduct } from "./queries/get-product";
 export { listMovements } from "./queries/list-movements";
+export { getInventoryStats } from "./queries/get-inventory-stats";
+export type { InventoryStats } from "./queries/get-inventory-stats";
 
 export { ProductTable } from "./components/product-table";
 export { ProductForm } from "./components/product-form";

--- a/src/modules/inventory/queries/get-inventory-stats.ts
+++ b/src/modules/inventory/queries/get-inventory-stats.ts
@@ -1,0 +1,36 @@
+import "server-only";
+import { createClient } from "@/lib/supabase/server";
+import type { Product } from "../types";
+
+export type InventoryStats = {
+  totalActive: number;
+  lowStockCount: number;
+  totalStockValue: number;
+  lowStockProducts: Pick<Product, "id" | "name" | "sku" | "stock" | "min_stock" | "unit">[];
+};
+
+export async function getInventoryStats(companyId: string): Promise<InventoryStats> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("products")
+    .select("id, name, sku, stock, min_stock, unit, cost_price")
+    .eq("company_id", companyId)
+    .eq("is_active", true);
+
+  if (error) throw new Error(error.message);
+
+  const products = data ?? [];
+  const lowStockProducts = products.filter((p) => Number(p.stock) <= Number(p.min_stock));
+  const totalStockValue = products.reduce(
+    (sum, p) => sum + Number(p.stock) * Number(p.cost_price),
+    0,
+  );
+
+  return {
+    totalActive: products.length,
+    lowStockCount: lowStockProducts.length,
+    totalStockValue,
+    lowStockProducts: lowStockProducts.slice(0, 5),
+  };
+}

--- a/src/modules/inventory/queries/list-products.ts
+++ b/src/modules/inventory/queries/list-products.ts
@@ -23,7 +23,7 @@ export async function listProducts(
   if (q) query = query.or(`name.ilike.%${q}%,sku.ilike.%${q}%`);
 
   const { data, count, error } = await query;
-  if (error) throw error;
+  if (error) throw new Error(error.message);
 
   const total = count ?? 0;
   return {

--- a/src/modules/inventory/schemas/index.ts
+++ b/src/modules/inventory/schemas/index.ts
@@ -31,7 +31,7 @@ export const movementSchema = z.object({
 export const listProductsSchema = z.object({
   q: z.string().optional(),
   page: z.coerce.number().int().min(1).default(1),
-  pageSize: z.coerce.number().int().min(1).max(9999).default(20),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
   onlyActive: z.coerce.boolean().default(true),
   sortBy: z.enum(["name", "sku", "stock", "cost_price", "sale_price"]).default("name"),
   sortDir: z.enum(["asc", "desc"]).default("asc"),

--- a/src/modules/knowledge-base/actions/create-article.ts
+++ b/src/modules/knowledge-base/actions/create-article.ts
@@ -8,17 +8,37 @@ import type { ActionResult } from "@/lib/errors";
 import type { Json } from "@/types/database.types";
 import { createArticleSchema } from "../schemas/article";
 import { generateSlug, ensureUniqueSlug } from "../services/slug-service";
+import type { KbArticleContent, KbArticleInsert } from "../types";
+
+function isJsonValue(value: unknown): value is Json {
+  if (value === null) return true;
+  if (["string", "number", "boolean"].includes(typeof value)) return true;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).every(isJsonValue);
+  }
+  return false;
+}
+
+function isKbArticleContent(value: unknown): value is KbArticleContent {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value as Record<string, unknown>).every(isJsonValue);
+}
 
 export async function createArticleAction(
   _prev: ActionResult,
   formData: FormData,
 ): Promise<ActionResult> {
-  const rawData = Object.fromEntries(formData);
+  const rawData: Record<string, unknown> = Object.fromEntries(formData);
 
   // Parse content_json from JSON string before schema validation
   if (typeof rawData.content_json === "string") {
     try {
-      rawData.content_json = JSON.parse(rawData.content_json) as unknown as string;
+      const content = JSON.parse(rawData.content_json);
+      if (!isKbArticleContent(content)) {
+        return { ok: false, fieldErrors: { content_json: ["JSON de conteúdo inválido"] } };
+      }
+      rawData.content_json = content;
     } catch {
       return { ok: false, fieldErrors: { content_json: ["JSON de conteúdo inválido"] } };
     }
@@ -28,6 +48,12 @@ export async function createArticleAction(
   if (!parsed.success) {
     return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
   }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
 
   const companyId = await getActiveCompanyId();
   if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
@@ -39,12 +65,6 @@ export async function createArticleAction(
       return { ok: false, message: "Acesso negado: permissão insuficiente" };
     throw e;
   }
-
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return { ok: false, message: "Não autenticado" };
 
   // Generate unique slug
   const baseSlug = generateSlug(parsed.data.title);
@@ -58,12 +78,12 @@ export async function createArticleAction(
   const existingSlugs = (existingRows ?? []).map((r) => r.slug);
   const slug = ensureUniqueSlug(baseSlug, existingSlugs);
 
-  const { error } = await supabase.from("kb_articles").insert({
+  const payload: KbArticleInsert = {
     company_id: companyId,
     title: parsed.data.title,
     slug,
     summary: parsed.data.summary ?? null,
-    content_json: parsed.data.content_json as Json,
+    content_json: parsed.data.content_json,
     content_md: parsed.data.content_md,
     category_id: parsed.data.category_id ?? null,
     audience: parsed.data.audience,
@@ -72,7 +92,9 @@ export async function createArticleAction(
     status: "draft",
     created_by: user.id,
     updated_by: user.id,
-  });
+  };
+
+  const { error } = await supabase.from("kb_articles").insert(payload);
 
   if (error) return { ok: false, message: error.message };
 

--- a/src/modules/knowledge-base/actions/delete-article.ts
+++ b/src/modules/knowledge-base/actions/delete-article.ts
@@ -15,6 +15,12 @@ export async function deleteArticleAction(
     return { ok: false, message: "ID do artigo obrigatório" };
   }
 
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
+
   const companyId = await getActiveCompanyId();
   if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
 
@@ -25,12 +31,6 @@ export async function deleteArticleAction(
       return { ok: false, message: "Acesso negado: permissão insuficiente" };
     throw e;
   }
-
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return { ok: false, message: "Não autenticado" };
 
   const { data, error } = await supabase
     .from("kb_articles")

--- a/src/modules/knowledge-base/actions/publish-article.ts
+++ b/src/modules/knowledge-base/actions/publish-article.ts
@@ -20,6 +20,12 @@ export async function publishArticleAction(
     return { ok: false, message: "Ação inválida. Use 'publish' ou 'unpublish'" };
   }
 
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
+
   const companyId = await getActiveCompanyId();
   if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
 
@@ -30,12 +36,6 @@ export async function publishArticleAction(
       return { ok: false, message: "Acesso negado: permissão insuficiente" };
     throw e;
   }
-
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return { ok: false, message: "Não autenticado" };
 
   const updatePayload =
     action === "publish"

--- a/src/modules/knowledge-base/actions/update-article.ts
+++ b/src/modules/knowledge-base/actions/update-article.ts
@@ -7,6 +7,22 @@ import { requirePermission, ForbiddenError } from "@/modules/authz";
 import type { ActionResult } from "@/lib/errors";
 import type { Json } from "@/types/database.types";
 import { updateArticleSchema } from "../schemas/article";
+import type { KbArticleContent, KbArticleUpdate } from "../types";
+
+function isJsonValue(value: unknown): value is Json {
+  if (value === null) return true;
+  if (["string", "number", "boolean"].includes(typeof value)) return true;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).every(isJsonValue);
+  }
+  return false;
+}
+
+function isKbArticleContent(value: unknown): value is KbArticleContent {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value as Record<string, unknown>).every(isJsonValue);
+}
 
 export async function updateArticleAction(
   _prev: ActionResult,
@@ -17,13 +33,17 @@ export async function updateArticleAction(
     return { ok: false, message: "ID do artigo obrigatório" };
   }
 
-  const rawData = Object.fromEntries(formData);
+  const rawData: Record<string, unknown> = Object.fromEntries(formData);
   delete rawData["id"];
 
   // Parse content_json from JSON string before schema validation
   if (typeof rawData.content_json === "string") {
     try {
-      rawData.content_json = JSON.parse(rawData.content_json) as unknown as string;
+      const content = JSON.parse(rawData.content_json);
+      if (!isKbArticleContent(content)) {
+        return { ok: false, fieldErrors: { content_json: ["JSON de conteúdo inválido"] } };
+      }
+      rawData.content_json = content;
     } catch {
       return { ok: false, fieldErrors: { content_json: ["JSON de conteúdo inválido"] } };
     }
@@ -33,6 +53,12 @@ export async function updateArticleAction(
   if (!parsed.success) {
     return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
   }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: "Não autenticado" };
 
   const companyId = await getActiveCompanyId();
   if (!companyId) return { ok: false, message: "Nenhuma empresa ativa" };
@@ -45,22 +71,27 @@ export async function updateArticleAction(
     throw e;
   }
 
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return { ok: false, message: "Não autenticado" };
+  const payload: KbArticleUpdate = {
+    updated_by: user.id,
+    updated_at: new Date().toISOString(),
+  };
 
-  const { content_json, ...rest } = parsed.data;
+  if (parsed.data.title !== undefined) payload.title = parsed.data.title;
+  if (parsed.data.summary !== undefined) payload.summary = parsed.data.summary ?? null;
+  if (parsed.data.content_json !== undefined) payload.content_json = parsed.data.content_json;
+  if (parsed.data.content_md !== undefined) payload.content_md = parsed.data.content_md;
+  if (parsed.data.category_id !== undefined) payload.category_id = parsed.data.category_id ?? null;
+  if (parsed.data.audience !== undefined) payload.audience = parsed.data.audience;
+  if (parsed.data.related_module !== undefined) {
+    payload.related_module = parsed.data.related_module ?? null;
+  }
+  if (parsed.data.related_table !== undefined) {
+    payload.related_table = parsed.data.related_table ?? null;
+  }
 
   const { data, error } = await supabase
     .from("kb_articles")
-    .update({
-      ...rest,
-      ...(content_json !== undefined ? { content_json: content_json as Json } : {}),
-      updated_by: user.id,
-      updated_at: new Date().toISOString(),
-    })
+    .update(payload)
     .eq("id", id)
     .eq("company_id", companyId)
     .select("id")

--- a/src/modules/knowledge-base/schemas/article.ts
+++ b/src/modules/knowledge-base/schemas/article.ts
@@ -1,10 +1,27 @@
 import { z } from "zod";
+import type { Json } from "@/types/database.types";
+import type { KbArticleContent } from "../types";
+
+function isJsonValue(value: unknown): value is Json {
+  if (value === null) return true;
+  if (["string", "number", "boolean"].includes(typeof value)) return true;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).every(isJsonValue);
+  }
+  return false;
+}
+
+function isKbArticleContent(value: unknown): value is KbArticleContent {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value as Record<string, unknown>).every(isJsonValue);
+}
 
 export const createArticleSchema = z.object({
   title: z.string().min(2, "Mínimo 2 caracteres").max(200, "Máximo 200 caracteres"),
   summary: z.string().max(500, "Máximo 500 caracteres").optional(),
   content_md: z.string().min(1, "Conteúdo obrigatório"),
-  content_json: z.record(z.unknown()),
+  content_json: z.custom<KbArticleContent>(isKbArticleContent, "JSON de conteúdo inválido"),
   category_id: z.string().uuid("Categoria inválida").optional(),
   audience: z.enum(["user", "dev", "both"]).default("user"),
   related_module: z.string().optional(),

--- a/src/modules/knowledge-base/types/index.ts
+++ b/src/modules/knowledge-base/types/index.ts
@@ -1,6 +1,9 @@
-import type { Database } from "@/types/database.types";
+import type { Database, Json } from "@/types/database.types";
 
 export type KbArticle = Database["public"]["Tables"]["kb_articles"]["Row"];
+export type KbArticleInsert = Database["public"]["Tables"]["kb_articles"]["Insert"];
+export type KbArticleUpdate = Database["public"]["Tables"]["kb_articles"]["Update"];
+export type KbArticleContent = { [key: string]: Json | undefined };
 export type KbCategory = Database["public"]["Tables"]["kb_categories"]["Row"];
 
 export type KbArticleStatus = "draft" | "published" | "archived";

--- a/src/modules/tenancy/components/create-company-form.tsx
+++ b/src/modules/tenancy/components/create-company-form.tsx
@@ -48,12 +48,6 @@ export function CreateCompanyForm({ modules }: Props) {
 
   return (
     <form ref={formRef} action={formAction} className="space-y-6">
-      {!state.ok && state.message && (
-        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-          {state.message}
-        </div>
-      )}
-
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         {/* Nome */}
         <div className="space-y-2">

--- a/src/modules/tenancy/components/create-company-form.tsx
+++ b/src/modules/tenancy/components/create-company-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useRef } from "react";
 import { useFormStatus } from "react-dom";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -25,16 +26,28 @@ type Props = {
 export function CreateCompanyForm({ modules }: Props) {
   const router = useRouter();
   const [state, formAction] = useActionState(createCompanyAction, initial);
+  const formRef = useRef<HTMLFormElement>(null);
+  const hasMountedRef = useRef(false);
   const fieldErrors = state.ok ? undefined : state.fieldErrors;
 
   useEffect(() => {
-    if (state.ok) {
-      router.push("/admin/companies");
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
     }
+
+    if (state.ok) {
+      formRef.current?.reset();
+      toast.success(state.message ?? "Salvo com sucesso.");
+      router.push("/admin/companies");
+      return;
+    }
+
+    if (state.message) toast.error(state.message);
   }, [state, router]);
 
   return (
-    <form action={formAction} className="space-y-6">
+    <form ref={formRef} action={formAction} className="space-y-6">
       {!state.ok && state.message && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
           {state.message}

--- a/src/modules/tenancy/components/create-module-form.tsx
+++ b/src/modules/tenancy/components/create-module-form.tsx
@@ -1,34 +1,44 @@
 "use client";
 
-import { useActionState } from "react";
+import { useActionState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useFormStatus } from "react-dom";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { createModuleAction } from "../actions/create-module";
+import type { ActionResult } from "@/lib/errors";
 
-const initial = { ok: true as const };
+const initial: ActionResult = { ok: false };
 
 export function CreateModuleForm() {
   const router = useRouter();
-  const [state, formAction, isPending] = useActionState(createModuleAction, initial);
+  const [state, formAction] = useActionState(createModuleAction, initial);
+  const formRef = useRef<HTMLFormElement>(null);
+  const hasMountedRef = useRef(false);
 
   useEffect(() => {
-    if (state.ok && state.message) {
-      toast.success(state.message);
-      router.push("/admin/platform/modules");
-    } else if (!state.ok && state.message && !("fieldErrors" in state)) {
-      toast.error(state.message);
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
     }
+
+    if (state.ok) {
+      formRef.current?.reset();
+      toast.success(state.message ?? "Salvo com sucesso.");
+      router.push("/admin/platform/modules");
+      return;
+    }
+
+    if (state.message) toast.error(state.message);
   }, [state, router]);
 
-  const errors = !state.ok && "fieldErrors" in state ? state.fieldErrors : undefined;
+  const errors = state.ok ? undefined : state.fieldErrors;
 
   return (
-    <form action={formAction} className="max-w-lg space-y-4">
+    <form ref={formRef} action={formAction} className="max-w-lg space-y-4">
       <div className="space-y-1">
         <Label htmlFor="code">Código</Label>
         <Input id="code" name="code" placeholder="ex: crm" pattern="[a-z0-9\-]+" required />
@@ -59,9 +69,7 @@ export function CreateModuleForm() {
       <input type="hidden" name="is_system" value="false" />
 
       <div className="flex gap-2">
-        <Button type="submit" disabled={isPending}>
-          {isPending ? "Criando..." : "Criar módulo"}
-        </Button>
+        <SubmitButton />
         <Button
           type="button"
           variant="outline"
@@ -71,5 +79,14 @@ export function CreateModuleForm() {
         </Button>
       </div>
     </form>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? "Criando..." : "Criar módulo"}
+    </Button>
   );
 }

--- a/src/modules/tenancy/components/edit-module-form.tsx
+++ b/src/modules/tenancy/components/edit-module-form.tsx
@@ -28,7 +28,6 @@ export function EditModuleForm({ module }: Props) {
     }
 
     if (state.ok) {
-      formRef.current?.reset();
       toast.success(state.message ?? "Salvo com sucesso.");
       return;
     }

--- a/src/modules/tenancy/components/edit-module-form.tsx
+++ b/src/modules/tenancy/components/edit-module-form.tsx
@@ -1,29 +1,45 @@
 "use client";
 
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useRef } from "react";
+import { useFormStatus } from "react-dom";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { updateModuleAction } from "../actions/update-module";
+import type { ActionResult } from "@/lib/errors";
 import type { Tables } from "@/types/database.types";
 
 type Props = { module: Tables<"modules"> };
 
+const initial: ActionResult = { ok: false };
+
 export function EditModuleForm({ module }: Props) {
   const boundAction = updateModuleAction.bind(null, module.code);
-  const [state, formAction, isPending] = useActionState(boundAction, { ok: true as const });
+  const [state, formAction] = useActionState(boundAction, initial);
+  const formRef = useRef<HTMLFormElement>(null);
+  const hasMountedRef = useRef(false);
 
   useEffect(() => {
-    if (state.ok && state.message) toast.success(state.message);
-    else if (!state.ok && state.message && !("fieldErrors" in state)) toast.error(state.message);
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
+    if (state.ok) {
+      formRef.current?.reset();
+      toast.success(state.message ?? "Salvo com sucesso.");
+      return;
+    }
+
+    if (state.message) toast.error(state.message);
   }, [state]);
 
-  const errors = !state.ok && "fieldErrors" in state ? state.fieldErrors : undefined;
+  const errors = state.ok ? undefined : state.fieldErrors;
 
   return (
-    <form action={formAction} className="max-w-lg space-y-4">
+    <form ref={formRef} action={formAction} className="max-w-lg space-y-4">
       <div className="space-y-1">
         <Label>Código</Label>
         <Input value={module.code} disabled className="font-mono" />
@@ -55,9 +71,16 @@ export function EditModuleForm({ module }: Props) {
         <Input id="sort_order" name="sort_order" type="number" defaultValue={module.sort_order} />
       </div>
 
-      <Button type="submit" disabled={isPending}>
-        {isPending ? "Salvando..." : "Salvar alterações"}
-      </Button>
+      <SubmitButton />
     </form>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? "Salvando..." : "Salvar alterações"}
+    </Button>
   );
 }

--- a/src/modules/tenancy/components/update-company-form.tsx
+++ b/src/modules/tenancy/components/update-company-form.tsx
@@ -54,12 +54,6 @@ export function UpdateCompanyForm({ company }: Props) {
       {/* ID oculto */}
       <input type="hidden" name="id" value={company.id} />
 
-      {!state.ok && state.message && (
-        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-          {state.message}
-        </div>
-      )}
-
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         {/* Nome */}
         <div className="space-y-2">

--- a/src/modules/tenancy/components/update-company-form.tsx
+++ b/src/modules/tenancy/components/update-company-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useRef } from "react";
 import { useFormStatus } from "react-dom";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -28,16 +29,28 @@ type Props = {
 export function UpdateCompanyForm({ company }: Props) {
   const router = useRouter();
   const [state, formAction] = useActionState(updateCompanyAction, initial);
+  const formRef = useRef<HTMLFormElement>(null);
+  const hasMountedRef = useRef(false);
   const fieldErrors = state.ok ? undefined : state.fieldErrors;
 
   useEffect(() => {
-    if (state.ok) {
-      router.push("/admin/companies");
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
     }
+
+    if (state.ok) {
+      formRef.current?.reset();
+      toast.success(state.message ?? "Salvo com sucesso.");
+      router.push("/admin/companies");
+      return;
+    }
+
+    if (state.message) toast.error(state.message);
   }, [state, router]);
 
   return (
-    <form action={formAction} className="space-y-6">
+    <form ref={formRef} action={formAction} className="space-y-6">
       {/* ID oculto */}
       <input type="hidden" name="id" value={company.id} />
 

--- a/supabase/migrations/20260519000044_fix_platform_admin_rls.sql
+++ b/supabase/migrations/20260519000044_fix_platform_admin_rls.sql
@@ -1,0 +1,95 @@
+-- Fix: garantir que platform admins possam executar writes mesmo sem permissão
+-- de role explícita (requirePermission() em TS já bypassa para admins, mas
+-- has_permission() no Postgres não conhece platform_admins)
+
+-- ─── PROFILES ────────────────────────────────────────────────────────────────
+drop policy if exists "profiles_select_own_or_admin" on public.profiles;
+create policy "profiles_select_own_or_admin"
+  on public.profiles for select
+  using (id = auth.uid() or public.is_platform_admin());
+
+-- ─── PRODUCTS ────────────────────────────────────────────────────────────────
+drop policy if exists "products_insert" on public.products;
+create policy "products_insert" on public.products
+  for insert with check (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'inventory:product:create')
+  );
+
+drop policy if exists "products_update" on public.products;
+create policy "products_update" on public.products
+  for update
+  using (public.is_platform_admin() or public.has_permission(company_id, 'inventory:product:update'))
+  with check (public.is_platform_admin() or public.has_permission(company_id, 'inventory:product:update'));
+
+drop policy if exists "products_delete" on public.products;
+create policy "products_delete" on public.products
+  for delete using (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'inventory:product:delete')
+  );
+
+-- ─── STOCK MOVEMENTS ─────────────────────────────────────────────────────────
+drop policy if exists "movements_insert" on public.stock_movements;
+create policy "movements_insert" on public.stock_movements
+  for insert with check (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'movements:movement:create')
+  );
+
+-- ─── KNOWLEDGE BASE ──────────────────────────────────────────────────────────
+drop policy if exists "kb_categories_insert" on public.kb_categories;
+create policy "kb_categories_insert" on public.kb_categories
+  for insert with check (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'kb:article:write')
+  );
+
+drop policy if exists "kb_categories_update" on public.kb_categories;
+create policy "kb_categories_update" on public.kb_categories
+  for update using (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'kb:article:write')
+  );
+
+drop policy if exists "kb_categories_delete" on public.kb_categories;
+create policy "kb_categories_delete" on public.kb_categories
+  for delete using (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'kb:article:write')
+  );
+
+drop policy if exists "kb_articles_insert" on public.kb_articles;
+create policy "kb_articles_insert" on public.kb_articles
+  for insert with check (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'kb:article:write')
+  );
+
+drop policy if exists "kb_articles_update" on public.kb_articles;
+create policy "kb_articles_update" on public.kb_articles
+  for update using (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'kb:article:write')
+  );
+
+drop policy if exists "kb_articles_delete" on public.kb_articles;
+create policy "kb_articles_delete" on public.kb_articles
+  for delete using (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'kb:article:write')
+  );
+
+drop policy if exists "kb_videos_insert" on public.kb_videos;
+create policy "kb_videos_insert" on public.kb_videos
+  for insert with check (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'kb:article:write')
+  );
+
+drop policy if exists "kb_videos_update" on public.kb_videos;
+create policy "kb_videos_update" on public.kb_videos
+  for update using (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'kb:article:write')
+  );

--- a/supabase/migrations/20260519000045_fix_kb_videos_delete_policy.sql
+++ b/supabase/migrations/20260519000045_fix_kb_videos_delete_policy.sql
@@ -1,0 +1,11 @@
+-- Add missing delete policy for kb_videos
+-- The original RLS migration (20260425000020_kb_rls.sql) did not include a delete policy for kb_videos.
+-- The platform admin fix migration (20260519000044) updated insert/update but could not add delete
+-- since it didn't exist. This migration adds the missing policy.
+
+drop policy if exists "kb_videos_delete" on public.kb_videos;
+create policy "kb_videos_delete" on public.kb_videos
+  for delete using (
+    public.is_platform_admin()
+    or public.has_permission(company_id, 'kb:article:write')
+  );


### PR DESCRIPTION
## Contexto

Auditoria do projeto contra as 7 skills de guardrail criadas. Este PR centraliza todos os ajustes identificados + corrige bugs encontrados durante o processo.

## Fixes incluídos

### 🔐 Segurança — KB Actions
- `create-article`, `update-article`, `delete-article`, `publish-article`: `requirePermission` estava sendo chamado antes da autenticação do usuário. Reordenado para: parse → auth → companyId → requirePermission
- Removidos type casts inline (`as unknown as string`, `as Json`)

### 🛡️ RLS — Platform Admin Trap
- Nova migration `20260519000044`: adiciona `is_platform_admin() OR` em todas as write policies de `products`, `stock_movements`, `kb_categories`, `kb_articles` e `kb_videos`
- Corrige `profiles_select_own_or_admin` que usava o role system antigo
- **Motivação**: `requirePermission()` em TypeScript bypassa para platform admins (`Set(["*"])`), mas `has_permission()` no Postgres não conhece `platform_admins` — causava falha silenciosa (0 rows affected)
- Nova migration `20260519000045`: adiciona policy `kb_videos_delete` que estava completamente ausente

### 📊 Queries
- `inventory/list-products`, `audit/list-audit-logs`, `audit/list-audit-logs-global`: padronizado para `throw new Error(error.message)`
- `inventory/schemas`: adicionado `pageSize.max(100)` — cap de segurança para paginação user-facing

### 🧩 Forms (6 arquivos)
- `movement-form`, `product-form`, `create-company-form`, `update-company-form`, `create-module-form`, `edit-module-form`
- Adicionados: `hasMountedRef` (evita toast no mount inicial), `toast` (sonner), `formRef.current?.reset()` no sucesso, `SubmitButton` separado com `useFormStatus`

### 🐛 Bug Fix — Dashboard crash (produção)
- `src/app/(dashboard)/page.tsx` passava `pageSize: 9999` para `listProducts`, que agora tem `.max(100)` no schema → ZodError em Server Component → crash em produção
- **Fix**: nova query `getInventoryStats(companyId)` no módulo `inventory` que busca todos os produtos ativos sem schema de paginação, computando lowStock, totalValue e count server-side
- Dashboard atualizado para usar a nova query

### 📚 Skills
- `erp-module-conventions`: documentada exceção para módulos de infraestrutura (`auth`, `authz`, `audit`, `tenancy`)
- `erp-infra-modules` (nova skill): documenta padrões, regras e como estender cada um dos 4 módulos infra — validada contra o código real

## Fora deste PR (próximos)
- Tipos inline em queries → refactor por módulo (PRs separados, começando por `audit`)
