### PR TITLE
feat(authz): role templates schema (PR #D1)

### DIFF
--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1439,6 +1439,36 @@ export type Database = {
           },
         ];
       };
+      role_templates: {
+        Row: {
+          code: string;
+          created_at: string;
+          description: string | null;
+          is_system: boolean;
+          name: string;
+          sort_order: number;
+          updated_at: string;
+        };
+        Insert: {
+          code: string;
+          created_at?: string;
+          description?: string | null;
+          is_system?: boolean;
+          name: string;
+          sort_order?: number;
+          updated_at?: string;
+        };
+        Update: {
+          code?: string;
+          created_at?: string;
+          description?: string | null;
+          is_system?: boolean;
+          name?: string;
+          sort_order?: number;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       roles: {
         Row: {
           code: string;
@@ -1448,6 +1478,8 @@ export type Database = {
           id: string;
           is_system: boolean;
           name: string;
+          template_code: string | null;
+          template_synced_at: string | null;
           updated_at: string;
         };
         Insert: {
@@ -1458,6 +1490,8 @@ export type Database = {
           id?: string;
           is_system?: boolean;
           name: string;
+          template_code?: string | null;
+          template_synced_at?: string | null;
           updated_at?: string;
         };
         Update: {
@@ -1468,6 +1502,8 @@ export type Database = {
           id?: string;
           is_system?: boolean;
           name?: string;
+          template_code?: string | null;
+          template_synced_at?: string | null;
           updated_at?: string;
         };
         Relationships: [
@@ -1477,6 +1513,13 @@ export type Database = {
             isOneToOne: false;
             referencedRelation: "companies";
             referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "roles_template_code_fkey";
+            columns: ["template_code"];
+            isOneToOne: false;
+            referencedRelation: "role_templates";
+            referencedColumns: ["code"];
           },
         ];
       };
@@ -1561,6 +1604,39 @@ export type Database = {
           },
         ];
       };
+      template_permissions: {
+        Row: {
+          added_at: string;
+          permission_code: string;
+          template_code: string;
+        };
+        Insert: {
+          added_at?: string;
+          permission_code: string;
+          template_code: string;
+        };
+        Update: {
+          added_at?: string;
+          permission_code?: string;
+          template_code?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "template_permissions_permission_code_fkey";
+            columns: ["permission_code"];
+            isOneToOne: false;
+            referencedRelation: "permissions";
+            referencedColumns: ["code"];
+          },
+          {
+            foreignKeyName: "template_permissions_template_code_fkey";
+            columns: ["template_code"];
+            isOneToOne: false;
+            referencedRelation: "role_templates";
+            referencedColumns: ["code"];
+          },
+        ];
+      };
     };
     Views: {
       [_ in never]: never;
@@ -1574,6 +1650,14 @@ export type Database = {
         Args: { p_permission: string; p_user_id: string };
         Returns: boolean;
       };
+      apply_template_to_company: {
+        Args: { p_company: string; p_force?: boolean; p_template_code: string };
+        Returns: {
+          perms_added: number;
+          perms_removed: number;
+          role_id: string;
+        }[];
+      };
       bootstrap_company_rbac: {
         Args: { p_company: string };
         Returns: undefined;
@@ -1583,6 +1667,10 @@ export type Database = {
         Returns: string;
       };
       get_user_id_by_email: { Args: { p_email: string }; Returns: string };
+      grant_module_to_all_companies: {
+        Args: { p_module_code: string; p_role_to_perms: Json };
+        Returns: undefined;
+      };
       has_medical_patient_access: {
         Args: { p_company: string; p_patient: string };
         Returns: boolean;

--- a/supabase/migrations/20260523000051_role_templates_schema.sql
+++ b/supabase/migrations/20260523000051_role_templates_schema.sql
@@ -1,0 +1,63 @@
+-- 20260523000051_role_templates_schema.sql
+-- PR #D1 da evolução de roles: catálogo global de templates de role + ligação
+-- das instâncias por tenant (roles.template_code, roles.template_synced_at).
+-- Sem mudança comportamental nesta migration — dados são populados na 052,
+-- e bootstrap passa a usar templates na 053.
+
+-- ─── role_templates: catálogo global ─────────────────────────────────────────
+create table public.role_templates (
+  code         text primary key,
+  name         text not null,
+  description  text,
+  is_system    boolean not null default false,
+  sort_order   int not null default 100,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+create index idx_role_templates_sort on public.role_templates(sort_order);
+
+alter table public.role_templates enable row level security;
+
+-- Leitura global (autenticados); escrita só platform admin
+create policy "role_templates_select" on public.role_templates
+  for select using (auth.uid() is not null);
+
+create policy "role_templates_write_platform" on public.role_templates
+  for all using (public.is_platform_admin())
+  with check (public.is_platform_admin());
+
+comment on table public.role_templates is
+  'PR #D1: catálogo global de templates (perfis-padrão). Instâncias por tenant em public.roles via template_code.';
+
+-- ─── template_permissions: contrato de cada template ─────────────────────────
+create table public.template_permissions (
+  template_code   text not null references public.role_templates(code) on delete cascade,
+  permission_code text not null references public.permissions(code) on delete cascade,
+  added_at        timestamptz not null default now(),
+  primary key (template_code, permission_code)
+);
+create index idx_template_permissions_template on public.template_permissions(template_code);
+
+alter table public.template_permissions enable row level security;
+
+create policy "template_permissions_select" on public.template_permissions
+  for select using (auth.uid() is not null);
+
+create policy "template_permissions_write_platform" on public.template_permissions
+  for all using (public.is_platform_admin())
+  with check (public.is_platform_admin());
+
+comment on table public.template_permissions is
+  'PR #D1: permissões que compõem cada template. Fonte para apply_template_to_company.';
+
+-- ─── roles: ligação para template ────────────────────────────────────────────
+alter table public.roles
+  add column template_code text references public.role_templates(code) on delete set null,
+  add column template_synced_at timestamptz;
+
+create index idx_roles_template_code on public.roles(template_code);
+
+comment on column public.roles.template_code is
+  'PR #D1: template do qual esta role foi instanciada (null = role custom criada do zero).';
+comment on column public.roles.template_synced_at is
+  'PR #D1: última vez que esta role recebeu apply do template. NULL = divergente (customizada após bootstrap/apply).';

--- a/supabase/migrations/20260523000052_seed_templates_from_system_roles.sql
+++ b/supabase/migrations/20260523000052_seed_templates_from_system_roles.sql
@@ -1,0 +1,48 @@
+-- 20260523000052_seed_templates_from_system_roles.sql
+-- PR #D1: popula role_templates e template_permissions a partir do estado
+-- atual das system roles (owner/manager/operator). Marca instâncias existentes
+-- como sincronizadas (template_synced_at = now()).
+--
+-- Lógica de seed:
+--   - Para cada role.code distinto com is_system=true: cria template.
+--   - Permissões do template: união das permissões observadas em todas as
+--     instâncias daquela role.code. Tenant que diverge em uma perm específica
+--     vai aparecer divergente após apply do template no futuro.
+
+-- 1. Inserir templates (idempotente)
+insert into public.role_templates (code, name, description, is_system, sort_order)
+select distinct
+  r.code,
+  initcap(r.name),
+  case r.code
+    when 'owner'    then 'Acesso total à empresa'
+    when 'manager'  then 'Gestão operacional de módulos habilitados'
+    when 'operator' then 'Leitura e criação em módulos habilitados'
+    else null
+  end,
+  true,
+  case r.code
+    when 'owner' then 0
+    when 'manager' then 10
+    when 'operator' then 20
+    else 100
+  end
+from public.roles r
+where r.is_system
+on conflict (code) do nothing;
+
+-- 2. Inserir template_permissions (união das perms observadas)
+insert into public.template_permissions (template_code, permission_code)
+select distinct r.code, rp.permission_code
+from public.roles r
+join public.role_permissions rp on rp.role_id = r.id
+where r.is_system
+  and rp.is_active = true
+on conflict do nothing;
+
+-- 3. Vincular instâncias existentes ao template e marcar sincronizadas
+update public.roles
+  set template_code = code,
+      template_synced_at = now()
+  where is_system
+    and template_code is null;

--- a/supabase/migrations/20260523000053_bootstrap_and_apply_template_rpc.sql
+++ b/supabase/migrations/20260523000053_bootstrap_and_apply_template_rpc.sql
@@ -1,0 +1,157 @@
+-- 20260523000053_bootstrap_and_apply_template_rpc.sql
+-- PR #D1: substitui bootstrap_company_rbac por versão que itera templates.
+-- Cria apply_template_to_company para resync per role. Trigger zera
+-- template_synced_at quando role_permissions divergem do template.
+
+-- ─── bootstrap_company_rbac: reescrita usando templates ──────────────────────
+create or replace function public.bootstrap_company_rbac(p_company uuid)
+returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  v_tpl record;
+  v_role_id uuid;
+begin
+  for v_tpl in
+    select code, name from public.role_templates where is_system order by sort_order
+  loop
+    -- Cria/recupera instância
+    insert into public.roles (company_id, code, name, is_system, template_code, template_synced_at)
+      values (p_company, v_tpl.code, v_tpl.name, true, v_tpl.code, now())
+      on conflict (company_id, code) do update
+        set template_code = excluded.template_code,
+            template_synced_at = now()
+      returning id into v_role_id;
+
+    if v_role_id is null then
+      select id into v_role_id
+      from public.roles
+      where company_id = p_company and code = v_tpl.code;
+    end if;
+
+    -- Aplica permissões do template, filtradas pelos módulos habilitados
+    insert into public.role_permissions (role_id, permission_code, is_active)
+      select v_role_id, tp.permission_code, true
+      from public.template_permissions tp
+      join public.permissions p on p.code = tp.permission_code
+      where tp.template_code = v_tpl.code
+        and (
+          p.module_code = 'core'
+          or p.module_code in (
+            select module_code from public.company_modules where company_id = p_company
+          )
+        )
+      on conflict do nothing;
+  end loop;
+end $$;
+
+comment on function public.bootstrap_company_rbac(uuid) is
+  'PR #D1: itera role_templates(is_system) e instancia roles + permissions por empresa, filtrando perms por module_code em company_modules.';
+
+-- ─── apply_template_to_company: resync de uma role específica ────────────────
+create or replace function public.apply_template_to_company(
+  p_company uuid,
+  p_template_code text,
+  p_force boolean default false
+) returns table (role_id uuid, perms_added int, perms_removed int)
+language plpgsql security definer set search_path = public as $$
+declare
+  v_role_id uuid;
+  v_synced_at timestamptz;
+  v_added int := 0;
+  v_removed int := 0;
+begin
+  if not public.is_platform_admin() then
+    raise exception 'Acesso restrito a platform admins' using errcode = 'P0401';
+  end if;
+
+  if not exists (select 1 from public.role_templates where code = p_template_code) then
+    raise exception 'Template % não existe', p_template_code using errcode = 'P0404';
+  end if;
+
+  select r.id, r.template_synced_at into v_role_id, v_synced_at
+  from public.roles r
+  where r.company_id = p_company and r.code = p_template_code;
+
+  if v_role_id is null then
+    raise exception 'Empresa % não tem instância da role %', p_company, p_template_code
+      using errcode = 'P0404';
+  end if;
+
+  -- Se divergente e sem force, pular
+  if v_synced_at is null and not p_force then
+    raise exception 'Role % divergiu do template; use p_force=true para sobrescrever',
+      p_template_code using errcode = 'P0409';
+  end if;
+
+  -- Calcula diff: remove perms que não estão mais no template + filtradas
+  with target_perms as (
+    select tp.permission_code
+    from public.template_permissions tp
+    join public.permissions p on p.code = tp.permission_code
+    where tp.template_code = p_template_code
+      and (
+        p.module_code = 'core'
+        or p.module_code in (
+          select module_code from public.company_modules where company_id = p_company
+        )
+      )
+  ),
+  current_perms as (
+    select permission_code from public.role_permissions
+    where role_id = v_role_id and is_active = true
+  ),
+  removed as (
+    delete from public.role_permissions
+    where role_id = v_role_id
+      and permission_code in (
+        select permission_code from current_perms
+        except select permission_code from target_perms
+      )
+    returning 1
+  ),
+  added as (
+    insert into public.role_permissions (role_id, permission_code, is_active)
+      select v_role_id, permission_code, true
+      from target_perms
+      where permission_code not in (select permission_code from current_perms)
+      on conflict (role_id, permission_code) do update set is_active = true
+      returning 1
+  )
+  select (select count(*) from added), (select count(*) from removed)
+  into v_added, v_removed;
+
+  -- Marca como sincronizada (atualização explícita após trigger zerar)
+  update public.roles set template_synced_at = now() where id = v_role_id;
+
+  return query select v_role_id, v_added, v_removed;
+end $$;
+
+revoke all on function public.apply_template_to_company(uuid, text, boolean) from public, anon;
+grant execute on function public.apply_template_to_company(uuid, text, boolean) to authenticated;
+
+comment on function public.apply_template_to_company(uuid, text, boolean) is
+  'PR #D1: resync de uma role com seu template. Pula se divergente (synced_at IS NULL) salvo p_force=true. Retorna (role_id, perms_added, perms_removed).';
+
+-- ─── Trigger: zera template_synced_at quando role_permissions diverge ────────
+create or replace function public.mark_template_divergence()
+returns trigger
+language plpgsql security definer set search_path = public as $$
+declare
+  v_role_id uuid;
+begin
+  v_role_id := coalesce(new.role_id, old.role_id);
+
+  -- Só zera se a role aponta para um template
+  update public.roles
+    set template_synced_at = null
+    where id = v_role_id and template_code is not null;
+
+  return coalesce(new, old);
+end $$;
+
+create trigger trg_role_permissions_mark_divergence
+  after insert or update or delete on public.role_permissions
+  for each row execute function public.mark_template_divergence();
+
+comment on function public.mark_template_divergence() is
+  'PR #D1: zera roles.template_synced_at quando role_permissions é alterado, sinalizando divergência. apply_template_to_company re-marca synced ao final.';


### PR DESCRIPTION
## Summary

PR #D1 da evolução de roles & permissões (spec 'Fase 1', schema only).

- Cria \`role_templates\` (catálogo global) + \`template_permissions\` (conteúdo).
- Adiciona \`roles.template_code\` (ligação) e \`roles.template_synced_at\` (marca divergência).
- Reescreve \`bootstrap_company_rbac\` iterando templates.
- Cria RPC \`apply_template_to_company(company, template, force)\` retornando diff (added/removed).
- Trigger zera \`template_synced_at\` em qualquer mudança de \`role_permissions\`, marcando divergência automaticamente.
- Seeda templates a partir das system roles atuais (owner/manager/operator) sem mudança comportamental.

## Não inclui (escopo deferido)

- D2: Kill \`is_owner\` (rename → drop em release seguinte).
- D3: UI \`/admin/platform/role-templates\` + reformulação \`/admin/platform/roles\` + badge "Personalizada" + reset button + remoção do RPC obsoleto \`update_system_role_permissions\`.

## Dependência

Base: \`feat/roles-evolution\` (com PRs #A, #B, #C mergeados).

## Commits

- \`ccaf372\` schema (tabelas + colunas + RLS)
- \`b484bfa\` seed (snapshot system roles existentes)
- \`1a96400\` bootstrap reescrita + apply_template_to_company RPC + trigger divergência
- \`067520c\` regen types

## Migrations

- \`051_role_templates_schema.sql\`
- \`052_seed_templates_from_system_roles.sql\`
- \`053_bootstrap_and_apply_template_rpc.sql\`

## Test Plan

- [x] DB: tabelas + colunas com tipos corretos
- [x] DB: RLS habilitada + 4 policies (select autenticado, write platform admin)
- [x] DB: seed populou 3 templates (owner=38 perms, manager=36, operator=20)
- [x] DB: 18 instâncias linkadas + sincronizadas (6 tenants × 3 codes)
- [x] DB: bootstrap_company_rbac usa role_templates (pg_proc verificado)
- [x] DB: apply_template_to_company existe com signature correta + grants restritos
- [x] DB: trigger trg_role_permissions_mark_divergence existe + AFTER row-level
- [x] Smoke: trigger zera template_synced_at em mudança de role_permissions
- [x] Smoke: apply_template_to_company gate P0401 funciona (service role)
- [x] \`npm run typecheck\` zero erros
- [ ] Manual: criar empresa nova → bootstrap usa templates corretamente
- [ ] Manual: chamar apply_template_to_company autenticado como platform admin (testa P0404 + happy path + p_force)
- [ ] Manual: edit em /[companySlug]/settings/roles zera synced_at

## Notas

- Smoke test de trigger inseriu \`core:audit:read\` em operator role \`35f82f13-ea87-4071-b8fb-c5345db3e3bd\` via upsert. Incerto se pré-existia (3/6 operator roles têm). Se o admin quiser limpar, rodar:
  \`\`\`sql
  delete from role_permissions where role_id = '35f82f13-ea87-4071-b8fb-c5345db3e3bd' and permission_code = 'core:audit:read';
  \`\`\`
  (Validar antes que de fato não devia estar lá.)
- Drift de perms entre tenants (templates capturados como união) é esperado e será naturalmente resolvido por apply_template_to_company filtrado por company_modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)