### PR TITLE
feat(authz): platform_roles granular (PR #E)

### DIFF
--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1320,6 +1320,62 @@ export type Database = {
         };
         Relationships: [];
       };
+      platform_role_assignments: {
+        Row: {
+          granted_at: string;
+          granted_by: string | null;
+          role_code: string;
+          user_id: string;
+        };
+        Insert: {
+          granted_at?: string;
+          granted_by?: string | null;
+          role_code: string;
+          user_id: string;
+        };
+        Update: {
+          granted_at?: string;
+          granted_by?: string | null;
+          role_code?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "platform_role_assignments_role_code_fkey";
+            columns: ["role_code"];
+            isOneToOne: false;
+            referencedRelation: "platform_roles";
+            referencedColumns: ["code"];
+          },
+        ];
+      };
+      platform_roles: {
+        Row: {
+          code: string;
+          created_at: string;
+          description: string | null;
+          name: string;
+          permissions: string[];
+          updated_at: string;
+        };
+        Insert: {
+          code: string;
+          created_at?: string;
+          description?: string | null;
+          name: string;
+          permissions?: string[];
+          updated_at?: string;
+        };
+        Update: {
+          code?: string;
+          created_at?: string;
+          description?: string | null;
+          name?: string;
+          permissions?: string[];
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       products: {
         Row: {
           company_id: string;

--- a/supabase/migrations/20260525000057_platform_roles_schema.sql
+++ b/supabase/migrations/20260525000057_platform_roles_schema.sql
@@ -1,0 +1,54 @@
+-- 20260525000057_platform_roles_schema.sql
+-- PR #E da evolução de roles: substitui platform_admins boolean por
+-- sistema role-based. Abre caminho pra "support staff" read-only sem
+-- mudar schema futuramente. Sem mudança comportamental nesta migration
+-- (function is_platform_admin reescrita na 059).
+
+-- ─── platform_roles: catálogo global ─────────────────────────────────────────
+create table public.platform_roles (
+  code         text primary key,
+  name         text not null,
+  description  text,
+  permissions  text[] not null default '{}',
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+
+alter table public.platform_roles enable row level security;
+
+create policy "platform_roles_select" on public.platform_roles
+  for select using (auth.uid() is not null);
+
+create policy "platform_roles_write_platform" on public.platform_roles
+  for all using (public.is_platform_admin())
+  with check (public.is_platform_admin());
+
+comment on table public.platform_roles is
+  'PR #E: catálogo global de platform roles. Permissions é array de codes; ''*'' ou ''platform:*'' = full bypass.';
+
+-- ─── platform_role_assignments: user × role ──────────────────────────────────
+create table public.platform_role_assignments (
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  role_code   text not null references public.platform_roles(code) on delete restrict,
+  granted_by  uuid references auth.users(id),
+  granted_at  timestamptz not null default now(),
+  primary key (user_id, role_code)
+);
+create index idx_pra_user on public.platform_role_assignments(user_id);
+create index idx_pra_role on public.platform_role_assignments(role_code);
+
+alter table public.platform_role_assignments enable row level security;
+
+-- Usuário vê próprias atribuições; platform admin vê tudo
+create policy "platform_role_assignments_select" on public.platform_role_assignments
+  for select using (
+    user_id = auth.uid()
+    or public.is_platform_admin()
+  );
+
+create policy "platform_role_assignments_write_platform" on public.platform_role_assignments
+  for all using (public.is_platform_admin())
+  with check (public.is_platform_admin());
+
+comment on table public.platform_role_assignments is
+  'PR #E: atribuição N×N user→platform_role. Substitui platform_admins. Drop da tabela antiga em follow-up.';

--- a/supabase/migrations/20260525000058_platform_roles_seed_and_backfill.sql
+++ b/supabase/migrations/20260525000058_platform_roles_seed_and_backfill.sql
@@ -1,0 +1,19 @@
+-- 20260525000058_platform_roles_seed_and_backfill.sql
+-- PR #E: seed da role default 'platform_admin' (permissions=['*']) e
+-- backfill 1:1 de platform_admins → platform_role_assignments.
+
+-- 1. Seed do role default
+insert into public.platform_roles (code, name, description, permissions)
+values (
+  'platform_admin',
+  'Administrador da Plataforma',
+  'Bypass total — acesso a todos os dados e RPCs administrativos.',
+  array['*']
+)
+on conflict (code) do nothing;
+
+-- 2. Backfill: todo platform_admin atual vira assignment de 'platform_admin'
+insert into public.platform_role_assignments (user_id, role_code, granted_by, granted_at)
+select pa.user_id, 'platform_admin', pa.granted_by, pa.granted_at
+from public.platform_admins pa
+on conflict (user_id, role_code) do nothing;

--- a/supabase/migrations/20260525000059_rewrite_is_platform_admin.sql
+++ b/supabase/migrations/20260525000059_rewrite_is_platform_admin.sql
@@ -1,0 +1,22 @@
+-- 20260525000059_rewrite_is_platform_admin.sql
+-- PR #E: is_platform_admin agora consulta platform_role_assignments + permissions.
+-- Backward-compatible: todo platform_admin atual já foi backfilled na 058.
+-- Tabela platform_admins mantida como deprecated (drop em follow-up).
+
+create or replace function public.is_platform_admin()
+returns boolean
+language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1
+    from public.platform_role_assignments pra
+    join public.platform_roles pr on pr.code = pra.role_code
+    where pra.user_id = auth.uid()
+      and ('*' = any(pr.permissions) or 'platform:*' = any(pr.permissions))
+  )
+$$;
+
+comment on function public.is_platform_admin() is
+  'PR #E: lê platform_role_assignments. Retorna true se user tem role com permissions contendo ''*'' ou ''platform:*''.';
+
+comment on table public.platform_admins is
+  'PR #E DEPRECATED: substituída por platform_role_assignments. Mantida 1 release para rollback; drop em follow-up. is_platform_admin não lê mais daqui.';


### PR DESCRIPTION
## Summary

PR #E da evolução de roles & permissões (spec 5.4).

Substitui tabela boolean \`platform_admins\` por sistema role-based:
- \`platform_roles\` (catálogo global com permissions array)
- \`platform_role_assignments\` (user × role)
- \`is_platform_admin()\` reescrita pra ler nova tabela
- Backfill 1:1 dos admins existentes pra role 'platform_admin' (permissions=['*'])
- Tabela \`platform_admins\` mantida como deprecated (drop em follow-up)

Abre caminho pra "support staff" read-only no futuro sem mudar schema.

## Migrations

- \`057\` schema: 2 tabelas + RLS (2 policies cada)
- \`058\` seed default role 'platform_admin' + backfill (1=1, paridade total)
- \`059\` rewrite is_platform_admin() lê novas tabelas

## Commits

- \`88fc0b2\` schema
- \`9b60502\` seed + backfill
- \`42d5503\` rewrite is_platform_admin
- \`86b2dc4\` regen types

## Test Plan

- [x] DB: 2 tabelas + RLS criadas
- [x] DB: role 'platform_admin' seedada com permissions=['*']
- [x] DB: backfill 1:1 (1 legacy, 1 backfilled)
- [x] DB: is_platform_admin lê platform_role_assignments (pg_proc verificado)
- [x] DB: smoke test is_platform_admin() compila e retorna boolean
- [x] \`npm run typecheck\` zero erros
- [ ] Manual: platform admin existente continua sendo admin (acessa /admin/platform/*)
- [ ] Manual: user não-admin continua não admin
- [ ] Manual: criar nova assignment via SQL → user vira admin

## Dependência

Base: \`feat/roles-evolution\` (PRs #A–#D3 mergeados).

## Não inclui (deferido)

- UI pra gerenciar platform_roles/assignments (sem demanda real ainda).
- Drop final tabela \`platform_admins\` (follow-up após estabilização).
- Audit triggers (spec 5.5) — PR separado.
- Permissions granulares (além de '*') — quando houver caso de uso (support staff etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)