### PR TITLE
feat(authz): kill is_owner — owner = role pura (PR #D2)

### DIFF
--- a/src/modules/auth/queries/get-current-user.ts
+++ b/src/modules/auth/queries/get-current-user.ts
@@ -37,7 +37,6 @@ export async function getCurrentUser() {
       id,
       company_id,
       status,
-      is_owner,
       company:companies ( slug, name ),
       membership_roles (
         role:roles ( code )
@@ -55,14 +54,16 @@ export async function getCurrentUser() {
       }
     ).membership_roles;
 
+    const roleCodes = (membershipRoles ?? []).map((mr) => mr.role?.code ?? "").filter(Boolean);
+
     return {
       id: m.id,
       companyId: m.company_id,
       companySlug: company?.slug ?? "",
       companyName: company?.name ?? "",
       status: m.status,
-      isOwner: m.is_owner,
-      roles: (membershipRoles ?? []).map((mr) => mr.role?.code ?? "").filter(Boolean),
+      isOwner: roleCodes.includes("owner"),
+      roles: roleCodes,
     };
   });
 

--- a/src/modules/tenancy/actions/__tests__/transfer-member.test.ts
+++ b/src/modules/tenancy/actions/__tests__/transfer-member.test.ts
@@ -22,12 +22,10 @@ function makeSupabaseMock({
   sourceMembership = {
     id: "mem-1",
     user_id: "user-1",
-    is_owner: false,
     membership_roles: [] as Array<{ role_id: string }>,
   } as {
     id: string;
     user_id: string;
-    is_owner: boolean;
     membership_roles: Array<{ role_id: string }>;
   } | null,
   existingDestMembership = null as { id: string; status: string } | null,
@@ -143,7 +141,6 @@ describe("transferMemberAction", () => {
       sourceMembership: {
         id: "mem-1",
         user_id: "user-1",
-        is_owner: false,
         membership_roles: [{ role_id: "role-editor" }],
       },
     });

--- a/src/modules/tenancy/actions/transfer-member.ts
+++ b/src/modules/tenancy/actions/transfer-member.ts
@@ -23,7 +23,7 @@ export async function transferMemberAction(
 
   const { data: source, error: srcErr } = await supabase
     .from("memberships")
-    .select("id, user_id, is_owner, membership_roles(role_id)")
+    .select("id, user_id, membership_roles(role_id)")
     .eq("id", membershipId)
     .eq("company_id", sourceCompanyId)
     .maybeSingle();

--- a/src/modules/tenancy/actions/update-member-status.ts
+++ b/src/modules/tenancy/actions/update-member-status.ts
@@ -29,7 +29,7 @@ export async function updateMemberStatusAction(
 
   const { data: membership, error: fetchError } = await supabase
     .from("memberships")
-    .select("id, user_id, is_owner")
+    .select("id, user_id, membership_roles(roles(code))")
     .eq("id", membershipId)
     .eq("company_id", companyId)
     .maybeSingle();
@@ -37,7 +37,15 @@ export async function updateMemberStatusAction(
   if (fetchError) return { ok: false, message: fetchError.message };
   if (!membership) return { ok: false, message: "Membro não encontrado" };
 
-  if (membership.is_owner && (status === "suspended" || status === "removed")) {
+  const membershipRoles =
+    (
+      membership as unknown as {
+        membership_roles: Array<{ roles: { code: string } | null }>;
+      }
+    ).membership_roles ?? [];
+  const isOwner = membershipRoles.some((mr) => mr.roles?.code === "owner");
+
+  if (isOwner && (status === "suspended" || status === "removed")) {
     return { ok: false, message: "Não é possível suspender ou remover o proprietário da empresa" };
   }
 

--- a/src/modules/tenancy/queries/list-company-members.ts
+++ b/src/modules/tenancy/queries/list-company-members.ts
@@ -22,7 +22,6 @@ export async function listCompanyMembers(companyId: string): Promise<CompanyMemb
       id,
       user_id,
       status,
-      is_owner,
       joined_at,
       membership_roles (
         roles ( id, name, code )
@@ -44,15 +43,19 @@ export async function listCompanyMembers(companyId: string): Promise<CompanyMemb
 
   const profileMap = new Map((profiles ?? []).map((p) => [p.id, p.full_name]));
 
-  return memberships.map((row) => ({
-    membershipId: row.id,
-    userId: row.user_id,
-    fullName: profileMap.get(row.user_id) ?? "—",
-    status: row.status,
-    isOwner: row.is_owner,
-    joinedAt: row.joined_at,
-    roles: (row.membership_roles ?? [])
+  return memberships.map((row) => {
+    const roles = (row.membership_roles ?? [])
       .map((mr) => mr.roles)
-      .filter((r): r is { id: string; name: string; code: string } => r !== null),
-  }));
+      .filter((r): r is { id: string; name: string; code: string } => r !== null);
+
+    return {
+      membershipId: row.id,
+      userId: row.user_id,
+      fullName: profileMap.get(row.user_id) ?? "—",
+      status: row.status,
+      isOwner: roles.some((r) => r.code === "owner"),
+      joinedAt: row.joined_at,
+      roles,
+    };
+  });
 }

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1110,8 +1110,8 @@ export type Database = {
           id: string;
           invited_at: string | null;
           invited_by: string | null;
-          is_owner: boolean;
           joined_at: string | null;
+          legacy_is_owner: boolean;
           status: Database["public"]["Enums"]["membership_status"];
           updated_at: string;
           user_id: string;
@@ -1122,8 +1122,8 @@ export type Database = {
           id?: string;
           invited_at?: string | null;
           invited_by?: string | null;
-          is_owner?: boolean;
           joined_at?: string | null;
+          legacy_is_owner?: boolean;
           status?: Database["public"]["Enums"]["membership_status"];
           updated_at?: string;
           user_id: string;
@@ -1134,8 +1134,8 @@ export type Database = {
           id?: string;
           invited_at?: string | null;
           invited_by?: string | null;
-          is_owner?: boolean;
           joined_at?: string | null;
+          legacy_is_owner?: boolean;
           status?: Database["public"]["Enums"]["membership_status"];
           updated_at?: string;
           user_id?: string;
@@ -1677,6 +1677,10 @@ export type Database = {
       };
       has_permission: {
         Args: { p_company: string; p_permission: string };
+        Returns: boolean;
+      };
+      is_membership_owner: {
+        Args: { p_membership_id: string };
         Returns: boolean;
       };
       is_platform_admin: { Args: never; Returns: boolean };

--- a/supabase/migrations/20260524000054_kill_is_owner_policies.sql
+++ b/supabase/migrations/20260524000054_kill_is_owner_policies.sql
@@ -1,0 +1,92 @@
+-- 20260524000054_kill_is_owner_policies.sql
+-- PR #D2 da evolução de roles: owner deixa de ser boolean denormalizado.
+-- Fonte de verdade passa a ser membership_roles + roles.code = 'owner'.
+-- Coluna renomeada para legacy_is_owner (deprecação); drop em follow-up.
+
+-- ─── 1. Backfill: garante role 'owner' para todo membership com is_owner=true ─
+insert into public.membership_roles (membership_id, role_id)
+  select m.id, r.id
+  from public.memberships m
+  join public.roles r on r.company_id = m.company_id and r.code = 'owner'
+  where m.is_owner = true
+  on conflict do nothing;
+
+-- ─── 2. Helper para checar owner por membership ──────────────────────────────
+-- Reutilizado em policies e queries downstream
+create or replace function public.is_membership_owner(p_membership_id uuid)
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1
+    from public.membership_roles mr
+    join public.roles r on r.id = mr.role_id
+    where mr.membership_id = p_membership_id
+      and r.code = 'owner'
+  )
+$$;
+
+comment on function public.is_membership_owner(uuid) is
+  'PR #D2: substitui memberships.is_owner. True se o membership tem a role owner via membership_roles.';
+
+-- ─── 3. Policies que dependiam de is_owner ───────────────────────────────────
+
+-- companies_update_platform_or_owner (definida em 20260420000006_helpers_and_policies.sql
+-- e revisitada em 20260422000009_fix_companies_update_rls.sql): substitui 'and is_owner'
+-- por EXISTS join via membership_roles.
+drop policy if exists "companies_update_platform_or_owner" on public.companies;
+create policy "companies_update_platform_or_owner" on public.companies
+  for update using (
+    public.is_platform_admin()
+    or exists (
+      select 1
+      from public.memberships m
+      join public.membership_roles mr on mr.membership_id = m.id
+      join public.roles r on r.id = mr.role_id
+      where m.user_id = auth.uid()
+        and m.company_id = companies.id
+        and m.status = 'active'
+        and r.code = 'owner'
+    )
+  );
+
+-- memberships_delete (definida em 20260502000033_memberships_delete_policy.sql):
+-- substitui 'not is_owner' por not is_membership_owner.
+drop policy if exists "memberships_delete" on public.memberships;
+create policy "memberships_delete" on public.memberships
+  for delete using (
+    (
+      public.is_platform_admin()
+      or public.has_permission(company_id, 'core:member:manage')
+    )
+    and not public.is_membership_owner(id)
+  );
+
+-- ─── 4. Function actor_can_manage_reset (definida em 20260504000036): ────────
+-- Substitui ref direta a target_m.is_owner por is_membership_owner(target_m.id).
+create or replace function public.actor_can_manage_reset(p_user_id uuid, p_permission text)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.memberships actor_m
+    join public.memberships target_m
+      on target_m.user_id = p_user_id
+     and target_m.company_id = actor_m.company_id
+     and target_m.status = 'active'
+    where actor_m.user_id = auth.uid()
+      and actor_m.status = 'active'
+      and has_permission(actor_m.company_id, p_permission)
+      -- PR #D2: company owner não pode resetar outro owner (via membership_roles)
+      and not (public.is_membership_owner(target_m.id) and not is_platform_admin())
+  )
+$$;
+
+-- ─── 5. Rename column para sinalizar deprecação ──────────────────────────────
+alter table public.memberships rename column is_owner to legacy_is_owner;
+
+comment on column public.memberships.legacy_is_owner is
+  'PR #D2 DEPRECATED: usar membership_roles + roles.code=''owner''. Coluna mantida por 1 release para rollback rápido; drop em follow-up.';

--- a/supabase/migrations/20260524000055_fix_handle_new_user_drop_is_owner.sql
+++ b/supabase/migrations/20260524000055_fix_handle_new_user_drop_is_owner.sql
@@ -1,0 +1,67 @@
+-- 20260524000055_fix_handle_new_user_drop_is_owner.sql
+-- Fix do PR #D2: a migration 054 renomeou memberships.is_owner para
+-- legacy_is_owner, mas a function handle_new_user_default_membership
+-- (trigger on_auth_user_created em auth.users) ainda referenciava is_owner
+-- no INSERT. Signup novo passaria a falhar.
+--
+-- Solução: reescrever function dropando is_owner do INSERT — default era false
+-- e a role 'operator' é atribuída logo abaixo via membership_roles (que é
+-- a nova fonte de verdade do PR #D2).
+
+create or replace function public.handle_new_user_default_membership()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_default_company_id uuid;
+  v_membership_id      uuid;
+  v_operator_role_id   uuid;
+begin
+  -- 1. Cria ou ignora o profile público do usuário
+  insert into public.profiles (id, full_name)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data->>'full_name', split_part(new.email, '@', 1))
+  )
+  on conflict (id) do nothing;
+
+  -- 2. Busca a empresa padrão (criada no Sprint 1)
+  select id into v_default_company_id
+  from public.companies
+  where slug = 'default-company'
+  limit 1;
+
+  -- Se não existir empresa padrão, não cria membership (ambiente novo)
+  if v_default_company_id is null then
+    return new;
+  end if;
+
+  -- 3. Cria membership como active. Sem is_owner — owner agora é via
+  -- membership_roles + roles.code='owner' (PR #D2).
+  insert into public.memberships (user_id, company_id, status, joined_at)
+  values (new.id, v_default_company_id, 'active', now())
+  on conflict (user_id, company_id) do nothing
+  returning id into v_membership_id;
+
+  -- Se o INSERT foi ignorado (conflito), não atribui role novamente
+  if v_membership_id is null then
+    return new;
+  end if;
+
+  -- 4. Atribui role 'operator' da empresa padrão (se existir)
+  select id into v_operator_role_id
+  from public.roles
+  where company_id = v_default_company_id
+    and code = 'operator'
+  limit 1;
+
+  if v_operator_role_id is not null then
+    insert into public.membership_roles (membership_id, role_id)
+    values (v_membership_id, v_operator_role_id)
+    on conflict do nothing;
+  end if;
+
+  return new;
+end $$;


### PR DESCRIPTION
## Summary

PR #D2 da evolução de roles & permissões (spec Fase 1 + 5.1).

\`memberships.is_owner\` deixa de ser fonte de verdade. Owner = role pura via \`membership_roles + roles.code='owner'\`.

### Mudanças DB

- Backfill membership_roles para todos os legacy \`is_owner=true\` (4/4 coberto).
- Nova function helper \`is_membership_owner(uuid)\` reutilizável.
- 2 policies recriadas sem refs a \`is_owner\`: \`companies_update_platform_or_owner\` e \`memberships_delete\`.
- Function \`actor_can_manage_reset\` reescrita usando \`is_membership_owner()\`.
- Trigger \`handle_new_user_default_membership\` corrigido (NÃO referencia mais \`is_owner\`) — bug crítico capturado em review (signup teria quebrado).
- Coluna renomeada para \`legacy_is_owner\` (deprecação visível). Drop em D2-followup após 1 release de estabilização.

### Mudanças TS

- \`get-current-user.ts\` e \`list-company-members.ts\` derivam \`isOwner\` de \`roles.some(r => r.code === 'owner')\`.
- \`update-member-status.ts\` checa owner via \`membership_roles\` join (proteção de owner preservada).
- \`transfer-member.ts\` apenas remove select inexistente.
- \`transfer-member.test.ts\` fixtures sem \`is_owner\`.
- UI components inalterados (continuam consumindo prop \`isOwner\` — só muda a fonte upstream).

## Dependência

Base: \`feat/roles-evolution\` (PRs #A, #B, #C, #D1 mergeados).

## Commits

- \`52d306f\` migration 054 (backfill + helper + policies + actor_can_manage_reset + rename)
- \`7da2285\` migration 055 (fix handle_new_user trigger — bug crítico)
- \`843ad93\` TS queries (regen types + get-current-user + list-company-members)
- \`c422773\` TS actions (update-member-status + transfer-member + test)

## Test Plan

- [x] DB: backfill 100% (legacy_owners == backfilled)
- [x] DB: policies sem refs a is_owner / legacy_is_owner
- [x] DB: actor_can_manage_reset usa is_membership_owner
- [x] DB: handle_new_user trigger sem refs a is_owner (signup intacto)
- [x] DB: coluna renomeada com sucesso
- [x] \`npm run typecheck\` zero erros
- [x] \`npx vitest run --dir src\` 119/119 pass
- [x] Sweep \`git grep .is_owner src/\` apenas refs a legacy_is_owner em database.types.ts (esperado)
- [ ] Manual: owner aparece com badge em /admin/companies/<X>/members; Suspender/Remover hidden
- [ ] Manual: tentativa de suspender owner via API bloqueada
- [ ] Manual: empresa nova criada → first user tem role owner via bootstrap
- [ ] Manual: owner edita dados da empresa (testa companies_update_platform_or_owner)
- [ ] Manual: signup novo cria membership + role operator corretamente (testa handle_new_user fix)

## Não inclui (deferido)

- Drop final da coluna legacy_is_owner (D2-followup após estabilização)
- UI nova (badge "Personalizada", reset button) — D3
- Reformulação /admin/platform/roles → templates UI — D3

🤖 Generated with [Claude Code](https://claude.com/claude-code)