### PR TITLE
feat(authz): hierarquia de roles (PR #F)

### DIFF
--- a/src/app/(dashboard)/[companySlug]/settings/members/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/members/page.tsx
@@ -1,5 +1,11 @@
 import { notFound } from "next/navigation";
-import { resolveCompany, listCompanyMembers, listCompanyRoles, listPendingInvitations } from "@/modules/tenancy";
+import {
+  resolveCompany,
+  listCompanyMembers,
+  listManageableRoles,
+  listPendingInvitations,
+  type CompanyRole,
+} from "@/modules/tenancy";
 import { listResetRequestsForCompany } from "@/modules/auth";
 import { Can } from "@/modules/authz";
 import { AppError } from "@/lib/errors";
@@ -26,12 +32,28 @@ export default async function SettingsMembersPage({ params }: Props) {
     throw e;
   }
 
-  const [members, roles, invitations, resetRequests] = await Promise.all([
+  const [members, manageableRoles, invitations, resetRequests] = await Promise.all([
     listCompanyMembers(company.id),
-    listCompanyRoles(company.id),
+    listManageableRoles(company.id),
     listPendingInvitations(company.id),
     listResetRequestsForCompany(company.id),
   ]);
+
+  // ManageableRole carrega apenas campos relevantes para atribuição.
+  // Adaptamos ao shape CompanyRole exigido pelos componentes UI (InviteMemberDialog,
+  // MemberCard, MemberRolesSheet) preenchendo campos não usados com defaults seguros.
+  const rolesForUi: CompanyRole[] = manageableRoles.map((r) => ({
+    id: r.id,
+    code: r.code,
+    name: r.name,
+    description: null,
+    isSystem: false,
+    templateCode: null,
+    syncedAt: null,
+    divergent: false,
+    parentRoleId: null,
+    hierarchyLevel: r.hierarchyLevel,
+  }));
 
   return (
     <section className="space-y-6">
@@ -43,7 +65,7 @@ export default async function SettingsMembersPage({ params }: Props) {
           </p>
         </div>
         <Can permission="core:invitation:create">
-          <InviteMemberDialog companyId={company.id} roles={roles} />
+          <InviteMemberDialog companyId={company.id} roles={rolesForUi} />
         </Can>
       </div>
 
@@ -64,7 +86,7 @@ export default async function SettingsMembersPage({ params }: Props) {
                   key={member.membershipId}
                   member={member}
                   companyId={company.id}
-                  availableRoles={roles}
+                  availableRoles={rolesForUi}
                 />
               ))}
             </div>

--- a/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/[roleId]/page.tsx
@@ -5,6 +5,7 @@ import {
   updateRoleAction,
   listRolePermissionMatrix,
   updateRolePermissionsAction,
+  listCompanyRoles,
 } from "@/modules/tenancy";
 import { requirePermission, ForbiddenError } from "@/modules/authz";
 import { AppError } from "@/lib/errors";
@@ -42,7 +43,7 @@ export default async function EditRolePage({ params }: Props) {
   const supabase = await createClient();
   const { data: role, error } = await supabase
     .from("roles")
-    .select("id, code, name, description, is_system")
+    .select("id, code, name, description, is_system, parent_role_id")
     .eq("id", roleId)
     .eq("company_id", company.id)
     .maybeSingle();
@@ -53,6 +54,13 @@ export default async function EditRolePage({ params }: Props) {
   const backHref = `/${companySlug}/settings/roles`;
   const matrix = await listRolePermissionMatrix(company.id, role.id);
   const permAction = updateRolePermissionsAction.bind(null, company.id, role.id);
+
+  const allRoles = await listCompanyRoles(company.id);
+  const availableParents = allRoles.map((r) => ({
+    id: r.id,
+    name: r.name,
+    hierarchyLevel: r.hierarchyLevel,
+  }));
 
   return (
     <section className="max-w-2xl space-y-6">
@@ -92,7 +100,10 @@ export default async function EditRolePage({ params }: Props) {
                 defaultValues={{
                   name: role.name,
                   description: role.description ?? undefined,
+                  parentRoleId: role.parent_role_id ?? null,
                 }}
+                availableParents={availableParents}
+                currentRoleId={role.id}
               />
             </div>
           </TabsContent>

--- a/src/app/(dashboard)/[companySlug]/settings/roles/new/page.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/new/page.tsx
@@ -1,6 +1,6 @@
 import { redirect, notFound } from "next/navigation";
 import Link from "next/link";
-import { resolveCompany, createRoleAction } from "@/modules/tenancy";
+import { resolveCompany, createRoleAction, listCompanyRoles } from "@/modules/tenancy";
 import { requirePermission, ForbiddenError } from "@/modules/authz";
 import { AppError } from "@/lib/errors";
 import { Button } from "@/components/ui/button";
@@ -34,6 +34,13 @@ export default async function NewRolePage({ params }: Props) {
 
   const action = createRoleAction.bind(null, company.id);
 
+  const roles = await listCompanyRoles(company.id);
+  const availableParents = roles.map((r) => ({
+    id: r.id,
+    name: r.name,
+    hierarchyLevel: r.hierarchyLevel,
+  }));
+
   return (
     <section className="max-w-lg space-y-6">
       <div className="flex items-center gap-4">
@@ -47,6 +54,7 @@ export default async function NewRolePage({ params }: Props) {
         action={action}
         backHref={`/${companySlug}/settings/roles`}
         submitLabel="Criar role"
+        availableParents={availableParents}
       />
     </section>
   );

--- a/src/app/(dashboard)/[companySlug]/settings/roles/role-form.tsx
+++ b/src/app/(dashboard)/[companySlug]/settings/roles/role-form.tsx
@@ -1,26 +1,46 @@
 "use client";
 
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import type { ActionResult } from "@/lib/errors";
+
+type ParentOption = { id: string; name: string; hierarchyLevel: number };
 
 type Props = {
   action: (_prev: ActionResult, formData: FormData) => Promise<ActionResult>;
   backHref: string;
   submitLabel: string;
-  defaultValues?: { name?: string; description?: string };
+  defaultValues?: { name?: string; description?: string; parentRoleId?: string | null };
+  availableParents: ParentOption[];
+  currentRoleId?: string;
 };
 
 const initialState: ActionResult = { ok: false };
+const NONE_VALUE = "__none__";
 
-export function RoleForm({ action, backHref, submitLabel, defaultValues }: Props) {
+export function RoleForm({
+  action,
+  backHref,
+  submitLabel,
+  defaultValues,
+  availableParents,
+  currentRoleId,
+}: Props) {
   const router = useRouter();
   const [state, formAction, isPending] = useActionState(action, initialState);
+  const [parentValue, setParentValue] = useState<string>(defaultValues?.parentRoleId ?? NONE_VALUE);
 
   useEffect(() => {
     if (state.ok) {
@@ -60,6 +80,34 @@ export function RoleForm({ action, backHref, submitLabel, defaultValues }: Props
         {fieldErrors.description && (
           <p className="text-sm text-destructive">{fieldErrors.description[0]}</p>
         )}
+      </div>
+
+      <div className="space-y-2">
+        <input
+          type="hidden"
+          name="parent_role_id"
+          value={parentValue === NONE_VALUE ? "" : parentValue}
+        />
+        <Label htmlFor="parent_role_id_select">Role superior (opcional)</Label>
+        <Select value={parentValue} onValueChange={setParentValue}>
+          <SelectTrigger id="parent_role_id_select">
+            <SelectValue placeholder="Sem hierarquia (flat)" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NONE_VALUE}>Sem hierarquia (flat)</SelectItem>
+            {availableParents
+              .filter((p) => p.id !== currentRoleId)
+              .map((p) => (
+                <SelectItem key={p.id} value={p.id}>
+                  {"  ".repeat(p.hierarchyLevel)}
+                  {p.name}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Hierarquia controla quem gerencia quem. Não propaga permissões.
+        </p>
       </div>
 
       {!state.ok && state.message && <p className="text-sm text-destructive">{state.message}</p>}

--- a/src/modules/tenancy/actions/create-role.ts
+++ b/src/modules/tenancy/actions/create-role.ts
@@ -27,9 +27,14 @@ export async function createRoleAction(
     return { ok: false, message: "Sem permissão para gerenciar roles" };
   }
 
+  const parentRoleIdRaw = formData.get("parent_role_id");
+  const parentRoleId =
+    typeof parentRoleIdRaw === "string" && parentRoleIdRaw.length > 0 ? parentRoleIdRaw : null;
+
   const parsed = createRoleSchema.safeParse({
     name: formData.get("name"),
     description: formData.get("description") || undefined,
+    parent_role_id: parentRoleId,
   });
 
   if (!parsed.success) {
@@ -52,6 +57,7 @@ export async function createRoleAction(
       name,
       description: description ?? null,
       is_system: false,
+      parent_role_id: parsed.data.parent_role_id ?? null,
     })
     .select("id")
     .single();

--- a/src/modules/tenancy/actions/update-role.ts
+++ b/src/modules/tenancy/actions/update-role.ts
@@ -19,9 +19,14 @@ export async function updateRoleAction(
     return { ok: false, message: "Sem permissão para gerenciar roles" };
   }
 
+  const parentRoleIdRaw = formData.get("parent_role_id");
+  const parentRoleId =
+    typeof parentRoleIdRaw === "string" && parentRoleIdRaw.length > 0 ? parentRoleIdRaw : null;
+
   const parsed = updateRoleSchema.safeParse({
     name: formData.get("name"),
     description: formData.get("description") || undefined,
+    parent_role_id: parentRoleId,
   });
 
   if (!parsed.success) {
@@ -48,7 +53,12 @@ export async function updateRoleAction(
 
   const { error } = await supabase
     .from("roles")
-    .update({ name, description: description ?? null, updated_at: new Date().toISOString() })
+    .update({
+      name,
+      description: description ?? null,
+      parent_role_id: parsed.data.parent_role_id ?? null,
+      updated_at: new Date().toISOString(),
+    })
     .eq("id", roleId);
 
   if (error) return { ok: false, message: error.message };

--- a/src/modules/tenancy/index.ts
+++ b/src/modules/tenancy/index.ts
@@ -34,6 +34,8 @@ export { listModules } from "./queries/list-modules";
 export { listCompanyModules } from "./queries/list-company-modules";
 export { listCompanyMembers } from "./queries/list-company-members";
 export { listCompanyRoles } from "./queries/list-company-roles";
+export { listManageableRoles } from "./queries/list-manageable-roles";
+export type { ManageableRole } from "./queries/list-manageable-roles";
 export { listRolePermissionMatrix } from "./queries/list-role-permission-matrix";
 export type { ModulePermissions, PermissionRow } from "./queries/list-role-permission-matrix";
 export { searchUsersForCompanyAction } from "./actions/search-users-for-company";

--- a/src/modules/tenancy/queries/list-company-roles.ts
+++ b/src/modules/tenancy/queries/list-company-roles.ts
@@ -11,6 +11,8 @@ export type CompanyRole = {
   templateCode: string | null;
   syncedAt: string | null;
   divergent: boolean;
+  parentRoleId: string | null;
+  hierarchyLevel: number;
 };
 
 export async function listCompanyRoles(companyId: string): Promise<CompanyRole[]> {
@@ -18,9 +20,11 @@ export async function listCompanyRoles(companyId: string): Promise<CompanyRole[]
 
   const { data, error } = await supabase
     .from("roles")
-    .select("id, code, name, description, is_system, template_code, template_synced_at")
+    .select(
+      "id, code, name, description, is_system, template_code, template_synced_at, parent_role_id, hierarchy_level",
+    )
     .eq("company_id", companyId)
-    .order("is_system", { ascending: false })
+    .order("hierarchy_level")
     .order("name");
 
   if (error) throw error;
@@ -34,5 +38,7 @@ export async function listCompanyRoles(companyId: string): Promise<CompanyRole[]
     templateCode: r.template_code,
     syncedAt: r.template_synced_at,
     divergent: r.template_code !== null && r.template_synced_at === null,
+    parentRoleId: r.parent_role_id,
+    hierarchyLevel: r.hierarchy_level,
   }));
 }

--- a/src/modules/tenancy/queries/list-manageable-roles.ts
+++ b/src/modules/tenancy/queries/list-manageable-roles.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+
+export type ManageableRole = {
+  id: string;
+  code: string;
+  name: string;
+  hierarchyLevel: number;
+};
+
+/**
+ * Lista as roles que o usuário atual pode atribuir a outros membros,
+ * baseado na hierarquia (can_manage_role). Não inclui roles fora da hierarquia
+ * gerenciada pelo actor.
+ */
+export async function listManageableRoles(companyId: string): Promise<ManageableRole[]> {
+  const supabase = await createClient();
+
+  // Pega todas roles da empresa, filtra via can_manage_role
+  const { data, error } = await supabase
+    .from("roles")
+    .select("id, code, name, hierarchy_level")
+    .eq("company_id", companyId)
+    .order("hierarchy_level");
+
+  if (error) throw error;
+  if (!data?.length) return [];
+
+  // Filtra cada role via RPC can_manage_role
+  // (Em batch — chamada RPC por role pode ser lenta com muitas roles. Aceitável <100 roles/tenant.)
+  const checks = await Promise.all(
+    data.map(async (r) => {
+      const { data: ok } = await supabase.rpc("can_manage_role", {
+        p_company: companyId,
+        p_target_role: r.id,
+      });
+      return ok === true ? r : null;
+    }),
+  );
+
+  return checks
+    .filter((r): r is NonNullable<typeof r> => r !== null)
+    .map((r) => ({
+      id: r.id,
+      code: r.code,
+      name: r.name,
+      hierarchyLevel: r.hierarchy_level,
+    }));
+}

--- a/src/modules/tenancy/schemas/create-role.ts
+++ b/src/modules/tenancy/schemas/create-role.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const createRoleSchema = z.object({
   name: z.string().min(2).max(50),
   description: z.string().max(200).optional(),
+  parent_role_id: z.string().uuid().optional().nullable(),
 });
 
 export type CreateRoleInput = z.infer<typeof createRoleSchema>;

--- a/src/modules/tenancy/schemas/update-role.ts
+++ b/src/modules/tenancy/schemas/update-role.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const updateRoleSchema = z.object({
   name: z.string().min(2).max(50),
   description: z.string().max(200).optional(),
+  parent_role_id: z.string().uuid().optional().nullable(),
 });
 
 export type UpdateRoleInput = z.infer<typeof updateRoleSchema>;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1502,6 +1502,7 @@ export type Database = {
           description: string | null;
           is_system: boolean;
           name: string;
+          parent_template_code: string | null;
           sort_order: number;
           updated_at: string;
         };
@@ -1511,6 +1512,7 @@ export type Database = {
           description?: string | null;
           is_system?: boolean;
           name: string;
+          parent_template_code?: string | null;
           sort_order?: number;
           updated_at?: string;
         };
@@ -1520,10 +1522,19 @@ export type Database = {
           description?: string | null;
           is_system?: boolean;
           name?: string;
+          parent_template_code?: string | null;
           sort_order?: number;
           updated_at?: string;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: "role_templates_parent_template_code_fkey";
+            columns: ["parent_template_code"];
+            isOneToOne: false;
+            referencedRelation: "role_templates";
+            referencedColumns: ["code"];
+          },
+        ];
       };
       roles: {
         Row: {
@@ -1531,9 +1542,11 @@ export type Database = {
           company_id: string;
           created_at: string;
           description: string | null;
+          hierarchy_level: number;
           id: string;
           is_system: boolean;
           name: string;
+          parent_role_id: string | null;
           template_code: string | null;
           template_synced_at: string | null;
           updated_at: string;
@@ -1543,9 +1556,11 @@ export type Database = {
           company_id: string;
           created_at?: string;
           description?: string | null;
+          hierarchy_level?: number;
           id?: string;
           is_system?: boolean;
           name: string;
+          parent_role_id?: string | null;
           template_code?: string | null;
           template_synced_at?: string | null;
           updated_at?: string;
@@ -1555,9 +1570,11 @@ export type Database = {
           company_id?: string;
           created_at?: string;
           description?: string | null;
+          hierarchy_level?: number;
           id?: string;
           is_system?: boolean;
           name?: string;
+          parent_role_id?: string | null;
           template_code?: string | null;
           template_synced_at?: string | null;
           updated_at?: string;
@@ -1568,6 +1585,13 @@ export type Database = {
             columns: ["company_id"];
             isOneToOne: false;
             referencedRelation: "companies";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "roles_parent_role_id_fkey";
+            columns: ["parent_role_id"];
+            isOneToOne: false;
+            referencedRelation: "roles";
             referencedColumns: ["id"];
           },
           {
@@ -1717,6 +1741,10 @@ export type Database = {
       bootstrap_company_rbac: {
         Args: { p_company: string };
         Returns: undefined;
+      };
+      can_manage_role: {
+        Args: { p_company: string; p_target_role: string };
+        Returns: boolean;
       };
       consume_password_reset: {
         Args: { p_short_code: string; p_token_hash: string };

--- a/supabase/migrations/20260525000060_roles_hierarchy_schema.sql
+++ b/supabase/migrations/20260525000060_roles_hierarchy_schema.sql
@@ -1,0 +1,58 @@
+-- 20260525000060_roles_hierarchy_schema.sql
+-- PR #F da evolução de roles: hierarquia opcional entre roles via
+-- parent_role_id (self-ref). hierarchy_level mantido via trigger.
+-- Controla 'quem gerencia quem'; NÃO propaga permissões.
+
+alter table public.roles
+  add column parent_role_id uuid references public.roles(id) on delete set null,
+  add column hierarchy_level int not null default 0;
+
+create index idx_roles_parent on public.roles(parent_role_id);
+
+comment on column public.roles.parent_role_id is
+  'PR #F: role pai na hierarquia. NULL = flat. Hierarquia controla gestão (can_manage_role), não autorização de recurso.';
+comment on column public.roles.hierarchy_level is
+  'PR #F: denormalizado via trigger. 0 = raiz; aumenta a cada nível. Max 10.';
+
+-- Trigger anti-ciclo + auto-set hierarchy_level
+create or replace function public.check_role_hierarchy()
+returns trigger
+language plpgsql as $$
+declare
+  v_current uuid := new.parent_role_id;
+  v_depth int := 0;
+begin
+  if new.parent_role_id is null then
+    new.hierarchy_level := 0;
+    return new;
+  end if;
+
+  -- Parent precisa estar na mesma empresa
+  if not exists (
+    select 1 from public.roles r
+    where r.id = new.parent_role_id and r.company_id = new.company_id
+  ) then
+    raise exception 'parent_role_id deve referenciar role na mesma empresa' using errcode = 'P0001';
+  end if;
+
+  while v_current is not null loop
+    if v_current = new.id then
+      raise exception 'Ciclo detectado em hierarquia de roles' using errcode = 'P0001';
+    end if;
+    v_depth := v_depth + 1;
+    if v_depth > 10 then
+      raise exception 'Profundidade máxima de hierarquia excedida (10)' using errcode = 'P0001';
+    end if;
+    select parent_role_id into v_current from public.roles where id = v_current;
+  end loop;
+
+  new.hierarchy_level := v_depth;
+  return new;
+end $$;
+
+create trigger trg_check_role_hierarchy
+  before insert or update of parent_role_id on public.roles
+  for each row execute function public.check_role_hierarchy();
+
+comment on function public.check_role_hierarchy() is
+  'PR #F: valida parent_role_id (mesma empresa, sem ciclo, max depth 10) e seta hierarchy_level automaticamente.';

--- a/supabase/migrations/20260525000061_template_hierarchy_schema_and_seed.sql
+++ b/supabase/migrations/20260525000061_template_hierarchy_schema_and_seed.sql
@@ -1,0 +1,27 @@
+-- 20260525000061_template_hierarchy_schema_and_seed.sql
+-- PR #F: role_templates ganha parent_template_code. Default hierarchy:
+-- owner → manager → operator. Backfill aplica parent_role_id nas
+-- instâncias existentes baseado no template.
+
+alter table public.role_templates
+  add column parent_template_code text references public.role_templates(code) on delete set null;
+
+comment on column public.role_templates.parent_template_code is
+  'PR #F: template pai. Bootstrap propaga essa estrutura para parent_role_id em instâncias.';
+
+-- Seed da hierarquia default: owner > manager > operator
+update public.role_templates set parent_template_code = 'owner' where code = 'manager';
+update public.role_templates set parent_template_code = 'manager' where code = 'operator';
+
+-- Backfill: aplica parent_role_id nas instâncias existentes
+-- Para cada role com template_code definido, busca o parent_template_code,
+-- encontra a role correspondente na MESMA empresa, e seta parent_role_id.
+update public.roles target
+set parent_role_id = parent_role.id
+from public.role_templates tpl,
+     public.roles parent_role
+where target.template_code = tpl.code
+  and tpl.parent_template_code is not null
+  and parent_role.code = tpl.parent_template_code
+  and parent_role.company_id = target.company_id
+  and target.parent_role_id is null;

--- a/supabase/migrations/20260525000062_can_manage_role_and_update_set_member_roles.sql
+++ b/supabase/migrations/20260525000062_can_manage_role_and_update_set_member_roles.sql
@@ -1,0 +1,91 @@
+-- 20260525000062_can_manage_role_and_update_set_member_roles.sql
+-- PR #F: helper can_manage_role + atualização do RPC set_member_roles
+-- para validar a hierarquia antes de atribuir.
+
+-- Helper: actor pode gerenciar target_role?
+-- Regra: target é descendente (transitivo) de alguma role do actor, OU actor
+-- é platform admin. Roles sem parent (flat) só são "gerenciáveis" por quem
+-- tem perm core:role:manage E também é membership_role do mesmo company —
+-- mas neste helper focamos só na hierarquia. A perm geral é checada pela
+-- policy/RPC caller.
+create or replace function public.can_manage_role(p_company uuid, p_target_role uuid)
+returns boolean
+language sql stable security definer set search_path = public as $$
+  with recursive actor_roles as (
+    select r.id, r.parent_role_id, r.company_id
+    from public.memberships m
+    join public.membership_roles mr on mr.membership_id = m.id
+    join public.roles r on r.id = mr.role_id
+    where m.user_id = auth.uid()
+      and m.company_id = p_company
+      and m.status = 'active'
+  ),
+  descendants as (
+    select id, parent_role_id from public.roles
+    where parent_role_id in (select id from actor_roles)
+      and company_id = p_company
+    union all
+    select r.id, r.parent_role_id from public.roles r
+    join descendants d on r.parent_role_id = d.id
+    where r.company_id = p_company
+  )
+  select public.is_platform_admin()
+      or exists(select 1 from descendants where id = p_target_role);
+$$;
+
+comment on function public.can_manage_role(uuid, uuid) is
+  'PR #F: actor pode gerenciar target_role? True se platform admin OU target é descendente transitivo de alguma role do actor. Hierarquia controla gestão, não autorização.';
+
+-- Atualizar set_member_roles para validar can_manage_role para cada role
+-- antes do delete/insert.
+create or replace function public.set_member_roles(
+  p_company_id    uuid,
+  p_membership_id uuid,
+  p_role_ids      uuid[]
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not public.has_permission(p_company_id, 'core:member:manage') then
+    raise exception 'Sem permissão para gerenciar membros' using errcode = 'P0401';
+  end if;
+
+  if not exists (
+    select 1 from public.memberships
+    where id = p_membership_id and company_id = p_company_id
+  ) then
+    raise exception 'Membro não encontrado' using errcode = 'P0404';
+  end if;
+
+  if array_length(p_role_ids, 1) > 0 then
+    -- Validar que todas as roles são da empresa
+    if exists (
+      select 1 from unnest(p_role_ids) rid
+      where not exists (
+        select 1 from public.roles r
+        where r.id = rid and r.company_id = p_company_id
+      )
+    ) then
+      raise exception 'Uma ou mais roles são inválidas' using errcode = 'P0422';
+    end if;
+
+    -- PR #F: validar que actor pode gerenciar cada role na hierarquia
+    if exists (
+      select 1 from unnest(p_role_ids) rid
+      where not public.can_manage_role(p_company_id, rid)
+    ) then
+      raise exception 'Sem permissão hierárquica para atribuir uma ou mais roles'
+        using errcode = 'P0403';
+    end if;
+  end if;
+
+  delete from public.membership_roles where membership_id = p_membership_id;
+
+  if array_length(p_role_ids, 1) > 0 then
+    insert into public.membership_roles (membership_id, role_id)
+    select p_membership_id, rid from unnest(p_role_ids) rid;
+  end if;
+end $$;

--- a/supabase/migrations/20260525000063_bootstrap_with_hierarchy.sql
+++ b/supabase/migrations/20260525000063_bootstrap_with_hierarchy.sql
@@ -1,0 +1,57 @@
+-- 20260525000063_bootstrap_with_hierarchy.sql
+-- PR #F: reescreve bootstrap_company_rbac com 2-pass. Pass 1 cria roles
+-- (sem parent); pass 2 popula parent_role_id baseado em parent_template_code.
+
+create or replace function public.bootstrap_company_rbac(p_company uuid)
+returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  v_tpl record;
+  v_role_id uuid;
+begin
+  -- Pass 1: criar/atualizar todas as roles a partir dos templates
+  for v_tpl in
+    select code, name from public.role_templates where is_system order by sort_order
+  loop
+    insert into public.roles (company_id, code, name, is_system, template_code, template_synced_at)
+      values (p_company, v_tpl.code, v_tpl.name, true, v_tpl.code, now())
+      on conflict (company_id, code) do update
+        set template_code = excluded.template_code,
+            template_synced_at = now()
+      returning id into v_role_id;
+
+    if v_role_id is null then
+      select id into v_role_id
+      from public.roles
+      where company_id = p_company and code = v_tpl.code;
+    end if;
+
+    insert into public.role_permissions (role_id, permission_code, is_active)
+      select v_role_id, tp.permission_code, true
+      from public.template_permissions tp
+      join public.permissions p on p.code = tp.permission_code
+      where tp.template_code = v_tpl.code
+        and (
+          p.module_code = 'core'
+          or p.module_code in (
+            select module_code from public.company_modules where company_id = p_company
+          )
+        )
+      on conflict do nothing;
+  end loop;
+
+  -- Pass 2: popular parent_role_id baseado em parent_template_code
+  update public.roles target
+  set parent_role_id = parent_role.id
+  from public.role_templates tpl
+  join public.roles parent_role
+    on parent_role.code = tpl.parent_template_code
+    and parent_role.company_id = target.company_id
+  where target.template_code = tpl.code
+    and target.company_id = p_company
+    and tpl.parent_template_code is not null
+    and target.parent_role_id is distinct from parent_role.id;
+end $$;
+
+comment on function public.bootstrap_company_rbac(uuid) is
+  'PR #F: 2-pass — Pass 1 cria roles + perms; Pass 2 popula parent_role_id via parent_template_code.';


### PR DESCRIPTION
## Summary

PR #F da evolução de roles & permissões (spec Fase 2).

Hierarquia opcional entre roles via \`parent_role_id\`. Controla **quem gerencia quem**, NÃO propaga permissões (semântica explícita).

### Backend (4 migrations)
- \`060\` schema: \`roles.parent_role_id\` + \`hierarchy_level\` + trigger anti-ciclo (max depth 10, valida same-company).
- \`061\` template hierarchy: \`role_templates.parent_template_code\` + seed default (owner → manager → operator) + backfill 12 instâncias existentes.
- \`062\` \`can_manage_role(company, target)\` helper via CTE recursiva + \`set_member_roles\` RPC valida P0403 antes de atribuir.
- \`063\` \`bootstrap_company_rbac\` reescrita 2-pass: Pass 1 cria roles+perms, Pass 2 popula \`parent_role_id\`.

### TS
- \`listCompanyRoles\` retorna \`parentRoleId\` + \`hierarchyLevel\`.
- Novo \`listManageableRoles(companyId)\` — filtra via \`can_manage_role\` RPC.
- \`create-role\` e \`update-role\` aceitam \`parent_role_id\` do form.

### UI
- \`role-form.tsx\` ganha Select "Role superior (opcional)" — lista indentada por hierarchy_level, sentinela \`__none__\` mapeia a null no backend.
- \`members/page.tsx\` usa \`listManageableRoles\` em vez de \`listCompanyRoles\` — actor só vê roles atribuíveis (filtragem server-side via RPC).

## Commits

- \`7c2517b\` schema
- \`cdbbd18\` template hierarchy + backfill
- \`df5804b\` can_manage_role + set_member_roles
- \`440922d\` bootstrap 2-pass
- \`4bbbe2a\` TS queries+actions
- \`0577be8\` UI select + filter

## Test Plan

- [x] DB: 4 migrations aplicadas + validadas
- [x] DB: 12 roles backfilled (6 manager + 6 operator com parent populado)
- [x] DB: trigger anti-ciclo presente e funcional
- [x] DB: can_manage_role + set_member_roles validate via pg_proc
- [x] DB: bootstrap 2-pass (Pass 1 / Pass 2 confirmados no prosrc)
- [x] \`npm run typecheck\` zero erros
- [x] \`npx vitest run --dir src\` 114/114 pass
- [ ] Manual: criar role custom com parent → verificar hierarchy_level
- [ ] Manual: tentar criar role com parent de outra empresa → P0001
- [ ] Manual: tentar ciclo → P0001
- [ ] Manual: usuário não-owner não vê role owner em member-roles-sheet
- [ ] Manual: tentar atribuir role owner a um operator via API → P0403
- [ ] Manual: empresa nova criada → bootstrap popula parent_role_id automaticamente

## Dependência

Base: \`feat/roles-evolution\` (PRs #A–#E mergeados).

## Notas

- \`listManageableRoles\` faz N+1 RPC calls (uma por role). Aceitável <100 roles/tenant. Otimizar com single recursive SQL se virar bottleneck.
- Type mismatch entre \`ManageableRole\` e \`CompanyRole\` resolvido via mapping inline pragmático em members/page.tsx (preenche defaults). Refatorar para interface mínima ficaria para outra PR.

## Não inclui (deferido)

- Tree-view component (deferred).
- Propagação de permissões via hierarquia (spec proíbe).
- Audit triggers (spec 5.5).
- Drop \`legacy_is_owner\` (D2-followup).
- Fases 3-4 (scopes, field-level) — #G, #H.

🤖 Generated with [Claude Code](https://claude.com/claude-code)