### PR TITLE
feat(authz): role_permissions.is_active (PR #A)

### DIFF
--- a/src/modules/tenancy/actions/__tests__/bulk-toggle-module-for-companies.test.ts
+++ b/src/modules/tenancy/actions/__tests__/bulk-toggle-module-for-companies.test.ts
@@ -10,16 +10,23 @@ import { bulkToggleModuleForCompaniesAction } from "../bulk-toggle-module-for-co
 
 // Enable path:
 //   rpc is_platform_admin → auth.getUser → companies.select → company_modules.upsert
-//   → permissions.select.eq → roles.select.eq → role_permissions.upsert
+//   → permissions.select.eq → role_permissions.update({ is_active: true }).in
+//   → roles.select.eq → role_permissions.upsert
 // Disable path:
 //   rpc is_platform_admin → auth.getUser → company_modules.delete.eq
-//   → permissions.select.eq → role_permissions.delete.in
+//   → permissions.select.eq → role_permissions.update({ is_active: false }).in
 
 function makeEnableMock({
   isPlatformAdmin = true,
   companies = [{ id: "c1" }, { id: "c2" }],
   upsertError = null as { message: string } | null,
+  modulePerms = [] as Array<{ code: string; action: string }>,
+  systemRoles = [] as Array<{ id: string; code: string }>,
 } = {}) {
+  const rolePermsUpdateIn = vi.fn().mockResolvedValue({ data: null, error: null });
+  const rolePermsUpdateFn = vi.fn().mockReturnValue({ in: rolePermsUpdateIn });
+  const rolePermsUpsert = vi.fn().mockResolvedValue({ error: null });
+
   return {
     rpc: vi.fn().mockResolvedValue({ data: isPlatformAdmin, error: null }),
     auth: {
@@ -35,23 +42,32 @@ function makeEnableMock({
       if (table === "permissions")
         return {
           select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+            eq: vi.fn().mockResolvedValue({ data: modulePerms, error: null }),
           }),
         };
       if (table === "roles")
         return {
           select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+            eq: vi.fn().mockResolvedValue({ data: systemRoles, error: null }),
           }),
         };
       if (table === "role_permissions")
-        return { upsert: vi.fn().mockResolvedValue({ error: null }) };
+        return { update: rolePermsUpdateFn, upsert: rolePermsUpsert };
       return {};
     }),
+    rolePermsUpdateFn,
+    rolePermsUpdateIn,
+    rolePermsUpsert,
   };
 }
 
-function makeDisableMock({ deleteError = null as { message: string } | null } = {}) {
+function makeDisableMock({
+  deleteError = null as { message: string } | null,
+  permsToDeactivate = [{ code: "kb:article:read" }] as Array<{ code: string }>,
+} = {}) {
+  const rolePermsUpdateIn = vi.fn().mockResolvedValue({ data: null, error: null });
+  const rolePermsUpdateFn = vi.fn().mockReturnValue({ in: rolePermsUpdateIn });
+
   return {
     rpc: vi.fn().mockResolvedValue({ data: true, error: null }),
     auth: {
@@ -67,17 +83,14 @@ function makeDisableMock({ deleteError = null as { message: string } | null } = 
       if (table === "permissions")
         return {
           select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ data: [{ code: "kb:article:read" }], error: null }),
+            eq: vi.fn().mockResolvedValue({ data: permsToDeactivate, error: null }),
           }),
         };
-      if (table === "role_permissions")
-        return {
-          delete: vi.fn().mockReturnValue({
-            in: vi.fn().mockResolvedValue({ error: null }),
-          }),
-        };
+      if (table === "role_permissions") return { update: rolePermsUpdateFn };
       return {};
     }),
+    rolePermsUpdateFn,
+    rolePermsUpdateIn,
   };
 }
 
@@ -100,6 +113,58 @@ describe("bulkToggleModuleForCompaniesAction", () => {
     vi.mocked(createClient).mockResolvedValue(makeEnableMock({ isPlatformAdmin: false }) as never);
     await expect(bulkToggleModuleForCompaniesAction("knowledge-base", true)).rejects.toThrow(
       "Acesso negado",
+    );
+  });
+
+  it("disable: marca is_active=false em role_permissions globalmente", async () => {
+    const mock = makeDisableMock({
+      permsToDeactivate: [{ code: "inventory:product:read" }, { code: "inventory:product:create" }],
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await bulkToggleModuleForCompaniesAction("inventory", false);
+
+    expect(result.ok).toBe(true);
+    expect(mock.rolePermsUpdateFn).toHaveBeenCalledWith({ is_active: false });
+    expect(mock.rolePermsUpdateIn).toHaveBeenCalledWith(
+      "permission_code",
+      expect.arrayContaining(["inventory:product:read", "inventory:product:create"]),
+    );
+  });
+
+  it("enable: marca is_active=true em role_permissions globalmente antes do upsert", async () => {
+    const mock = makeEnableMock({
+      modulePerms: [
+        { code: "inventory:product:read", action: "read" },
+        { code: "inventory:product:create", action: "create" },
+      ],
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const result = await bulkToggleModuleForCompaniesAction("inventory", true);
+
+    expect(result.ok).toBe(true);
+    expect(mock.rolePermsUpdateFn).toHaveBeenCalledWith({ is_active: true });
+    expect(mock.rolePermsUpdateIn).toHaveBeenCalledWith(
+      "permission_code",
+      expect.arrayContaining(["inventory:product:read", "inventory:product:create"]),
+    );
+  });
+
+  it("enable: upsert das perms-padrão inclui is_active=true", async () => {
+    const mock = makeEnableMock({
+      systemRoles: [{ id: "role-owner", code: "owner" }],
+      modulePerms: [{ code: "inventory:product:read", action: "read" }],
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    await bulkToggleModuleForCompaniesAction("inventory", true);
+
+    expect(mock.rolePermsUpsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ permission_code: "inventory:product:read", is_active: true }),
+      ]),
+      expect.objectContaining({ onConflict: "role_id,permission_code" }),
     );
   });
 });

--- a/src/modules/tenancy/actions/__tests__/toggle-module.test.ts
+++ b/src/modules/tenancy/actions/__tests__/toggle-module.test.ts
@@ -18,7 +18,7 @@ type ToggleMockOptions = {
   deleteModuleError?: { message: string } | null;
   systemRoles?: Array<{ id: string; code: string }>;
   permissions?: Array<{ code: string }>;
-  permsToRemove?: Array<{ code: string }>;
+  permsToDeactivate?: Array<{ code: string }>;
   companyRoles?: Array<{ id: string }>;
 };
 
@@ -105,17 +105,17 @@ function makeEnableMock({
 //   company_modules.delete().eq("company_id").eq("module_code") — sem return, só checa error
 //   permissions.select("code").eq("module_code", moduleCode)    — uma eq, resolve array
 //   roles.select("id").eq("company_id", companyId)              — uma eq, resolve array
-//   role_permissions.delete().in("role_id", roleIds).in("permission_code", codes) — sem return
+//   role_permissions.update({ is_active: false }).in("role_id", roleIds).in("permission_code", codes) — sem return
 // -------------------------------------------------------------------
 function makeDisableMock({
   isPlatformAdmin = true,
   rpcError = null,
   deleteModuleError = null,
-  permsToRemove = [{ code: "inventory:product:read" }],
+  permsToDeactivate = [{ code: "inventory:product:read" }],
   companyRoles = [{ id: "role-owner" }, { id: "role-manager" }],
 }: Pick<
   ToggleMockOptions,
-  "isPlatformAdmin" | "rpcError" | "deleteModuleError" | "permsToRemove" | "companyRoles"
+  "isPlatformAdmin" | "rpcError" | "deleteModuleError" | "permsToDeactivate" | "companyRoles"
 > = {}) {
   // company_modules: .delete().eq().eq() — terminal
   const modulesDeleteEq2 = vi
@@ -127,7 +127,7 @@ function makeDisableMock({
   const modulesDeleteFn = vi.fn().mockReturnValue({ eq: modulesDeleteEq1 });
 
   // permissions: .select("code").eq("module_code", moduleCode) — uma eq, resolve array
-  const permsEqDisable = vi.fn().mockResolvedValue({ data: permsToRemove, error: null });
+  const permsEqDisable = vi.fn().mockResolvedValue({ data: permsToDeactivate, error: null });
   const permsSelectDisable = vi.fn().mockReturnValue({ eq: permsEqDisable });
 
   // roles: .select("id").eq("company_id", companyId) — uma eq, resolve array
@@ -259,7 +259,7 @@ describe("toggleModuleAction", () => {
     const mock = makeDisableMock({
       isPlatformAdmin: true,
       companyRoles: [{ id: "role-a" }, { id: "role-b" }],
-      permsToRemove: [{ code: "inventory:product:read" }],
+      permsToDeactivate: [{ code: "inventory:product:read" }],
     });
     await callToggle(mock, "company-1", "inventory", false);
 

--- a/src/modules/tenancy/actions/__tests__/toggle-module.test.ts
+++ b/src/modules/tenancy/actions/__tests__/toggle-module.test.ts
@@ -26,9 +26,12 @@ type ToggleMockOptions = {
 // Factory: mock para o caminho enable=true
 // Sequência de produção:
 //   company_modules.insert()
-//   roles.select("id, code").eq("company_id").eq("is_system", true)
-//   permissions.select("code").eq("module_code").in("action", [...])
-//   role_permissions.upsert(...)
+//   roles.select("id").eq("company_id")                       — todas as roles (reativação)
+//   permissions.select("code").eq("module_code")              — perms do módulo (reativação)
+//   role_permissions.update({ is_active: true }).in().in()    — reativa perms antigas
+//   roles.select("id, code").eq("company_id").eq("is_system") — system roles
+//   permissions.select("code").eq("module_code").in("action") — loop distribuição
+//   role_permissions.upsert(...)                              — distribui defaults
 // -------------------------------------------------------------------
 function makeEnableMock({
   isPlatformAdmin = true,
@@ -51,18 +54,39 @@ function makeEnableMock({
       insertModuleError ? { data: null, error: insertModuleError } : { data: null, error: null },
     );
 
-  // roles: .select().eq().eq() — 2 eqs
+  // roles: primeira chamada (todas) — .select("id").eq("company_id")
+  const rolesAllEq = vi
+    .fn()
+    .mockResolvedValue({
+      data: [{ id: "role-owner" }, { id: "role-manager" }, { id: "role-operator" }],
+      error: null,
+    });
+  const rolesAllSelect = vi.fn().mockReturnValue({ eq: rolesAllEq });
+
+  // roles: segunda chamada (system) — .select("id, code").eq("company_id").eq("is_system")
   const rolesEq2System = vi.fn().mockResolvedValue({ data: systemRoles, error: null });
   const rolesEq1System = vi.fn().mockReturnValue({ eq: rolesEq2System });
   const rolesSelectSystem = vi.fn().mockReturnValue({ eq: rolesEq1System });
 
-  // permissions: .select().eq().in()
-  const permsIn = vi.fn().mockResolvedValue({ data: permissions, error: null });
-  const permsEqEnable = vi.fn().mockReturnValue({ in: permsIn });
-  const permsSelectEnable = vi.fn().mockReturnValue({ eq: permsEqEnable });
+  // permissions: primeira chamada (reativação) — .select("code").eq("module_code")
+  const permsReactEq = vi.fn().mockResolvedValue({ data: permissions, error: null });
+  const permsReactSelect = vi.fn().mockReturnValue({ eq: permsReactEq });
+
+  // permissions: chamadas seguintes (loop distribuição) — .select("code").eq("module_code").in("action", [...])
+  const permsDistIn = vi.fn().mockResolvedValue({ data: permissions, error: null });
+  const permsDistEq = vi.fn().mockReturnValue({ in: permsDistIn });
+  const permsDistSelect = vi.fn().mockReturnValue({ eq: permsDistEq });
+
+  // role_permissions: .update({ is_active: true }).in("role_id").in("permission_code")
+  const rolePermsUpdateIn2 = vi.fn().mockResolvedValue({ data: null, error: null });
+  const rolePermsUpdateIn1 = vi.fn().mockReturnValue({ in: rolePermsUpdateIn2 });
+  const rolePermsUpdateFn = vi.fn().mockReturnValue({ in: rolePermsUpdateIn1 });
 
   // role_permissions: .upsert() terminal
   const rolePermsUpsert = vi.fn().mockResolvedValue({ data: null, error: null });
+
+  let rolesCallCount = 0;
+  let permsCallCount = 0;
 
   return {
     auth: {
@@ -74,13 +98,15 @@ function makeEnableMock({
         return { insert: modulesInsert };
       }
       if (table === "roles") {
-        return { select: rolesSelectSystem };
+        rolesCallCount++;
+        return { select: rolesCallCount === 1 ? rolesAllSelect : rolesSelectSystem };
       }
       if (table === "permissions") {
-        return { select: permsSelectEnable };
+        permsCallCount++;
+        return { select: permsCallCount === 1 ? permsReactSelect : permsDistSelect };
       }
       if (table === "role_permissions") {
-        return { upsert: rolePermsUpsert };
+        return { update: rolePermsUpdateFn, upsert: rolePermsUpsert };
       }
       // fallback para tabelas não esperadas — joga erro para detectar acessos inesperados
       return vi.fn().mockReturnValue({
@@ -95,6 +121,8 @@ function makeEnableMock({
     }),
     // Helpers expostos para inspecionar nos testes
     modulesInsert,
+    rolePermsUpdateFn,
+    rolePermsUpdateIn2,
     rolePermsUpsert,
   };
 }
@@ -234,11 +262,22 @@ describe("toggleModuleAction", () => {
 
     expect(mock.rolePermsUpsert).toHaveBeenCalledWith(
       expect.arrayContaining([
-        expect.objectContaining({ permission_code: "inventory:product:read" }),
-        expect.objectContaining({ permission_code: "inventory:product:create" }),
+        expect.objectContaining({ permission_code: "inventory:product:read", is_active: true }),
+        expect.objectContaining({ permission_code: "inventory:product:create", is_active: true }),
       ]),
       expect.objectContaining({ onConflict: "role_id,permission_code" }),
     );
+  });
+
+  it("ao habilitar módulo chama update com is_active=true para reativar perms antigas", async () => {
+    const mock = makeEnableMock({
+      isPlatformAdmin: true,
+      systemRoles: [{ id: "role-owner-id", code: "owner" }],
+      permissions: [{ code: "inventory:product:read" }],
+    });
+    await callToggle(mock, "company-1", "inventory", true);
+
+    expect(mock.rolePermsUpdateFn).toHaveBeenCalledWith({ is_active: true });
   });
 
   it("retorna { ok: true } ao desabilitar módulo", async () => {

--- a/src/modules/tenancy/actions/__tests__/toggle-module.test.ts
+++ b/src/modules/tenancy/actions/__tests__/toggle-module.test.ts
@@ -134,10 +134,10 @@ function makeDisableMock({
   const rolesEqCompany = vi.fn().mockResolvedValue({ data: companyRoles, error: null });
   const rolesSelectCompany = vi.fn().mockReturnValue({ eq: rolesEqCompany });
 
-  // role_permissions: .delete().in("role_id").in("permission_code") — sem return
-  const rolePermsDeleteIn2 = vi.fn().mockResolvedValue({ data: null, error: null });
-  const rolePermsDeleteIn1 = vi.fn().mockReturnValue({ in: rolePermsDeleteIn2 });
-  const rolePermsDeleteFn = vi.fn().mockReturnValue({ in: rolePermsDeleteIn1 });
+  // role_permissions: .update({ is_active: false }).in("role_id").in("permission_code") — sem return
+  const rolePermsUpdateIn2 = vi.fn().mockResolvedValue({ data: null, error: null });
+  const rolePermsUpdateIn1 = vi.fn().mockReturnValue({ in: rolePermsUpdateIn2 });
+  const rolePermsUpdateFn = vi.fn().mockReturnValue({ in: rolePermsUpdateIn1 });
 
   return {
     auth: {
@@ -155,7 +155,7 @@ function makeDisableMock({
         return { select: rolesSelectCompany };
       }
       if (table === "role_permissions") {
-        return { delete: rolePermsDeleteFn };
+        return { update: rolePermsUpdateFn };
       }
       // fallback para tabelas não esperadas — joga erro para detectar acessos inesperados
       return vi.fn().mockReturnValue({
@@ -171,7 +171,8 @@ function makeDisableMock({
     // Helpers expostos para inspecionar nos testes
     modulesDeleteFn,
     permsEqDisable,
-    rolePermsDeleteIn2,
+    rolePermsUpdateFn,
+    rolePermsUpdateIn2,
   };
 }
 
@@ -254,7 +255,7 @@ describe("toggleModuleAction", () => {
     expect(mock.modulesDeleteFn).toHaveBeenCalled();
   });
 
-  it("ao desabilitar módulo chama delete em role_permissions com os ids corretos", async () => {
+  it("ao desabilitar módulo chama update com is_active=false em role_permissions", async () => {
     const mock = makeDisableMock({
       isPlatformAdmin: true,
       companyRoles: [{ id: "role-a" }, { id: "role-b" }],
@@ -264,8 +265,10 @@ describe("toggleModuleAction", () => {
 
     expect(mock.permsEqDisable).toHaveBeenCalledWith("module_code", "inventory");
 
-    // Verifica que o segundo .in() foi chamado com os permission_codes corretos
-    expect(mock.rolePermsDeleteIn2).toHaveBeenCalledWith(
+    // update foi chamado com payload de desativação
+    expect(mock.rolePermsUpdateFn).toHaveBeenCalledWith({ is_active: false });
+    // segundo .in() recebe permission_codes corretos
+    expect(mock.rolePermsUpdateIn2).toHaveBeenCalledWith(
       "permission_code",
       expect.arrayContaining(["inventory:product:read"]),
     );

--- a/src/modules/tenancy/actions/__tests__/update-role-permissions.test.ts
+++ b/src/modules/tenancy/actions/__tests__/update-role-permissions.test.ts
@@ -71,8 +71,9 @@ function makeSupabaseMock({
   const rolesEq1 = vi.fn().mockReturnValue({ eq: rolesEq2 });
   const rolesSelect = vi.fn().mockReturnValue({ eq: rolesEq1 });
 
-  // role_permissions select: .select("permission_code").eq("role_id") — Promise.all branch 1
-  const rpSelectEq = vi.fn().mockResolvedValue({ data: currentPerms, error: null });
+  // role_permissions select: .select("permission_code").eq("role_id").eq("is_active", true) — Promise.all branch 1
+  const rpSelectEqActive = vi.fn().mockResolvedValue({ data: currentPerms, error: null });
+  const rpSelectEq = vi.fn().mockReturnValue({ eq: rpSelectEqActive });
   const rpSelectFn = vi.fn().mockReturnValue({ eq: rpSelectEq });
 
   // company_modules: .select("module_code").eq("company_id") — Promise.all branch 2
@@ -197,11 +198,41 @@ describe("updateRolePermissionsAction", () => {
     expect(result.ok).toBe(true);
     expect(mock.rpUpsert).toHaveBeenCalledWith(
       expect.arrayContaining([
-        expect.objectContaining({ permission_code: "inventory:product:read" }),
-        expect.objectContaining({ permission_code: "inventory:product:create" }),
+        expect.objectContaining({ permission_code: "inventory:product:read", is_active: true }),
+        expect.objectContaining({ permission_code: "inventory:product:create", is_active: true }),
       ]),
       expect.objectContaining({ onConflict: "role_id,permission_code" }),
     );
+    // Não passa ignoreDuplicates: queremos que rows existentes com is_active=false sejam reativadas
+    const upsertOptions = mock.rpUpsert.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    expect(upsertOptions?.ignoreDuplicates).toBeUndefined();
+  });
+
+  it("reativa perm com is_active=false ao re-adicionar via UI (footgun PR #A→#B)", async () => {
+    // Cenário: módulo foi desabilitado → re-habilitado → mas a perm ficou is_active=false
+    // numa role custom porque update-role-permissions não filtra is_active.
+    // O fix garante que: (a) currentSet não inclui rows inactive, (b) upsert sem
+    // ignoreDuplicates ressuscita a row.
+    const mock = makeSupabaseMock({
+      currentPerms: [], // is_active=true filter retorna vazio (row existe mas inactive)
+      enabledModules: [{ module_code: "inventory" }],
+      validPerms: [{ code: "inventory:product:read" }],
+    });
+    vi.mocked(createClient).mockResolvedValue(mock as never);
+
+    const fd = makeFormData(["inventory:product:read"]);
+
+    const result = await updateRolePermissionsAction("company-1", "role-1", { ok: true }, fd);
+
+    expect(result.ok).toBe(true);
+    expect(mock.rpUpsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ permission_code: "inventory:product:read", is_active: true }),
+      ]),
+      expect.objectContaining({ onConflict: "role_id,permission_code" }),
+    );
+    const upsertOptions = mock.rpUpsert.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    expect(upsertOptions?.ignoreDuplicates).toBeUndefined();
   });
 
   it("retorna { ok: true } e chama delete quando remove permissões", async () => {

--- a/src/modules/tenancy/actions/bulk-toggle-module-for-companies.ts
+++ b/src/modules/tenancy/actions/bulk-toggle-module-for-companies.ts
@@ -40,26 +40,44 @@ export async function bulkToggleModuleForCompaniesAction(
       if (error) return { ok: false, message: error.message };
     }
 
-    // Distribui permissões do módulo nas roles-sistema de todas as empresas
-    const [{ data: allPerms }, { data: systemRoles }] = await Promise.all([
-      supabase.from("permissions").select("code, action").eq("module_code", moduleCode),
-      supabase.from("roles").select("id, code").eq("is_system", true),
-    ]);
+    const { data: modulePerms } = await supabase
+      .from("permissions")
+      .select("code, action")
+      .eq("module_code", moduleCode);
+
+    const modulePermCodes = (modulePerms ?? []).map((p) => p.code);
+
+    // Reativa globalmente perms previamente desativadas (preserva customizações
+    // tenant após ciclo disable→enable global do módulo).
+    if (modulePermCodes.length) {
+      const { error: updErr } = await supabase
+        .from("role_permissions")
+        .update({ is_active: true })
+        .in("permission_code", modulePermCodes);
+      if (updErr) return { ok: false, message: updErr.message };
+    }
+
+    // Distribui perms-padrão nas roles-sistema (idempotente)
+    const { data: systemRoles } = await supabase
+      .from("roles")
+      .select("id, code")
+      .eq("is_system", true);
 
     const permsByAction = (actions: string[]) =>
-      (allPerms ?? []).filter((p) => actions.includes(p.action)).map((p) => p.code);
+      (modulePerms ?? []).filter((p) => actions.includes(p.action)).map((p) => p.code);
 
     const ownerPerms = permsByAction(OWNER_ACTIONS);
     const managerPerms = permsByAction(MANAGER_ACTIONS);
     const operatorPerms = permsByAction(OPERATOR_ACTIONS);
 
-    const rpRows: { role_id: string; permission_code: string }[] = [];
+    const rpRows: { role_id: string; permission_code: string; is_active: boolean }[] = [];
     for (const role of systemRoles ?? []) {
       let perms: string[] = [];
       if (role.code === "owner") perms = ownerPerms;
       else if (role.code === "manager") perms = managerPerms;
       else if (role.code === "operator") perms = operatorPerms;
-      for (const perm of perms) rpRows.push({ role_id: role.id, permission_code: perm });
+      for (const perm of perms)
+        rpRows.push({ role_id: role.id, permission_code: perm, is_active: true });
     }
 
     if (rpRows.length > 0) {
@@ -72,19 +90,19 @@ export async function bulkToggleModuleForCompaniesAction(
     const { error } = await supabase.from("company_modules").delete().eq("module_code", moduleCode);
     if (error) return { ok: false, message: error.message };
 
-    // Remove permissões do módulo de todas as roles de todas as empresas
-    const { data: permsToRemove } = await supabase
+    // Soft-deactivate global de role_permissions do módulo em todas as empresas
+    const { data: permsToDeactivate } = await supabase
       .from("permissions")
       .select("code")
       .eq("module_code", moduleCode);
 
-    if (permsToRemove?.length) {
-      const permCodes = permsToRemove.map((p) => p.code);
-      const { error: delErr } = await supabase
+    if (permsToDeactivate?.length) {
+      const permCodes = permsToDeactivate.map((p) => p.code);
+      const { error: updErr } = await supabase
         .from("role_permissions")
-        .delete()
+        .update({ is_active: false })
         .in("permission_code", permCodes);
-      if (delErr) return { ok: false, message: delErr.message };
+      if (updErr) return { ok: false, message: updErr.message };
     }
   }
 

--- a/src/modules/tenancy/actions/toggle-module.ts
+++ b/src/modules/tenancy/actions/toggle-module.ts
@@ -73,13 +73,14 @@ export async function toggleModuleAction(
 
     if (error) return { ok: false, message: error.message };
 
-    // Remove permissões do módulo de todas as roles da empresa
-    const { data: permsToRemove } = await supabase
+    // Desativa logicamente permissões do módulo nas roles da empresa.
+    // Não deleta: preserva customizações tenant para quando módulo for reativado.
+    const { data: permsToDeactivate } = await supabase
       .from("permissions")
       .select("code")
       .eq("module_code", moduleCode);
 
-    if (permsToRemove?.length) {
+    if (permsToDeactivate?.length) {
       const { data: companyRoles } = await supabase
         .from("roles")
         .select("id")
@@ -87,14 +88,15 @@ export async function toggleModuleAction(
 
       const roleIds = (companyRoles ?? []).map((r) => r.id);
       if (roleIds.length) {
-        await supabase
+        const { error: updErr } = await supabase
           .from("role_permissions")
-          .delete()
+          .update({ is_active: false })
           .in("role_id", roleIds)
           .in(
             "permission_code",
-            permsToRemove.map((p) => p.code),
+            permsToDeactivate.map((p) => p.code),
           );
+        if (updErr) return { ok: false, message: updErr.message };
       }
     }
   }

--- a/src/modules/tenancy/actions/toggle-module.ts
+++ b/src/modules/tenancy/actions/toggle-module.ts
@@ -29,7 +29,33 @@ export async function toggleModuleAction(
     });
     if (error) return { ok: false, message: error.message };
 
-    // Distribui permissões do módulo nas roles-sistema existentes
+    // Reativa perms previamente desativadas (preserva customizações tenant
+    // após ciclo disable→enable do módulo).
+    const { data: companyRoles } = await supabase
+      .from("roles")
+      .select("id")
+      .eq("company_id", companyId);
+
+    const allRoleIds = (companyRoles ?? []).map((r) => r.id);
+
+    const { data: modulePerms } = await supabase
+      .from("permissions")
+      .select("code")
+      .eq("module_code", moduleCode);
+
+    const modulePermCodes = (modulePerms ?? []).map((p) => p.code);
+
+    if (allRoleIds.length && modulePermCodes.length) {
+      const { error: updErr } = await supabase
+        .from("role_permissions")
+        .update({ is_active: true })
+        .in("role_id", allRoleIds)
+        .in("permission_code", modulePermCodes);
+      if (updErr) return { ok: false, message: updErr.message };
+    }
+
+    // Distribui perms-padrão nas roles-sistema (idempotente; cobre o caso de
+    // habilitar o módulo pela primeira vez para a empresa).
     const { data: systemRoles } = await supabase
       .from("roles")
       .select("id, code")
@@ -59,7 +85,7 @@ export async function toggleModuleAction(
 
       if (perms?.length) {
         await supabase.from("role_permissions").upsert(
-          perms.map((p) => ({ role_id: role.id, permission_code: p.code })),
+          perms.map((p) => ({ role_id: role.id, permission_code: p.code, is_active: true })),
           { onConflict: "role_id,permission_code", ignoreDuplicates: true },
         );
       }

--- a/src/modules/tenancy/actions/update-role-permissions.ts
+++ b/src/modules/tenancy/actions/update-role-permissions.ts
@@ -37,7 +37,11 @@ export async function updateRolePermissionsAction(
 
   const [{ data: currentPerms, error: curErr }, { data: enabledModules, error: modErr }] =
     await Promise.all([
-      supabase.from("role_permissions").select("permission_code").eq("role_id", roleId),
+      supabase
+        .from("role_permissions")
+        .select("permission_code")
+        .eq("role_id", roleId)
+        .eq("is_active", true),
       supabase.from("company_modules").select("module_code").eq("company_id", companyId),
     ]);
 
@@ -75,9 +79,11 @@ export async function updateRolePermissionsAction(
   }
 
   if (toAdd.length > 0) {
+    // Upsert sem ignoreDuplicates: rows existentes com is_active=false (de um disable
+    // anterior do módulo) são reativadas; rows novas são criadas com is_active=true.
     const { error: insErr } = await supabase.from("role_permissions").upsert(
-      toAdd.map((code) => ({ role_id: roleId, permission_code: code })),
-      { onConflict: "role_id,permission_code", ignoreDuplicates: true },
+      toAdd.map((code) => ({ role_id: roleId, permission_code: code, is_active: true })),
+      { onConflict: "role_id,permission_code" },
     );
 
     if (insErr) return { ok: false, message: insErr.message };

--- a/src/modules/tenancy/queries/list-role-permission-matrix.ts
+++ b/src/modules/tenancy/queries/list-role-permission-matrix.ts
@@ -28,7 +28,11 @@ export async function listRolePermissionMatrix(
         .from("company_modules")
         .select("module_code, modules(name)")
         .eq("company_id", companyId),
-      supabase.from("role_permissions").select("permission_code").eq("role_id", roleId),
+      supabase
+        .from("role_permissions")
+        .select("permission_code")
+        .eq("role_id", roleId)
+        .eq("is_active", true),
     ]);
 
   if (modErr) throw modErr;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1,1161 +1,1771 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "14.5"
-  }
+    PostgrestVersion: "14.5";
+  };
   public: {
     Tables: {
       audit_logs: {
         Row: {
-          action: string
-          actor_email: string | null
-          actor_user_id: string | null
-          company_id: string | null
-          created_at: string
-          id: string
-          ip: unknown
-          metadata: Json
-          permission: string | null
-          resource_id: string | null
-          resource_type: string | null
-          status: string
-          user_agent: string | null
-        }
+          action: string;
+          actor_email: string | null;
+          actor_user_id: string | null;
+          company_id: string | null;
+          created_at: string;
+          id: string;
+          ip: unknown;
+          metadata: Json;
+          permission: string | null;
+          resource_id: string | null;
+          resource_type: string | null;
+          status: string;
+          user_agent: string | null;
+        };
         Insert: {
-          action: string
-          actor_email?: string | null
-          actor_user_id?: string | null
-          company_id?: string | null
-          created_at?: string
-          id?: string
-          ip?: unknown
-          metadata?: Json
-          permission?: string | null
-          resource_id?: string | null
-          resource_type?: string | null
-          status?: string
-          user_agent?: string | null
-        }
+          action: string;
+          actor_email?: string | null;
+          actor_user_id?: string | null;
+          company_id?: string | null;
+          created_at?: string;
+          id?: string;
+          ip?: unknown;
+          metadata?: Json;
+          permission?: string | null;
+          resource_id?: string | null;
+          resource_type?: string | null;
+          status?: string;
+          user_agent?: string | null;
+        };
         Update: {
-          action?: string
-          actor_email?: string | null
-          actor_user_id?: string | null
-          company_id?: string | null
-          created_at?: string
-          id?: string
-          ip?: unknown
-          metadata?: Json
-          permission?: string | null
-          resource_id?: string | null
-          resource_type?: string | null
-          status?: string
-          user_agent?: string | null
-        }
+          action?: string;
+          actor_email?: string | null;
+          actor_user_id?: string | null;
+          company_id?: string | null;
+          created_at?: string;
+          id?: string;
+          ip?: unknown;
+          metadata?: Json;
+          permission?: string | null;
+          resource_id?: string | null;
+          resource_type?: string | null;
+          status?: string;
+          user_agent?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "audit_logs_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "audit_logs_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       companies: {
         Row: {
-          created_at: string
-          created_by: string | null
-          document: string | null
-          id: string
-          is_active: boolean
-          name: string
-          plan: string
-          slug: string
-          updated_at: string
-        }
+          created_at: string;
+          created_by: string | null;
+          document: string | null;
+          id: string;
+          is_active: boolean;
+          name: string;
+          plan: string;
+          slug: string;
+          updated_at: string;
+        };
         Insert: {
-          created_at?: string
-          created_by?: string | null
-          document?: string | null
-          id?: string
-          is_active?: boolean
-          name: string
-          plan?: string
-          slug: string
-          updated_at?: string
-        }
+          created_at?: string;
+          created_by?: string | null;
+          document?: string | null;
+          id?: string;
+          is_active?: boolean;
+          name: string;
+          plan?: string;
+          slug: string;
+          updated_at?: string;
+        };
         Update: {
-          created_at?: string
-          created_by?: string | null
-          document?: string | null
-          id?: string
-          is_active?: boolean
-          name?: string
-          plan?: string
-          slug?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
+          created_at?: string;
+          created_by?: string | null;
+          document?: string | null;
+          id?: string;
+          is_active?: boolean;
+          name?: string;
+          plan?: string;
+          slug?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       company_invitations: {
         Row: {
-          accepted_at: string | null
-          accepted_by: string | null
-          company_id: string
-          created_at: string
-          email: string
-          expires_at: string
-          id: string
-          invited_by: string
-          revoked_at: string | null
-          revoked_by: string | null
-          role_ids: string[]
-          short_code: string
-          status: string
-          token_hash: string
-        }
+          accepted_at: string | null;
+          accepted_by: string | null;
+          company_id: string;
+          created_at: string;
+          email: string;
+          expires_at: string;
+          id: string;
+          invited_by: string;
+          revoked_at: string | null;
+          revoked_by: string | null;
+          role_ids: string[];
+          short_code: string;
+          status: string;
+          token_hash: string;
+        };
         Insert: {
-          accepted_at?: string | null
-          accepted_by?: string | null
-          company_id: string
-          created_at?: string
-          email: string
-          expires_at: string
-          id?: string
-          invited_by: string
-          revoked_at?: string | null
-          revoked_by?: string | null
-          role_ids?: string[]
-          short_code: string
-          status?: string
-          token_hash: string
-        }
+          accepted_at?: string | null;
+          accepted_by?: string | null;
+          company_id: string;
+          created_at?: string;
+          email: string;
+          expires_at: string;
+          id?: string;
+          invited_by: string;
+          revoked_at?: string | null;
+          revoked_by?: string | null;
+          role_ids?: string[];
+          short_code: string;
+          status?: string;
+          token_hash: string;
+        };
         Update: {
-          accepted_at?: string | null
-          accepted_by?: string | null
-          company_id?: string
-          created_at?: string
-          email?: string
-          expires_at?: string
-          id?: string
-          invited_by?: string
-          revoked_at?: string | null
-          revoked_by?: string | null
-          role_ids?: string[]
-          short_code?: string
-          status?: string
-          token_hash?: string
-        }
+          accepted_at?: string | null;
+          accepted_by?: string | null;
+          company_id?: string;
+          created_at?: string;
+          email?: string;
+          expires_at?: string;
+          id?: string;
+          invited_by?: string;
+          revoked_at?: string | null;
+          revoked_by?: string | null;
+          role_ids?: string[];
+          short_code?: string;
+          status?: string;
+          token_hash?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "company_invitations_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "company_invitations_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       company_modules: {
         Row: {
-          company_id: string
-          enabled_at: string
-          enabled_by: string | null
-          module_code: string
-        }
+          company_id: string;
+          enabled_at: string;
+          enabled_by: string | null;
+          module_code: string;
+        };
         Insert: {
-          company_id: string
-          enabled_at?: string
-          enabled_by?: string | null
-          module_code: string
-        }
+          company_id: string;
+          enabled_at?: string;
+          enabled_by?: string | null;
+          module_code: string;
+        };
         Update: {
-          company_id?: string
-          enabled_at?: string
-          enabled_by?: string | null
-          module_code?: string
-        }
+          company_id?: string;
+          enabled_at?: string;
+          enabled_by?: string | null;
+          module_code?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "company_modules_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "company_modules_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "company_modules_module_code_fkey"
-            columns: ["module_code"]
-            isOneToOne: false
-            referencedRelation: "modules"
-            referencedColumns: ["code"]
+            foreignKeyName: "company_modules_module_code_fkey";
+            columns: ["module_code"];
+            isOneToOne: false;
+            referencedRelation: "modules";
+            referencedColumns: ["code"];
           },
-        ]
-      }
+        ];
+      };
       kb_article_chunks: {
         Row: {
-          article_id: string
-          chunk_index: number
-          company_id: string
-          content: string
-          created_at: string
-          embedding: string
-          id: string
-        }
+          article_id: string;
+          chunk_index: number;
+          company_id: string;
+          content: string;
+          created_at: string;
+          embedding: string;
+          id: string;
+        };
         Insert: {
-          article_id: string
-          chunk_index: number
-          company_id: string
-          content: string
-          created_at?: string
-          embedding: string
-          id?: string
-        }
+          article_id: string;
+          chunk_index: number;
+          company_id: string;
+          content: string;
+          created_at?: string;
+          embedding: string;
+          id?: string;
+        };
         Update: {
-          article_id?: string
-          chunk_index?: number
-          company_id?: string
-          content?: string
-          created_at?: string
-          embedding?: string
-          id?: string
-        }
+          article_id?: string;
+          chunk_index?: number;
+          company_id?: string;
+          content?: string;
+          created_at?: string;
+          embedding?: string;
+          id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "kb_article_chunks_article_id_fkey"
-            columns: ["article_id"]
-            isOneToOne: false
-            referencedRelation: "kb_articles"
-            referencedColumns: ["id"]
+            foreignKeyName: "kb_article_chunks_article_id_fkey";
+            columns: ["article_id"];
+            isOneToOne: false;
+            referencedRelation: "kb_articles";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "kb_article_chunks_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "kb_article_chunks_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       kb_article_revisions: {
         Row: {
-          article_id: string
-          content_json: Json
-          content_md: string
-          edited_at: string
-          edited_by: string | null
-          id: string
-        }
+          article_id: string;
+          content_json: Json;
+          content_md: string;
+          edited_at: string;
+          edited_by: string | null;
+          id: string;
+        };
         Insert: {
-          article_id: string
-          content_json: Json
-          content_md: string
-          edited_at?: string
-          edited_by?: string | null
-          id?: string
-        }
+          article_id: string;
+          content_json: Json;
+          content_md: string;
+          edited_at?: string;
+          edited_by?: string | null;
+          id?: string;
+        };
         Update: {
-          article_id?: string
-          content_json?: Json
-          content_md?: string
-          edited_at?: string
-          edited_by?: string | null
-          id?: string
-        }
+          article_id?: string;
+          content_json?: Json;
+          content_md?: string;
+          edited_at?: string;
+          edited_by?: string | null;
+          id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "kb_article_revisions_article_id_fkey"
-            columns: ["article_id"]
-            isOneToOne: false
-            referencedRelation: "kb_articles"
-            referencedColumns: ["id"]
+            foreignKeyName: "kb_article_revisions_article_id_fkey";
+            columns: ["article_id"];
+            isOneToOne: false;
+            referencedRelation: "kb_articles";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       kb_articles: {
         Row: {
-          audience: string
-          category_id: string | null
-          company_id: string
-          content_json: Json
-          content_md: string
-          created_at: string
-          created_by: string | null
-          id: string
-          published_at: string | null
-          related_module: string | null
-          related_table: string | null
-          search_vector: unknown
-          slug: string
-          status: string
-          summary: string | null
-          title: string
-          updated_at: string
-          updated_by: string | null
-          video_id: string | null
-        }
+          audience: string;
+          category_id: string | null;
+          company_id: string;
+          content_json: Json;
+          content_md: string;
+          created_at: string;
+          created_by: string | null;
+          id: string;
+          published_at: string | null;
+          related_module: string | null;
+          related_table: string | null;
+          search_vector: unknown;
+          slug: string;
+          status: string;
+          summary: string | null;
+          title: string;
+          updated_at: string;
+          updated_by: string | null;
+          video_id: string | null;
+        };
         Insert: {
-          audience?: string
-          category_id?: string | null
-          company_id: string
-          content_json: Json
-          content_md: string
-          created_at?: string
-          created_by?: string | null
-          id?: string
-          published_at?: string | null
-          related_module?: string | null
-          related_table?: string | null
-          search_vector?: unknown
-          slug: string
-          status?: string
-          summary?: string | null
-          title: string
-          updated_at?: string
-          updated_by?: string | null
-          video_id?: string | null
-        }
+          audience?: string;
+          category_id?: string | null;
+          company_id: string;
+          content_json: Json;
+          content_md: string;
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          published_at?: string | null;
+          related_module?: string | null;
+          related_table?: string | null;
+          search_vector?: unknown;
+          slug: string;
+          status?: string;
+          summary?: string | null;
+          title: string;
+          updated_at?: string;
+          updated_by?: string | null;
+          video_id?: string | null;
+        };
         Update: {
-          audience?: string
-          category_id?: string | null
-          company_id?: string
-          content_json?: Json
-          content_md?: string
-          created_at?: string
-          created_by?: string | null
-          id?: string
-          published_at?: string | null
-          related_module?: string | null
-          related_table?: string | null
-          search_vector?: unknown
-          slug?: string
-          status?: string
-          summary?: string | null
-          title?: string
-          updated_at?: string
-          updated_by?: string | null
-          video_id?: string | null
-        }
+          audience?: string;
+          category_id?: string | null;
+          company_id?: string;
+          content_json?: Json;
+          content_md?: string;
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          published_at?: string | null;
+          related_module?: string | null;
+          related_table?: string | null;
+          search_vector?: unknown;
+          slug?: string;
+          status?: string;
+          summary?: string | null;
+          title?: string;
+          updated_at?: string;
+          updated_by?: string | null;
+          video_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "kb_articles_category_id_fkey"
-            columns: ["category_id"]
-            isOneToOne: false
-            referencedRelation: "kb_categories"
-            referencedColumns: ["id"]
+            foreignKeyName: "kb_articles_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "kb_categories";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "kb_articles_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "kb_articles_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "kb_articles_video_id_fkey"
-            columns: ["video_id"]
-            isOneToOne: false
-            referencedRelation: "kb_videos"
-            referencedColumns: ["id"]
+            foreignKeyName: "kb_articles_video_id_fkey";
+            columns: ["video_id"];
+            isOneToOne: false;
+            referencedRelation: "kb_videos";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       kb_categories: {
         Row: {
-          audience: string
-          company_id: string
-          created_at: string
-          id: string
-          parent_id: string | null
-          position: number
-          slug: string
-          title: string
-          updated_at: string
-        }
+          audience: string;
+          company_id: string;
+          created_at: string;
+          id: string;
+          parent_id: string | null;
+          position: number;
+          slug: string;
+          title: string;
+          updated_at: string;
+        };
         Insert: {
-          audience?: string
-          company_id: string
-          created_at?: string
-          id?: string
-          parent_id?: string | null
-          position?: number
-          slug: string
-          title: string
-          updated_at?: string
-        }
+          audience?: string;
+          company_id: string;
+          created_at?: string;
+          id?: string;
+          parent_id?: string | null;
+          position?: number;
+          slug: string;
+          title: string;
+          updated_at?: string;
+        };
         Update: {
-          audience?: string
-          company_id?: string
-          created_at?: string
-          id?: string
-          parent_id?: string | null
-          position?: number
-          slug?: string
-          title?: string
-          updated_at?: string
-        }
+          audience?: string;
+          company_id?: string;
+          created_at?: string;
+          id?: string;
+          parent_id?: string | null;
+          position?: number;
+          slug?: string;
+          title?: string;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "kb_categories_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "kb_categories_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "kb_categories_parent_id_fkey"
-            columns: ["parent_id"]
-            isOneToOne: false
-            referencedRelation: "kb_categories"
-            referencedColumns: ["id"]
+            foreignKeyName: "kb_categories_parent_id_fkey";
+            columns: ["parent_id"];
+            isOneToOne: false;
+            referencedRelation: "kb_categories";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       kb_videos: {
         Row: {
-          company_id: string
-          composition: string
-          created_at: string
-          created_by: string | null
-          description: string | null
-          duration_s: number | null
-          id: string
-          input_props: Json | null
-          status: string
-          storage_path: string | null
-          thumbnail_path: string | null
-          title: string
-          updated_at: string
-        }
+          company_id: string;
+          composition: string;
+          created_at: string;
+          created_by: string | null;
+          description: string | null;
+          duration_s: number | null;
+          id: string;
+          input_props: Json | null;
+          status: string;
+          storage_path: string | null;
+          thumbnail_path: string | null;
+          title: string;
+          updated_at: string;
+        };
         Insert: {
-          company_id: string
-          composition: string
-          created_at?: string
-          created_by?: string | null
-          description?: string | null
-          duration_s?: number | null
-          id?: string
-          input_props?: Json | null
-          status?: string
-          storage_path?: string | null
-          thumbnail_path?: string | null
-          title: string
-          updated_at?: string
-        }
+          company_id: string;
+          composition: string;
+          created_at?: string;
+          created_by?: string | null;
+          description?: string | null;
+          duration_s?: number | null;
+          id?: string;
+          input_props?: Json | null;
+          status?: string;
+          storage_path?: string | null;
+          thumbnail_path?: string | null;
+          title: string;
+          updated_at?: string;
+        };
         Update: {
-          company_id?: string
-          composition?: string
-          created_at?: string
-          created_by?: string | null
-          description?: string | null
-          duration_s?: number | null
-          id?: string
-          input_props?: Json | null
-          status?: string
-          storage_path?: string | null
-          thumbnail_path?: string | null
-          title?: string
-          updated_at?: string
-        }
+          company_id?: string;
+          composition?: string;
+          created_at?: string;
+          created_by?: string | null;
+          description?: string | null;
+          duration_s?: number | null;
+          id?: string;
+          input_props?: Json | null;
+          status?: string;
+          storage_path?: string | null;
+          thumbnail_path?: string | null;
+          title?: string;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "kb_videos_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "kb_videos_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
+      medical_anamneses: {
+        Row: {
+          answers_json: Json;
+          company_id: string;
+          consultation_id: string | null;
+          created_at: string;
+          created_by: string | null;
+          id: string;
+          patient_id: string;
+          summary: string | null;
+          template_id: string | null;
+          updated_at: string;
+          updated_by: string | null;
+        };
+        Insert: {
+          answers_json?: Json;
+          company_id: string;
+          consultation_id?: string | null;
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          patient_id: string;
+          summary?: string | null;
+          template_id?: string | null;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Update: {
+          answers_json?: Json;
+          company_id?: string;
+          consultation_id?: string | null;
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          patient_id?: string;
+          summary?: string | null;
+          template_id?: string | null;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "medical_anamneses_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_anamneses_consultation_id_fkey";
+            columns: ["consultation_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_consultations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_anamneses_patient_id_fkey";
+            columns: ["patient_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_patients";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_anamneses_template_id_fkey";
+            columns: ["template_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_anamnesis_templates";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      medical_anamnesis_templates: {
+        Row: {
+          company_id: string;
+          created_at: string;
+          created_by: string | null;
+          id: string;
+          is_active: boolean;
+          name: string;
+          schema_json: Json;
+          specialty: string | null;
+          updated_at: string;
+        };
+        Insert: {
+          company_id: string;
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          is_active?: boolean;
+          name: string;
+          schema_json?: Json;
+          specialty?: string | null;
+          updated_at?: string;
+        };
+        Update: {
+          company_id?: string;
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          is_active?: boolean;
+          name?: string;
+          schema_json?: Json;
+          specialty?: string | null;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "medical_anamnesis_templates_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      medical_attachment_metadata: {
+        Row: {
+          company_id: string;
+          consultation_id: string | null;
+          created_at: string;
+          created_by: string | null;
+          description: string | null;
+          file_name: string;
+          file_size_bytes: number | null;
+          file_type: string | null;
+          id: string;
+          patient_id: string;
+          storage_path: string | null;
+        };
+        Insert: {
+          company_id: string;
+          consultation_id?: string | null;
+          created_at?: string;
+          created_by?: string | null;
+          description?: string | null;
+          file_name: string;
+          file_size_bytes?: number | null;
+          file_type?: string | null;
+          id?: string;
+          patient_id: string;
+          storage_path?: string | null;
+        };
+        Update: {
+          company_id?: string;
+          consultation_id?: string | null;
+          created_at?: string;
+          created_by?: string | null;
+          description?: string | null;
+          file_name?: string;
+          file_size_bytes?: number | null;
+          file_type?: string | null;
+          id?: string;
+          patient_id?: string;
+          storage_path?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "medical_attachment_metadata_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_attachment_metadata_consultation_id_fkey";
+            columns: ["consultation_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_consultations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_attachment_metadata_patient_id_fkey";
+            columns: ["patient_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_patients";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      medical_consent_templates: {
+        Row: {
+          body: string;
+          company_id: string;
+          created_at: string;
+          created_by: string | null;
+          id: string;
+          is_active: boolean;
+          title: string;
+          updated_at: string;
+          version: number;
+        };
+        Insert: {
+          body: string;
+          company_id: string;
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          is_active?: boolean;
+          title: string;
+          updated_at?: string;
+          version?: number;
+        };
+        Update: {
+          body?: string;
+          company_id?: string;
+          created_at?: string;
+          created_by?: string | null;
+          id?: string;
+          is_active?: boolean;
+          title?: string;
+          updated_at?: string;
+          version?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "medical_consent_templates_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      medical_consultations: {
+        Row: {
+          chief_complaint: string | null;
+          clinical_evolution: string | null;
+          company_id: string;
+          conduct: string | null;
+          consultation_at: string;
+          created_at: string;
+          created_by: string | null;
+          diagnosis_text: string | null;
+          id: string;
+          notes: string | null;
+          patient_id: string;
+          updated_at: string;
+          updated_by: string | null;
+        };
+        Insert: {
+          chief_complaint?: string | null;
+          clinical_evolution?: string | null;
+          company_id: string;
+          conduct?: string | null;
+          consultation_at?: string;
+          created_at?: string;
+          created_by?: string | null;
+          diagnosis_text?: string | null;
+          id?: string;
+          notes?: string | null;
+          patient_id: string;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Update: {
+          chief_complaint?: string | null;
+          clinical_evolution?: string | null;
+          company_id?: string;
+          conduct?: string | null;
+          consultation_at?: string;
+          created_at?: string;
+          created_by?: string | null;
+          diagnosis_text?: string | null;
+          id?: string;
+          notes?: string | null;
+          patient_id?: string;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "medical_consultations_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_consultations_patient_id_fkey";
+            columns: ["patient_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_patients";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      medical_patient_assignments: {
+        Row: {
+          assigned_at: string;
+          assigned_by: string | null;
+          company_id: string;
+          ended_at: string | null;
+          id: string;
+          is_primary: boolean;
+          membership_id: string;
+          notes: string | null;
+          patient_id: string;
+          relationship: Database["public"]["Enums"]["medical_assignment_relationship"];
+        };
+        Insert: {
+          assigned_at?: string;
+          assigned_by?: string | null;
+          company_id: string;
+          ended_at?: string | null;
+          id?: string;
+          is_primary?: boolean;
+          membership_id: string;
+          notes?: string | null;
+          patient_id: string;
+          relationship?: Database["public"]["Enums"]["medical_assignment_relationship"];
+        };
+        Update: {
+          assigned_at?: string;
+          assigned_by?: string | null;
+          company_id?: string;
+          ended_at?: string | null;
+          id?: string;
+          is_primary?: boolean;
+          membership_id?: string;
+          notes?: string | null;
+          patient_id?: string;
+          relationship?: Database["public"]["Enums"]["medical_assignment_relationship"];
+        };
+        Relationships: [
+          {
+            foreignKeyName: "medical_patient_assignments_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_patient_assignments_membership_id_fkey";
+            columns: ["membership_id"];
+            isOneToOne: false;
+            referencedRelation: "memberships";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_patient_assignments_patient_id_fkey";
+            columns: ["patient_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_patients";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      medical_patient_consents: {
+        Row: {
+          accepted_at: string;
+          accepted_body: string;
+          accepted_by: string | null;
+          company_id: string;
+          id: string;
+          notes: string | null;
+          patient_id: string;
+          template_id: string | null;
+          template_title: string;
+          template_version: number;
+        };
+        Insert: {
+          accepted_at?: string;
+          accepted_body: string;
+          accepted_by?: string | null;
+          company_id: string;
+          id?: string;
+          notes?: string | null;
+          patient_id: string;
+          template_id?: string | null;
+          template_title: string;
+          template_version: number;
+        };
+        Update: {
+          accepted_at?: string;
+          accepted_body?: string;
+          accepted_by?: string | null;
+          company_id?: string;
+          id?: string;
+          notes?: string | null;
+          patient_id?: string;
+          template_id?: string | null;
+          template_title?: string;
+          template_version?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "medical_patient_consents_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_patient_consents_patient_id_fkey";
+            columns: ["patient_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_patients";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_patient_consents_template_id_fkey";
+            columns: ["template_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_consent_templates";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      medical_patients: {
+        Row: {
+          address: string | null;
+          archived_at: string | null;
+          birth_date: string | null;
+          company_id: string;
+          created_at: string;
+          created_by: string | null;
+          document: string | null;
+          email: string | null;
+          emergency_contact_name: string | null;
+          emergency_contact_phone: string | null;
+          full_name: string;
+          id: string;
+          is_archived: boolean;
+          notes: string | null;
+          phone: string | null;
+          sex: string | null;
+          updated_at: string;
+          updated_by: string | null;
+        };
+        Insert: {
+          address?: string | null;
+          archived_at?: string | null;
+          birth_date?: string | null;
+          company_id: string;
+          created_at?: string;
+          created_by?: string | null;
+          document?: string | null;
+          email?: string | null;
+          emergency_contact_name?: string | null;
+          emergency_contact_phone?: string | null;
+          full_name: string;
+          id?: string;
+          is_archived?: boolean;
+          notes?: string | null;
+          phone?: string | null;
+          sex?: string | null;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Update: {
+          address?: string | null;
+          archived_at?: string | null;
+          birth_date?: string | null;
+          company_id?: string;
+          created_at?: string;
+          created_by?: string | null;
+          document?: string | null;
+          email?: string | null;
+          emergency_contact_name?: string | null;
+          emergency_contact_phone?: string | null;
+          full_name?: string;
+          id?: string;
+          is_archived?: boolean;
+          notes?: string | null;
+          phone?: string | null;
+          sex?: string | null;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "medical_patients_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      medical_prescription_items: {
+        Row: {
+          company_id: string;
+          dosage: string | null;
+          duration: string | null;
+          frequency: string | null;
+          id: string;
+          instructions: string | null;
+          medication: string;
+          position: number;
+          prescription_id: string;
+          quantity: string | null;
+          route: string | null;
+        };
+        Insert: {
+          company_id: string;
+          dosage?: string | null;
+          duration?: string | null;
+          frequency?: string | null;
+          id?: string;
+          instructions?: string | null;
+          medication: string;
+          position?: number;
+          prescription_id: string;
+          quantity?: string | null;
+          route?: string | null;
+        };
+        Update: {
+          company_id?: string;
+          dosage?: string | null;
+          duration?: string | null;
+          frequency?: string | null;
+          id?: string;
+          instructions?: string | null;
+          medication?: string;
+          position?: number;
+          prescription_id?: string;
+          quantity?: string | null;
+          route?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "medical_prescription_items_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_prescription_items_prescription_id_fkey";
+            columns: ["prescription_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_prescriptions";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      medical_prescriptions: {
+        Row: {
+          company_id: string;
+          consultation_id: string | null;
+          created_at: string;
+          created_by: string | null;
+          general_instructions: string | null;
+          id: string;
+          issued_at: string;
+          patient_id: string;
+          updated_at: string;
+          updated_by: string | null;
+        };
+        Insert: {
+          company_id: string;
+          consultation_id?: string | null;
+          created_at?: string;
+          created_by?: string | null;
+          general_instructions?: string | null;
+          id?: string;
+          issued_at?: string;
+          patient_id: string;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Update: {
+          company_id?: string;
+          consultation_id?: string | null;
+          created_at?: string;
+          created_by?: string | null;
+          general_instructions?: string | null;
+          id?: string;
+          issued_at?: string;
+          patient_id?: string;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "medical_prescriptions_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_prescriptions_consultation_id_fkey";
+            columns: ["consultation_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_consultations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "medical_prescriptions_patient_id_fkey";
+            columns: ["patient_id"];
+            isOneToOne: false;
+            referencedRelation: "medical_patients";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       membership_roles: {
         Row: {
-          assigned_at: string
-          assigned_by: string | null
-          membership_id: string
-          role_id: string
-        }
+          assigned_at: string;
+          assigned_by: string | null;
+          membership_id: string;
+          role_id: string;
+        };
         Insert: {
-          assigned_at?: string
-          assigned_by?: string | null
-          membership_id: string
-          role_id: string
-        }
+          assigned_at?: string;
+          assigned_by?: string | null;
+          membership_id: string;
+          role_id: string;
+        };
         Update: {
-          assigned_at?: string
-          assigned_by?: string | null
-          membership_id?: string
-          role_id?: string
-        }
+          assigned_at?: string;
+          assigned_by?: string | null;
+          membership_id?: string;
+          role_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "membership_roles_membership_id_fkey"
-            columns: ["membership_id"]
-            isOneToOne: false
-            referencedRelation: "memberships"
-            referencedColumns: ["id"]
+            foreignKeyName: "membership_roles_membership_id_fkey";
+            columns: ["membership_id"];
+            isOneToOne: false;
+            referencedRelation: "memberships";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "membership_roles_role_id_fkey"
-            columns: ["role_id"]
-            isOneToOne: false
-            referencedRelation: "roles"
-            referencedColumns: ["id"]
+            foreignKeyName: "membership_roles_role_id_fkey";
+            columns: ["role_id"];
+            isOneToOne: false;
+            referencedRelation: "roles";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       memberships: {
         Row: {
-          company_id: string
-          created_at: string
-          id: string
-          invited_at: string | null
-          invited_by: string | null
-          is_owner: boolean
-          joined_at: string | null
-          status: Database["public"]["Enums"]["membership_status"]
-          updated_at: string
-          user_id: string
-        }
+          company_id: string;
+          created_at: string;
+          id: string;
+          invited_at: string | null;
+          invited_by: string | null;
+          is_owner: boolean;
+          joined_at: string | null;
+          status: Database["public"]["Enums"]["membership_status"];
+          updated_at: string;
+          user_id: string;
+        };
         Insert: {
-          company_id: string
-          created_at?: string
-          id?: string
-          invited_at?: string | null
-          invited_by?: string | null
-          is_owner?: boolean
-          joined_at?: string | null
-          status?: Database["public"]["Enums"]["membership_status"]
-          updated_at?: string
-          user_id: string
-        }
+          company_id: string;
+          created_at?: string;
+          id?: string;
+          invited_at?: string | null;
+          invited_by?: string | null;
+          is_owner?: boolean;
+          joined_at?: string | null;
+          status?: Database["public"]["Enums"]["membership_status"];
+          updated_at?: string;
+          user_id: string;
+        };
         Update: {
-          company_id?: string
-          created_at?: string
-          id?: string
-          invited_at?: string | null
-          invited_by?: string | null
-          is_owner?: boolean
-          joined_at?: string | null
-          status?: Database["public"]["Enums"]["membership_status"]
-          updated_at?: string
-          user_id?: string
-        }
+          company_id?: string;
+          created_at?: string;
+          id?: string;
+          invited_at?: string | null;
+          invited_by?: string | null;
+          is_owner?: boolean;
+          joined_at?: string | null;
+          status?: Database["public"]["Enums"]["membership_status"];
+          updated_at?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "memberships_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "memberships_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       migration_backfill_log: {
         Row: {
-          company_id: string
-          created_at: string
-          email: string
-          id: string
-          invitation_id: string
-          membership_id: string
-          short_code: string
-        }
+          company_id: string;
+          created_at: string;
+          email: string;
+          id: string;
+          invitation_id: string;
+          membership_id: string;
+          short_code: string;
+        };
         Insert: {
-          company_id: string
-          created_at?: string
-          email: string
-          id?: string
-          invitation_id: string
-          membership_id: string
-          short_code: string
-        }
+          company_id: string;
+          created_at?: string;
+          email: string;
+          id?: string;
+          invitation_id: string;
+          membership_id: string;
+          short_code: string;
+        };
         Update: {
-          company_id?: string
-          created_at?: string
-          email?: string
-          id?: string
-          invitation_id?: string
-          membership_id?: string
-          short_code?: string
-        }
-        Relationships: []
-      }
+          company_id?: string;
+          created_at?: string;
+          email?: string;
+          id?: string;
+          invitation_id?: string;
+          membership_id?: string;
+          short_code?: string;
+        };
+        Relationships: [];
+      };
       modules: {
         Row: {
-          code: string
-          created_at: string
-          description: string | null
-          icon: string | null
-          is_active: boolean
-          is_system: boolean
-          name: string
-          sort_order: number
-        }
+          code: string;
+          created_at: string;
+          description: string | null;
+          icon: string | null;
+          is_active: boolean;
+          is_system: boolean;
+          name: string;
+          sort_order: number;
+        };
         Insert: {
-          code: string
-          created_at?: string
-          description?: string | null
-          icon?: string | null
-          is_active?: boolean
-          is_system?: boolean
-          name: string
-          sort_order?: number
-        }
+          code: string;
+          created_at?: string;
+          description?: string | null;
+          icon?: string | null;
+          is_active?: boolean;
+          is_system?: boolean;
+          name: string;
+          sort_order?: number;
+        };
         Update: {
-          code?: string
-          created_at?: string
-          description?: string | null
-          icon?: string | null
-          is_active?: boolean
-          is_system?: boolean
-          name?: string
-          sort_order?: number
-        }
-        Relationships: []
-      }
+          code?: string;
+          created_at?: string;
+          description?: string | null;
+          icon?: string | null;
+          is_active?: boolean;
+          is_system?: boolean;
+          name?: string;
+          sort_order?: number;
+        };
+        Relationships: [];
+      };
       password_reset_requests: {
         Row: {
-          approved_at: string | null
-          approved_by: string | null
-          consumed_at: string | null
-          email: string
-          expires_at: string | null
-          id: string
-          metadata: Json
-          requested_at: string
-          revoked_at: string | null
-          revoked_by: string | null
-          short_code: string | null
-          source: string
-          status: string
-          token_hash: string | null
-          user_id: string
-        }
+          approved_at: string | null;
+          approved_by: string | null;
+          consumed_at: string | null;
+          email: string;
+          expires_at: string | null;
+          id: string;
+          metadata: Json;
+          requested_at: string;
+          revoked_at: string | null;
+          revoked_by: string | null;
+          short_code: string | null;
+          source: string;
+          status: string;
+          token_hash: string | null;
+          user_id: string;
+        };
         Insert: {
-          approved_at?: string | null
-          approved_by?: string | null
-          consumed_at?: string | null
-          email: string
-          expires_at?: string | null
-          id?: string
-          metadata?: Json
-          requested_at?: string
-          revoked_at?: string | null
-          revoked_by?: string | null
-          short_code?: string | null
-          source: string
-          status?: string
-          token_hash?: string | null
-          user_id: string
-        }
+          approved_at?: string | null;
+          approved_by?: string | null;
+          consumed_at?: string | null;
+          email: string;
+          expires_at?: string | null;
+          id?: string;
+          metadata?: Json;
+          requested_at?: string;
+          revoked_at?: string | null;
+          revoked_by?: string | null;
+          short_code?: string | null;
+          source: string;
+          status?: string;
+          token_hash?: string | null;
+          user_id: string;
+        };
         Update: {
-          approved_at?: string | null
-          approved_by?: string | null
-          consumed_at?: string | null
-          email?: string
-          expires_at?: string | null
-          id?: string
-          metadata?: Json
-          requested_at?: string
-          revoked_at?: string | null
-          revoked_by?: string | null
-          short_code?: string | null
-          source?: string
-          status?: string
-          token_hash?: string | null
-          user_id?: string
-        }
-        Relationships: []
-      }
+          approved_at?: string | null;
+          approved_by?: string | null;
+          consumed_at?: string | null;
+          email?: string;
+          expires_at?: string | null;
+          id?: string;
+          metadata?: Json;
+          requested_at?: string;
+          revoked_at?: string | null;
+          revoked_by?: string | null;
+          short_code?: string | null;
+          source?: string;
+          status?: string;
+          token_hash?: string | null;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       permissions: {
         Row: {
-          action: string
-          code: string
-          created_at: string
-          description: string | null
-          module_code: string
-          resource: string
-        }
+          action: string;
+          code: string;
+          created_at: string;
+          description: string | null;
+          module_code: string;
+          resource: string;
+        };
         Insert: {
-          action: string
-          code: string
-          created_at?: string
-          description?: string | null
-          module_code: string
-          resource: string
-        }
+          action: string;
+          code: string;
+          created_at?: string;
+          description?: string | null;
+          module_code: string;
+          resource: string;
+        };
         Update: {
-          action?: string
-          code?: string
-          created_at?: string
-          description?: string | null
-          module_code?: string
-          resource?: string
-        }
+          action?: string;
+          code?: string;
+          created_at?: string;
+          description?: string | null;
+          module_code?: string;
+          resource?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "permissions_module_code_fkey"
-            columns: ["module_code"]
-            isOneToOne: false
-            referencedRelation: "modules"
-            referencedColumns: ["code"]
+            foreignKeyName: "permissions_module_code_fkey";
+            columns: ["module_code"];
+            isOneToOne: false;
+            referencedRelation: "modules";
+            referencedColumns: ["code"];
           },
-        ]
-      }
+        ];
+      };
       platform_admins: {
         Row: {
-          granted_at: string
-          granted_by: string | null
-          user_id: string
-        }
+          granted_at: string;
+          granted_by: string | null;
+          user_id: string;
+        };
         Insert: {
-          granted_at?: string
-          granted_by?: string | null
-          user_id: string
-        }
+          granted_at?: string;
+          granted_by?: string | null;
+          user_id: string;
+        };
         Update: {
-          granted_at?: string
-          granted_by?: string | null
-          user_id?: string
-        }
-        Relationships: []
-      }
+          granted_at?: string;
+          granted_by?: string | null;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       products: {
         Row: {
-          company_id: string
-          cost_price: number
-          created_at: string
-          created_by: string | null
-          description: string | null
-          id: string
-          is_active: boolean
-          min_stock: number
-          name: string
-          sale_price: number
-          sku: string
-          stock: number
-          unit: string
-          updated_at: string
-        }
+          company_id: string;
+          cost_price: number;
+          created_at: string;
+          created_by: string | null;
+          description: string | null;
+          id: string;
+          is_active: boolean;
+          min_stock: number;
+          name: string;
+          sale_price: number;
+          sku: string;
+          stock: number;
+          unit: string;
+          updated_at: string;
+        };
         Insert: {
-          company_id: string
-          cost_price?: number
-          created_at?: string
-          created_by?: string | null
-          description?: string | null
-          id?: string
-          is_active?: boolean
-          min_stock?: number
-          name: string
-          sale_price?: number
-          sku: string
-          stock?: number
-          unit?: string
-          updated_at?: string
-        }
+          company_id: string;
+          cost_price?: number;
+          created_at?: string;
+          created_by?: string | null;
+          description?: string | null;
+          id?: string;
+          is_active?: boolean;
+          min_stock?: number;
+          name: string;
+          sale_price?: number;
+          sku: string;
+          stock?: number;
+          unit?: string;
+          updated_at?: string;
+        };
         Update: {
-          company_id?: string
-          cost_price?: number
-          created_at?: string
-          created_by?: string | null
-          description?: string | null
-          id?: string
-          is_active?: boolean
-          min_stock?: number
-          name?: string
-          sale_price?: number
-          sku?: string
-          stock?: number
-          unit?: string
-          updated_at?: string
-        }
+          company_id?: string;
+          cost_price?: number;
+          created_at?: string;
+          created_by?: string | null;
+          description?: string | null;
+          id?: string;
+          is_active?: boolean;
+          min_stock?: number;
+          name?: string;
+          sale_price?: number;
+          sku?: string;
+          stock?: number;
+          unit?: string;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "products_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "products_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       profiles: {
         Row: {
-          avatar_url: string | null
-          created_at: string
-          full_name: string
-          id: string
-          updated_at: string
-        }
+          avatar_url: string | null;
+          created_at: string;
+          full_name: string;
+          id: string;
+          updated_at: string;
+        };
         Insert: {
-          avatar_url?: string | null
-          created_at?: string
-          full_name: string
-          id: string
-          updated_at?: string
-        }
+          avatar_url?: string | null;
+          created_at?: string;
+          full_name: string;
+          id: string;
+          updated_at?: string;
+        };
         Update: {
-          avatar_url?: string | null
-          created_at?: string
-          full_name?: string
-          id?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
+          avatar_url?: string | null;
+          created_at?: string;
+          full_name?: string;
+          id?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       role_permissions: {
         Row: {
-          granted_at: string
-          permission_code: string
-          role_id: string
-        }
+          granted_at: string;
+          is_active: boolean;
+          permission_code: string;
+          role_id: string;
+        };
         Insert: {
-          granted_at?: string
-          permission_code: string
-          role_id: string
-        }
+          granted_at?: string;
+          is_active?: boolean;
+          permission_code: string;
+          role_id: string;
+        };
         Update: {
-          granted_at?: string
-          permission_code?: string
-          role_id?: string
-        }
+          granted_at?: string;
+          is_active?: boolean;
+          permission_code?: string;
+          role_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "role_permissions_permission_code_fkey"
-            columns: ["permission_code"]
-            isOneToOne: false
-            referencedRelation: "permissions"
-            referencedColumns: ["code"]
+            foreignKeyName: "role_permissions_permission_code_fkey";
+            columns: ["permission_code"];
+            isOneToOne: false;
+            referencedRelation: "permissions";
+            referencedColumns: ["code"];
           },
           {
-            foreignKeyName: "role_permissions_role_id_fkey"
-            columns: ["role_id"]
-            isOneToOne: false
-            referencedRelation: "roles"
-            referencedColumns: ["id"]
+            foreignKeyName: "role_permissions_role_id_fkey";
+            columns: ["role_id"];
+            isOneToOne: false;
+            referencedRelation: "roles";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       roles: {
         Row: {
-          code: string
-          company_id: string
-          created_at: string
-          description: string | null
-          id: string
-          is_system: boolean
-          name: string
-          updated_at: string
-        }
+          code: string;
+          company_id: string;
+          created_at: string;
+          description: string | null;
+          id: string;
+          is_system: boolean;
+          name: string;
+          updated_at: string;
+        };
         Insert: {
-          code: string
-          company_id: string
-          created_at?: string
-          description?: string | null
-          id?: string
-          is_system?: boolean
-          name: string
-          updated_at?: string
-        }
+          code: string;
+          company_id: string;
+          created_at?: string;
+          description?: string | null;
+          id?: string;
+          is_system?: boolean;
+          name: string;
+          updated_at?: string;
+        };
         Update: {
-          code?: string
-          company_id?: string
-          created_at?: string
-          description?: string | null
-          id?: string
-          is_system?: boolean
-          name?: string
-          updated_at?: string
-        }
+          code?: string;
+          company_id?: string;
+          created_at?: string;
+          description?: string | null;
+          id?: string;
+          is_system?: boolean;
+          name?: string;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "roles_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "roles_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       short_code_attempts: {
         Row: {
-          attempts: number
-          created_at: string
-          id: string
-          identifier: string
-          ip: unknown
-          locked_until: string | null
-          updated_at: string
-        }
+          attempts: number;
+          created_at: string;
+          id: string;
+          identifier: string;
+          ip: unknown;
+          locked_until: string | null;
+          updated_at: string;
+        };
         Insert: {
-          attempts?: number
-          created_at?: string
-          id?: string
-          identifier: string
-          ip?: unknown
-          locked_until?: string | null
-          updated_at?: string
-        }
+          attempts?: number;
+          created_at?: string;
+          id?: string;
+          identifier: string;
+          ip?: unknown;
+          locked_until?: string | null;
+          updated_at?: string;
+        };
         Update: {
-          attempts?: number
-          created_at?: string
-          id?: string
-          identifier?: string
-          ip?: unknown
-          locked_until?: string | null
-          updated_at?: string
-        }
-        Relationships: []
-      }
+          attempts?: number;
+          created_at?: string;
+          id?: string;
+          identifier?: string;
+          ip?: unknown;
+          locked_until?: string | null;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       stock_movements: {
         Row: {
-          company_id: string
-          created_at: string
-          id: string
-          movement_type: Database["public"]["Enums"]["movement_type"]
-          performed_by: string
-          product_id: string
-          quantity: number
-          reason: string | null
-          unit_cost: number | null
-        }
+          company_id: string;
+          created_at: string;
+          id: string;
+          movement_type: Database["public"]["Enums"]["movement_type"];
+          performed_by: string;
+          product_id: string;
+          quantity: number;
+          reason: string | null;
+          unit_cost: number | null;
+        };
         Insert: {
-          company_id: string
-          created_at?: string
-          id?: string
-          movement_type: Database["public"]["Enums"]["movement_type"]
-          performed_by: string
-          product_id: string
-          quantity: number
-          reason?: string | null
-          unit_cost?: number | null
-        }
+          company_id: string;
+          created_at?: string;
+          id?: string;
+          movement_type: Database["public"]["Enums"]["movement_type"];
+          performed_by: string;
+          product_id: string;
+          quantity: number;
+          reason?: string | null;
+          unit_cost?: number | null;
+        };
         Update: {
-          company_id?: string
-          created_at?: string
-          id?: string
-          movement_type?: Database["public"]["Enums"]["movement_type"]
-          performed_by?: string
-          product_id?: string
-          quantity?: number
-          reason?: string | null
-          unit_cost?: number | null
-        }
+          company_id?: string;
+          created_at?: string;
+          id?: string;
+          movement_type?: Database["public"]["Enums"]["movement_type"];
+          performed_by?: string;
+          product_id?: string;
+          quantity?: number;
+          reason?: string | null;
+          unit_cost?: number | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "stock_movements_company_id_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
+            foreignKeyName: "stock_movements_company_id_fkey";
+            columns: ["company_id"];
+            isOneToOne: false;
+            referencedRelation: "companies";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "stock_movements_product_id_fkey"
-            columns: ["product_id"]
-            isOneToOne: false
-            referencedRelation: "products"
-            referencedColumns: ["id"]
+            foreignKeyName: "stock_movements_product_id_fkey";
+            columns: ["product_id"];
+            isOneToOne: false;
+            referencedRelation: "products";
+            referencedColumns: ["id"];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       accept_invitation: {
-        Args: { p_short_code: string; p_token_hash: string; p_user_id: string }
-        Returns: Json
-      }
+        Args: { p_short_code: string; p_token_hash: string; p_user_id: string };
+        Returns: Json;
+      };
       actor_can_manage_reset: {
-        Args: { p_permission: string; p_user_id: string }
-        Returns: boolean
-      }
+        Args: { p_permission: string; p_user_id: string };
+        Returns: boolean;
+      };
       bootstrap_company_rbac: {
-        Args: { p_company: string }
-        Returns: undefined
-      }
+        Args: { p_company: string };
+        Returns: undefined;
+      };
       consume_password_reset: {
-        Args: { p_short_code: string; p_token_hash: string }
-        Returns: string
-      }
-      get_user_id_by_email: { Args: { p_email: string }; Returns: string }
+        Args: { p_short_code: string; p_token_hash: string };
+        Returns: string;
+      };
+      get_user_id_by_email: { Args: { p_email: string }; Returns: string };
+      has_medical_patient_access: {
+        Args: { p_company: string; p_patient: string };
+        Returns: boolean;
+      };
       has_permission: {
-        Args: { p_company: string; p_permission: string }
-        Returns: boolean
-      }
-      is_platform_admin: { Args: never; Returns: boolean }
+        Args: { p_company: string; p_permission: string };
+        Returns: boolean;
+      };
+      is_platform_admin: { Args: never; Returns: boolean };
       record_short_code_attempt: {
-        Args: { p_identifier: string; p_ip: string }
-        Returns: boolean
-      }
-      request_password_reset: { Args: { p_email: string }; Returns: undefined }
+        Args: { p_identifier: string; p_ip: string };
+        Returns: boolean;
+      };
+      request_password_reset: { Args: { p_email: string }; Returns: undefined };
       search_users_for_company: {
-        Args: { p_company_id: string; p_query: string }
+        Args: { p_company_id: string; p_query: string };
         Returns: {
-          email: string
-          full_name: string
-          user_id: string
-        }[]
-      }
+          email: string;
+          full_name: string;
+          user_id: string;
+        }[];
+      };
       set_member_roles: {
         Args: {
-          p_company_id: string
-          p_membership_id: string
-          p_role_ids: string[]
-        }
-        Returns: undefined
-      }
-      show_limit: { Args: never; Returns: number }
-      show_trgm: { Args: { "": string }; Returns: string[] }
+          p_company_id: string;
+          p_membership_id: string;
+          p_role_ids: string[];
+        };
+        Returns: undefined;
+      };
+      show_limit: { Args: never; Returns: number };
+      show_trgm: { Args: { "": string }; Returns: string[] };
       update_system_role_permissions: {
-        Args: { permission_codes: string[]; role_code: string }
-        Returns: undefined
-      }
-      user_company_ids: { Args: never; Returns: string[] }
-    }
+        Args: { permission_codes: string[]; role_code: string };
+        Returns: undefined;
+      };
+      user_company_ids: { Args: never; Returns: string[] };
+    };
     Enums: {
-      membership_status: "invited" | "active" | "suspended"
-      movement_type: "in" | "out" | "adjustment"
-    }
+      medical_assignment_relationship:
+        | "primary_physician"
+        | "physician"
+        | "nursing"
+        | "assistant"
+        | "therapist"
+        | "other";
+      membership_status: "invited" | "active" | "suspended";
+      movement_type: "in" | "out" | "adjustment";
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
       DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+      Row: infer R;
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+      Insert: infer I;
     }
     ? I
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+      Update: infer U;
     }
     ? U
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
     ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+    : never;
 
 export const Constants = {
   public: {
     Enums: {
+      medical_assignment_relationship: [
+        "primary_physician",
+        "physician",
+        "nursing",
+        "assistant",
+        "therapist",
+        "other",
+      ],
       membership_status: ["invited", "active", "suspended"],
       movement_type: ["in", "out", "adjustment"],
     },
   },
-} as const
-
+} as const;

--- a/supabase/migrations/20260522000046_role_permissions_is_active.sql
+++ b/supabase/migrations/20260522000046_role_permissions_is_active.sql
@@ -1,0 +1,16 @@
+-- 20260522000046_role_permissions_is_active.sql
+-- PR #A da evolução de roles: soft-deactivate de role_permissions
+-- quando módulo é desligado. has_permission() ainda não filtra por isto
+-- (próxima PR #B). Default true mantém retrocompatibilidade.
+
+alter table public.role_permissions
+  add column is_active boolean not null default true;
+
+-- Index parcial: queries quentes filtram por is_active=true. Index parcial
+-- reduz tamanho mantendo benefício para o caso comum.
+create index if not exists idx_role_permissions_active
+  on public.role_permissions (role_id, permission_code)
+  where is_active = true;
+
+comment on column public.role_permissions.is_active is
+  'Marca lógica de ativação. false = preservado mas ignorado por has_permission a partir do PR #B.';


### PR DESCRIPTION
## Summary

Primeiro PR da evolução de roles & permissões (`docs/superpowers/specs/2026-05-22-roles-evolucao-design.md`, seção 5.2).

- Adiciona coluna `role_permissions.is_active boolean not null default true` + index parcial `idx_role_permissions_active`.
- Refatora `toggleModuleAction` (por empresa) e `bulkToggleModuleForCompaniesAction` (global) para soft-deactivate (`UPDATE is_active=false`) em vez de DELETE no disable.
- Enable path agora reativa (`UPDATE is_active=true`) antes de upsert das perms-padrão. Preserva customizações tenant através do ciclo disable→enable.
- `has_permission()` NÃO foi tocada — virá na PR #B junto com merge do `is_platform_admin()`. Até lá: módulos desabilitados continuam concedendo acesso (sem regressão funcional; apenas a semântica do flag não está ativa).

Plan: `docs/superpowers/plans/2026-05-22-role-permissions-is-active.md`.

## Commits

- `e057811` feat(authz): add role_permissions.is_active column
- `68e88ff` refactor(tenancy): soft-deactivate role_permissions no disable de módulo
- `1d0c69e` chore(tenancy): align toggle-module disable mock comments and naming
- `2655a61` refactor(tenancy): reativa role_permissions no enable de módulo
- `234cc09` refactor(tenancy): bulk toggle usa soft-deactivate de role_permissions

## Test Plan

- [x] `npm test` (escopo `src/`) — 118 passed, 0 failed
- [x] `npm run typecheck` — zero erros
- [x] `npm run lint` — clean
- [ ] Manual: disable módulo em tenant → query mostra `is_active=false` em role_permissions
- [ ] Manual: re-enable → `is_active=true` (customizações preservadas)
- [ ] Manual: role custom com perm de módulo sobrevive ciclo disable→enable

## Notas operacionais

- Migration aplicada via Supabase MCP (CLI local sem token configurado). Registry remoto contém versão `20260522080701`; arquivo local `20260522000046`. Padrão de drift pré-existente no repo. Quem rodar `npm run db:push` em workstation linkada precisa `supabase migration repair --status applied 20260522000046` antes.
- Diff de `database.types.ts` é grande porque a regeneração capturou drift pré-existente (módulo `medical_records` etc.) que estava faltando localmente. Conteúdo correto contra schema remoto.

## Follow-ups (não-blockers)

- SELECTs em `permissions`/`roles`/`companies` dentro dos dois actions de toggle silenciam erros (padrão pré-existente). Vale PR de cleanup futuro.
- UI badge "Inativo" em `role-permissions-table` (cosmético — entra quando PR #B fizer o flag ter efeito visível).

🤖 Generated with [Claude Code](https://claude.com/claude-code)